### PR TITLE
Fix UNIQUE constraint crash on large C/C++ projects

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -185,7 +185,7 @@ export class QueryBuilder {
   insertNode(node: Node): void {
     if (!this.stmts.insertNode) {
       this.stmts.insertNode = this.db.prepare(`
-        INSERT INTO nodes (
+        INSERT OR REPLACE INTO nodes (
           id, kind, name, qualified_name, file_path, language,
           start_line, end_line, start_column, end_column,
           docstring, signature, visibility,
@@ -627,7 +627,7 @@ export class QueryBuilder {
   insertEdge(edge: Edge): void {
     if (!this.stmts.insertEdge) {
       this.stmts.insertEdge = this.db.prepare(`
-        INSERT INTO edges (source, target, kind, metadata, line, col)
+        INSERT OR IGNORE INTO edges (source, target, kind, metadata, line, col)
         VALUES (@source, @target, @kind, @metadata, @line, @col)
       `);
     }


### PR DESCRIPTION
Closes #11

## Summary
- Fixes `UNIQUE constraint failed: nodes.id` crash reported on large C/C++ and React/JSX projects
- Node insertion used plain `INSERT` which crashes on duplicate IDs
- In large projects, tree-sitter can produce duplicate nodes for the same symbol — e.g. `typedef struct` in C/C++ where both `struct_specifier` and `type_definition` resolve to the same name/kind/line, or in React projects with many barrel `index.js` files and similarly-named components/hooks across directories

## Changes
- **`INSERT OR REPLACE INTO nodes`** — if the same symbol ID appears twice, the second write wins (idempotent, same data anyway)
- **`INSERT OR IGNORE INTO edges`** — silently skip duplicate edges

## Why this is safe
The node ID is `sha256(filePath:kind:name:line)` which already uses **full relative paths** (not just filenames), so cross-directory collisions were never the issue. A hash collision means it's genuinely the same symbol extracted twice from the same location — replacing is correct.

## Test plan
- [x] Build passes
- [x] No regressions in existing test suite
- [ ] Verify on a large C/C++ project with duplicate filenames across directories
- [ ] Verify on a large React/JSX project with barrel index.js files

🤖 Generated with [Claude Code](https://claude.com/claude-code)