### PR TITLE
Add Claude Code hooks for automatic CodeGraph sync

### DIFF
--- a/src/directory.ts
+++ b/src/directory.ts
@@ -96,6 +96,9 @@ cache/
 
 # Logs
 *.log
+
+# Hook markers
+.dirty
 `;
 
     fs.writeFileSync(gitignorePath, gitignoreContent, 'utf-8');

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -8,7 +8,7 @@
 import { execSync } from 'child_process';
 import { showBanner, showNextSteps, success, error, info, chalk } from './banner';
 import { promptInstallLocation, promptAutoAllow, InstallLocation } from './prompts';
-import { writeMcpConfig, writePermissions, writeClaudeMd, hasMcpConfig, hasPermissions } from './config-writer';
+import { writeMcpConfig, writePermissions, writeClaudeMd, writeHooks, hasMcpConfig, hasPermissions, hasHooks } from './config-writer';
 import CodeGraph from '../index';
 
 /**
@@ -76,7 +76,17 @@ export async function runInstaller(): Promise<void> {
       }
     }
 
-    // Step 5: Write CLAUDE.md instructions
+    // Step 5: Write auto-sync hooks
+    const alreadyHasHooks = hasHooks(location);
+    writeHooks(location);
+
+    if (alreadyHasHooks) {
+      success(`Updated auto-sync hooks in ${location === 'global' ? '~/.claude/settings.json' : './.claude/settings.json'}`);
+    } else {
+      success(`Added auto-sync hooks to ${location === 'global' ? '~/.claude/settings.json' : './.claude/settings.json'}`);
+    }
+
+    // Step 6: Write CLAUDE.md instructions
     const claudeMdResult = writeClaudeMd(location);
     const claudeMdPath = location === 'global' ? '~/.claude/CLAUDE.md' : './.claude/CLAUDE.md';
 
@@ -88,7 +98,7 @@ export async function runInstaller(): Promise<void> {
       success(`Added CodeGraph instructions to ${claudeMdPath}`);
     }
 
-    // Step 6: For local install, initialize the project
+    // Step 7: For local install, initialize the project
     if (location === 'local') {
       await initializeLocalProject();
     }


### PR DESCRIPTION
## Summary

- Added `codegraph mark-dirty` and `codegraph sync-if-dirty` CLI commands for dirty-marker based sync
- Added hooks config writing to the installer (`writeHooks`, `hasHooks` in config-writer)
- Installer now writes PostToolUse + Stop hooks to `settings.json` automatically
- Added `.dirty` to `.codegraph/.gitignore` template

## How it works

When Claude edits files during a session, hooks keep the CodeGraph index fresh:

1. **PostToolUse(Edit|Write)** → `codegraph mark-dirty` (async) — writes timestamp to `.codegraph/.dirty`
2. **Stop** → `codegraph sync-if-dirty` (sync) — if `.dirty` exists, removes it and runs `cg.sync()`

This batches all edits in a single Claude response into one sync, right before the next user turn.

## Edge cases handled

| Case | Behavior |
|------|----------|
| `.codegraph/` doesn't exist | Both commands exit silently (code 0) |
| Project not initialized (no DB) | `sync-if-dirty` exits after removing marker |
| Rapid concurrent PostToolUse hooks | All overwrite same `.dirty` file — safe |
| Edit during sync | Marker deleted before sync, new edit re-creates it |
| `codegraph` not on PATH | Local installs use `npx @colbymchenry/codegraph` |

## Files changed

- `src/bin/codegraph.ts` — two new CLI commands
- `src/installer/config-writer.ts` — `getHooksConfig()`, `writeHooks()`, `hasHooks()`
- `src/installer/index.ts` — hooks step added to installer flow
- `src/directory.ts` — `.dirty` added to gitignore template

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `codegraph mark-dirty` exits silently when no `.codegraph/` exists
- [x] `codegraph sync-if-dirty` exits silently when no `.codegraph/` exists
- [x] `hasHooks()` correctly detects presence/absence of hooks

Resolves #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)