### PR TITLE
Optimize reference resolution with in-memory caches

### DIFF
--- a/src/resolution/import-resolver.ts
+++ b/src/resolution/import-resolver.ts
@@ -432,13 +432,11 @@ export function resolveViaImport(
   ref: UnresolvedRef,
   context: ResolutionContext
 ): ResolvedRef | null {
-  // Read the source file to extract imports
-  const content = context.readFile(ref.filePath);
-  if (!content) {
+  // Use cached import mappings (avoids re-reading and re-parsing per ref)
+  const imports = context.getImportMappings(ref.filePath, ref.language);
+  if (imports.length === 0 && !context.readFile(ref.filePath)) {
     return null;
   }
-
-  const imports = extractImportMappings(ref.filePath, content, ref.language);
 
   // Check if the reference name matches any import
   for (const imp of imports) {

--- a/src/resolution/types.ts
+++ b/src/resolution/types.ts
@@ -79,6 +79,10 @@ export interface ResolutionContext {
   getProjectRoot(): string;
   /** Get all files */
   getAllFiles(): string[];
+  /** Get nodes by lowercase name (O(1) lookup for fuzzy matching) */
+  getNodesByLowerName(lowerName: string): Node[];
+  /** Get cached import mappings for a file */
+  getImportMappings(filePath: string, language: Language): ImportMapping[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Add 4 new caches** to `ReferenceResolver.warmCaches()`: `kindCache`, `lowerNameCache`, `importMappingCache`, and `knownFiles` set — all populated in a single pass over nodes during warmup
- **Rewrite `matchFuzzy`** to use O(1) lowercase name index lookup instead of 3x `getNodesByKind` calls that loaded ALL functions+methods+classes per ref (the primary bottleneck)
- **Cache import mappings per file** so `resolveViaImport` doesn't re-read and re-parse the same file for every ref originating from it
- **Pre-build file existence set** from the index so `fileExists()` is O(1) instead of hitting disk via `fs.existsSync` for every extension variant

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npm test` — all previously-passing tests still pass (12/14 resolution tests; 2 pre-existing Windows path separator failures unchanged)
- [x] `codegraph index` on openclaw-main (3409 files, 38,675 nodes) completes in ~10s — resolution phase no longer stalls

🤖 Generated with [Claude Code](https://claude.com/claude-code)