### PR TITLE
perf: O(1) builtin lookups + SCIP resolvedBy type

### DIFF
--- a/src/resolution/index.ts
+++ b/src/resolution/index.ts
@@ -20,10 +20,31 @@ import {
 import { matchReference } from './name-matcher';
 import { resolveViaImport, extractImportMappings } from './import-resolver';
 import { detectFrameworks } from './frameworks';
-import { logDebug } from '../errors';
+import { logDebug, logWarn } from '../errors';
+import { isPathWithinRoot } from '../utils';
 
 // Re-export types
 export * from './types';
+
+// Module-level Sets for O(1) built-in lookups (instead of arrays with .includes())
+const jsBuiltIns = new Set([
+  'console', 'window', 'document', 'global', 'process',
+  'Promise', 'Array', 'Object', 'String', 'Number', 'Boolean',
+  'Date', 'Math', 'JSON', 'RegExp', 'Error', 'Map', 'Set',
+  'setTimeout', 'setInterval', 'clearTimeout', 'clearInterval',
+  'fetch', 'require', 'module', 'exports', '__dirname', '__filename',
+]);
+
+const reactHooks = new Set([
+  'useState', 'useEffect', 'useContext', 'useReducer', 'useCallback',
+  'useMemo', 'useRef', 'useLayoutEffect', 'useImperativeHandle', 'useDebugValue',
+]);
+
+const pythonBuiltIns = new Set([
+  'print', 'len', 'range', 'str', 'int', 'float', 'list', 'dict', 'set', 'tuple',
+  'open', 'input', 'type', 'isinstance', 'hasattr', 'getattr', 'setattr',
+  'super', 'self', 'cls', 'None', 'True', 'False',
+]);
 
 /**
  * Reference Resolver
@@ -167,6 +188,11 @@ export class ReferenceResolver {
       },
 
       fileExists: (filePath: string) => {
+        // Prevent path traversal
+        if (!isPathWithinRoot(filePath, this.projectRoot)) {
+          logWarn('Path traversal blocked in fileExists', { filePath });
+          return false;
+        }
         // Check pre-built known files set first (O(1))
         if (this.knownFiles) {
           const normalized = filePath.replace(/\\/g, '/');
@@ -188,6 +214,13 @@ export class ReferenceResolver {
       readFile: (filePath: string) => {
         if (this.fileCache.has(filePath)) {
           return this.fileCache.get(filePath)!;
+        }
+
+        // Prevent path traversal
+        if (!isPathWithinRoot(filePath, this.projectRoot)) {
+          logWarn('Path traversal blocked in readFile', { filePath });
+          this.fileCache.set(filePath, null);
+          return null;
         }
 
         const fullPath = path.join(this.projectRoot, filePath);
@@ -394,16 +427,8 @@ export class ReferenceResolver {
   private isBuiltInOrExternal(ref: UnresolvedRef): boolean {
     const name = ref.referenceName;
 
-    // JavaScript/TypeScript built-ins
-    const jsBuiltIns = [
-      'console', 'window', 'document', 'global', 'process',
-      'Promise', 'Array', 'Object', 'String', 'Number', 'Boolean',
-      'Date', 'Math', 'JSON', 'RegExp', 'Error', 'Map', 'Set',
-      'setTimeout', 'setInterval', 'clearTimeout', 'clearInterval',
-      'fetch', 'require', 'module', 'exports', '__dirname', '__filename',
-    ];
-
-    if (jsBuiltIns.includes(name)) {
+    // JavaScript/TypeScript built-ins (O(1) Set lookup)
+    if (jsBuiltIns.has(name)) {
       return true;
     }
 
@@ -412,20 +437,13 @@ export class ReferenceResolver {
       return true;
     }
 
-    // React hooks from React itself
-    const reactHooks = ['useState', 'useEffect', 'useContext', 'useReducer', 'useCallback', 'useMemo', 'useRef', 'useLayoutEffect', 'useImperativeHandle', 'useDebugValue'];
-    if (reactHooks.includes(name)) {
+    // React hooks from React itself (O(1) Set lookup)
+    if (reactHooks.has(name)) {
       return true;
     }
 
-    // Python built-ins
-    const pythonBuiltIns = [
-      'print', 'len', 'range', 'str', 'int', 'float', 'list', 'dict', 'set', 'tuple',
-      'open', 'input', 'type', 'isinstance', 'hasattr', 'getattr', 'setattr',
-      'super', 'self', 'cls', 'None', 'True', 'False',
-    ];
-
-    if (ref.language === 'python' && pythonBuiltIns.includes(name)) {
+    // Python built-ins (O(1) Set lookup)
+    if (ref.language === 'python' && pythonBuiltIns.has(name)) {
       return true;
     }
 

--- a/src/resolution/types.ts
+++ b/src/resolution/types.ts
@@ -39,7 +39,7 @@ export interface ResolvedRef {
   /** Confidence score (0-1) */
   confidence: number;
   /** How it was resolved */
-  resolvedBy: 'exact-match' | 'import' | 'qualified-name' | 'framework' | 'fuzzy';
+  resolvedBy: 'exact-match' | 'import' | 'qualified-name' | 'framework' | 'fuzzy' | 'scip';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add module-level `Set` objects (`jsBuiltIns`, `reactHooks`, `pythonBuiltIns`) for O(1) built-in/external reference filtering, replacing inline array `.includes()` checks in `isBuiltInOrExternal()`
- Add `isPathWithinRoot` validation in `fileExists` and `readFile` resolution context methods to prevent path traversal
- Add `'scip'` to the `resolvedBy` union type in preparation for SCIP import support

## Details

The builtin sets are defined at module scope so they're allocated once. Previously, `isBuiltInOrExternal` used local arrays with `.includes()` on every call — O(n) per lookup. With `Set.has()`, each lookup is O(1).

The `isPathWithinRoot` guard uses the existing utility from `src/utils.ts` to block path traversal attempts in the resolution context's `fileExists` and `readFile` methods, matching the security pattern already used elsewhere in the codebase.

The `'scip'` addition to `resolvedBy` is a type-only change that extends the union to support SCIP-based resolution results.

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm test` passes with same baseline (28 pre-existing failures, 326 passing)
- [x] Only 2 files changed: `src/resolution/index.ts`, `src/resolution/types.ts`
- [x] Zero new uncalled exports
- [x] Sentry (`captureException`) preserved — 3 call sites in resolution/index.ts
- [x] No upstream features removed