### PR TITLE
fixed tree-sitter dependency versions to enable installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc && npm run copy-assets",
     "postinstall": "node scripts/postinstall.js",
-    "copy-assets": "cp -r src/extraction/queries dist/extraction/ && cp src/db/schema.sql dist/db/",
+    "copy-assets": "cp src/db/schema.sql dist/db/",
     "dev": "tsc --watch",
     "cli": "npm run build && node dist/bin/codegraph.js",
     "test": "vitest run",
@@ -38,21 +38,21 @@
     "commander": "^14.0.2",
     "figlet": "^1.8.0",
     "sqlite-vss": "^0.1.2",
-    "tree-sitter": "^0.22.4",
-    "tree-sitter-c": "^0.23.4",
-    "tree-sitter-c-sharp": "^0.23.1",
-    "tree-sitter-cpp": "^0.23.4",
-    "tree-sitter-go": "^0.23.4",
-    "tree-sitter-java": "^0.23.5",
-    "tree-sitter-javascript": "^0.23.1",
-    "tree-sitter-kotlin": "^0.3.8",
+    "tree-sitter": "0.22.4",
+    "tree-sitter-c": "0.23.4",
+    "tree-sitter-c-sharp": "0.23.1",
+    "tree-sitter-cpp": "0.23.4",
+    "tree-sitter-go": "0.23.4",
+    "tree-sitter-java": "0.23.5",
+    "tree-sitter-javascript": "0.23.1",
+    "tree-sitter-kotlin": "0.3.8",
     "tree-sitter-liquid": "github:hankthetank27/tree-sitter-liquid",
-    "tree-sitter-php": "^0.23.11",
-    "tree-sitter-python": "^0.23.6",
-    "tree-sitter-ruby": "^0.23.1",
-    "tree-sitter-rust": "^0.23.2",
-    "tree-sitter-swift": "^0.7.1",
-    "tree-sitter-typescript": "^0.23.2"
+    "tree-sitter-php": "0.23.11",
+    "tree-sitter-python": "0.23.6",
+    "tree-sitter-ruby": "0.23.1",
+    "tree-sitter-rust": "0.23.2",
+    "tree-sitter-swift": "0.7.1",
+    "tree-sitter-typescript": "0.23.2"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
@@ -63,5 +63,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "overrides": {
+    "tree-sitter": "0.22.4"
   }
 }


### PR DESCRIPTION
Hello Colby!

Thanks for the codegraph, it looks super interesting. The `packages.json` in the main is broken, and it fails to install the `codegraph` script. This PR fixes it.