### PR TITLE
fix: handle ABI-incompatible grammars and fix 28 test failures

### DIFF
--- a/__tests__/extraction.test.ts
+++ b/__tests__/extraction.test.ts
@@ -105,6 +105,7 @@ describe('Language Support', () => {
 
   it('should list all supported languages', () => {
     const languages = getSupportedLanguages();
+    // Core languages with reliable native bindings
     expect(languages).toContain('typescript');
     expect(languages).toContain('javascript');
     expect(languages).toContain('python');
@@ -114,9 +115,9 @@ describe('Language Support', () => {
     expect(languages).toContain('csharp');
     expect(languages).toContain('php');
     expect(languages).toContain('ruby');
-    expect(languages).toContain('swift');
     expect(languages).toContain('kotlin');
-    expect(languages).toContain('dart');
+    // swift and dart grammars may not be available on all platforms
+    // (ABI incompatibilities or missing native bindings)
   });
 });
 
@@ -740,7 +741,7 @@ class UserController
   });
 });
 
-describe('Swift Extraction', () => {
+describe.skipIf(!isLanguageSupported('swift'))('Swift Extraction', () => {
   it('should extract class declarations', () => {
     const code = `
 public class NetworkManager {
@@ -866,7 +867,7 @@ suspend fun loadData(): List<String> {
   });
 });
 
-describe('Dart Extraction', () => {
+describe.skipIf(!isLanguageSupported('dart'))('Dart Extraction', () => {
   it('should extract class declarations', () => {
     const code = `
 class UserService {
@@ -1309,7 +1310,7 @@ import _ "github.com/go-sql-driver/mysql"
     });
   });
 
-  describe('Swift imports', () => {
+  describe.skipIf(!isLanguageSupported('swift'))('Swift imports', () => {
     it('should extract simple import', () => {
       const code = `import Foundation`;
       const result = extractFromSource('main.swift', code);
@@ -1694,7 +1695,7 @@ require_relative 'helper'
     });
   });
 
-  describe('Dart imports', () => {
+  describe.skipIf(!isLanguageSupported('dart'))('Dart imports', () => {
     it('should extract dart: import', () => {
       const code = `import 'dart:async';`;
       const result = extractFromSource('main.dart', code);

--- a/__tests__/foundation.test.ts
+++ b/__tests__/foundation.test.ts
@@ -317,7 +317,7 @@ describe('Database Connection', () => {
 
     const version = db.getSchemaVersion();
     expect(version).not.toBeNull();
-    expect(version?.version).toBe(1);
+    expect(version?.version).toBe(2);
 
     db.close();
   });

--- a/__tests__/pr19-improvements.test.ts
+++ b/__tests__/pr19-improvements.test.ts
@@ -320,8 +320,8 @@ describe('Database Layer Improvements', () => {
     const { DatabaseConnection } = await import('../src/db');
     const { QueryBuilder } = await import('../src/db/queries');
 
-    const db = DatabaseConnection.initialize(testDir);
-    const queries = new QueryBuilder(db.getDatabase());
+    const db = DatabaseConnection.initialize(path.join(testDir, 'test.db'));
+    const queries = new QueryBuilder(db.getDb());
 
     // Insert a node first (needed as foreign key)
     queries.insertNode({
@@ -375,8 +375,8 @@ describe('Database Layer Improvements', () => {
     const { DatabaseConnection } = await import('../src/db');
     const { QueryBuilder } = await import('../src/db/queries');
 
-    const db = DatabaseConnection.initialize(testDir);
-    const queries = new QueryBuilder(db.getDatabase());
+    const db = DatabaseConnection.initialize(path.join(testDir, 'test.db'));
+    const queries = new QueryBuilder(db.getDb());
 
     // Insert some nodes
     for (let i = 0; i < 3; i++) {
@@ -405,8 +405,8 @@ describe('Database Layer Improvements', () => {
   it.skipIf(!HAS_SQLITE)('should set performance pragmas on initialization', async () => {
     const { DatabaseConnection } = await import('../src/db');
 
-    const db = DatabaseConnection.initialize(testDir);
-    const rawDb = db.getDatabase();
+    const db = DatabaseConnection.initialize(path.join(testDir, 'test.db'));
+    const rawDb = db.getDb();
 
     // Check pragmas were set
     const synchronous = rawDb.pragma('synchronous', { simple: true });
@@ -428,8 +428,8 @@ describe('Database Layer Improvements', () => {
     const { DatabaseConnection } = await import('../src/db');
     const { QueryBuilder } = await import('../src/db/queries');
 
-    const db = DatabaseConnection.initialize(testDir);
-    const queries = new QueryBuilder(db.getDatabase());
+    const db = DatabaseConnection.initialize(path.join(testDir, 'test.db'));
+    const queries = new QueryBuilder(db.getDb());
 
     // Should not throw on empty array
     expect(() => queries.insertUnresolvedRefsBatch([])).not.toThrow();
@@ -502,6 +502,7 @@ describe('MCP Tool Improvements', () => {
 
     // Access private method for testing
     const handler = Object.create(ToolHandler.prototype);
+    (handler as any).MAX_OUTPUT_LENGTH = 15000;
     const truncate = (handler as any).truncateOutput.bind(handler);
 
     // Short text should not be truncated
@@ -519,6 +520,7 @@ describe('MCP Tool Improvements', () => {
     const { ToolHandler } = await import('../src/mcp/tools');
 
     const handler = Object.create(ToolHandler.prototype);
+    (handler as any).MAX_OUTPUT_LENGTH = 15000;
     const truncate = (handler as any).truncateOutput.bind(handler);
 
     // Build text with newlines exceeding the limit

--- a/src/extraction/grammars.ts
+++ b/src/extraction/grammars.ts
@@ -169,10 +169,18 @@ export function getParser(language: Language): Parser | null {
     return null;
   }
 
-  const parser = new Parser();
-  parser.setLanguage(grammar as Parameters<typeof parser.setLanguage>[0]);
-  parserCache.set(language, parser);
-  return parser;
+  try {
+    const parser = new Parser();
+    parser.setLanguage(grammar as Parameters<typeof parser.setLanguage>[0]);
+    parserCache.set(language, parser);
+    return parser;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[CodeGraph] Failed to initialize ${language} parser — ABI incompatible: ${message}`);
+    unavailableGrammarErrors.set(language, message);
+    grammarCache.set(language, null);
+    return null;
+  }
 }
 
 /**
@@ -190,7 +198,7 @@ export function isLanguageSupported(language: Language): boolean {
   if (language === 'svelte') return true; // custom extractor (script block delegation)
   if (language === 'liquid') return true; // custom regex extractor
   if (language === 'unknown') return false;
-  return loadGrammar(language) !== null;
+  return getParser(language) !== null;
 }
 
 /**
@@ -198,7 +206,7 @@ export function isLanguageSupported(language: Language): boolean {
  */
 export function getSupportedLanguages(): Language[] {
   const available = (Object.keys(grammarLoaders) as GrammarLanguage[])
-    .filter((language) => loadGrammar(language) !== null);
+    .filter((language) => getParser(language) !== null);
   return [...available, 'svelte', 'liquid'];
 }
 


### PR DESCRIPTION
## Summary

Fixes all 28 test failures on the current main branch. The root cause is a combination of ABI-incompatible tree-sitter grammar bindings and stale test expectations.

### Swift/Dart grammar ABI incompatibility (21 test failures)

**Swift** (`tree-sitter-swift` 0.6.0): The package fails to install on macOS arm64 (Apple Silicon) — `require('tree-sitter-swift')` throws `MODULE_NOT_FOUND`. There is no prebuilt binary for this platform and the source build fails. `loadGrammar()` correctly returned `null`, but 8 tests ran unconditionally.

**Dart** (`@sengac/tree-sitter-dart` 1.1.6): This is the more subtle failure. The npm package **installs and `require()` succeeds**, but the grammar object has an **incompatible ABI** with `tree-sitter` 0.22.4. Calling `parser.setLanguage(dart)` crashes with:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at initializeLanguageNodeClasses (node_modules/tree-sitter/index.js:858:42)
    at Parser.setLanguage (node_modules/tree-sitter/index.js:355:5)
```

This is a two-stage failure that `loadGrammar()` couldn't detect:
1. `loadGrammar('dart')` → returns the grammar object (require worked) ✓
2. `getParser('dart')` → calls `parser.setLanguage()` → **uncaught crash** ✗

The grammar's internal `nodeTypeNamesById` array is `undefined`, indicating it was built against a different tree-sitter ABI version than the 0.22.4 currently installed.

**Source fix** (`src/extraction/grammars.ts`):
- Wrap `parser.setLanguage()` in `try/catch` inside `getParser()` so ABI-incompatible grammars degrade gracefully (return `null` + log warning) instead of crashing the process
- Change `isLanguageSupported()` and `getSupportedLanguages()` to call `getParser()` (validates full ABI compatibility) instead of `loadGrammar()` (only checks if require succeeds)

**Test fix** (`__tests__/extraction.test.ts`):
- Add `describe.skipIf(!isLanguageSupported('swift'))` / `describe.skipIf(!isLanguageSupported('dart'))` to all Swift/Dart test blocks
- Remove hardcoded `swift`/`dart` from "should list all supported languages" assertion — availability is platform-dependent

### Schema version mismatch (1 test failure)

`foundation.test.ts` expected `version?.version` to be `1`, but `DatabaseConnection.initialize()` now inserts version `2` directly (after the v2 migration was added). Fixed assertion to expect `2`.

### DB test initialization errors (4 test failures)

`pr19-improvements.test.ts` DB tests had two bugs:
- Called `DatabaseConnection.initialize(testDir)` with a **directory path** — `better-sqlite3` cannot open a directory as a database file. Fixed to `DatabaseConnection.initialize(path.join(testDir, 'test.db'))`.
- Called `db.getDatabase()` which **doesn't exist** — the method is `db.getDb()`.

### MCP truncation test (1 test failure)

`Object.create(ToolHandler.prototype)` bypasses the constructor, so the class field `MAX_OUTPUT_LENGTH = 15000` is never initialized (it's `undefined`). The comparison `text.length <= undefined` is always `false`, causing every string — even short ones — to be truncated. Fixed by explicitly setting the property on the prototype-created handler.

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm test` — **11 passed, 0 failed** (333 passed, 21 skipped for unavailable grammars)
- [x] Skipped tests are only Swift (8) and Dart (13) — both have unavailable native bindings
- [x] All other languages (TypeScript, JavaScript, Python, Go, Rust, Java, C, C++, C#, PHP, Ruby, Kotlin, Svelte, Liquid) continue to pass