### PR TITLE
feat: SCIP import, git hooks manager, version tracking, CLI enhancements

### DIFF
--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -29,6 +29,7 @@ import CodeGraph, { getCodeGraphDir, findNearestCodeGraphRoot } from '../index';
 import type { IndexProgress } from '../index';
 import { runInstaller } from '../installer';
 import { initSentry, captureException } from '../sentry';
+import { getRuntimeVersion } from '../version';
 
 // Check if running with no arguments - run installer
 // Read version for Sentry release tag
@@ -219,6 +220,17 @@ function info(message: string): void {
  */
 function warn(message: string): void {
   console.log(chalk.yellow('⚠') + ' ' + message);
+}
+
+/**
+ * Display detailed index statistics
+ */
+function displayIndexStats(stats: { fileCount: number; nodeCount: number; edgeCount: number; dbSizeBytes: number }): void {
+  console.log(chalk.bold('Index Statistics:'));
+  console.log(`  Files:     ${formatNumber(stats.fileCount)}`);
+  console.log(`  Nodes:     ${formatNumber(stats.nodeCount)}`);
+  console.log(`  Edges:     ${formatNumber(stats.edgeCount)}`);
+  console.log(`  DB Size:   ${(stats.dbSizeBytes / 1024 / 1024).toFixed(2)} MB`);
 }
 
 // =============================================================================
@@ -505,16 +517,16 @@ program
 
       console.log(chalk.bold('\nCodeGraph Status\n'));
 
+      // Version info
+      const version = getRuntimeVersion();
+      console.log(chalk.cyan('Version:'), version.package + (version.git ? ` (${version.git})` : ''));
+
       // Project info
       console.log(chalk.cyan('Project:'), projectPath);
       console.log();
 
       // Index stats
-      console.log(chalk.bold('Index Statistics:'));
-      console.log(`  Files:     ${formatNumber(stats.fileCount)}`);
-      console.log(`  Nodes:     ${formatNumber(stats.nodeCount)}`);
-      console.log(`  Edges:     ${formatNumber(stats.edgeCount)}`);
-      console.log(`  DB Size:   ${(stats.dbSizeBytes / 1024 / 1024).toFixed(2)} MB`);
+      displayIndexStats(stats);
       console.log();
 
       // Node breakdown
@@ -995,6 +1007,109 @@ program
       // Never fail — this runs at the end of Claude responses
     }
     process.exit(0);
+  });
+
+/**
+ * codegraph hooks install/remove/status
+ */
+const hooks = program
+  .command('hooks')
+  .description('Manage git hooks for automatic sync');
+
+hooks
+  .command('install [path]')
+  .description('Install post-commit git hook for automatic sync')
+  .action(async (pathArg: string | undefined) => {
+    const projectPath = resolveProjectPath(pathArg);
+
+    try {
+      if (!CodeGraph.isInitialized(projectPath)) {
+        error(`CodeGraph not initialized in ${projectPath}`);
+        process.exit(1);
+      }
+
+      const cg = await CodeGraph.open(projectPath);
+      const result = cg.installGitHooks();
+
+      if (result.success) {
+        success(result.message);
+        if (result.hookPath) {
+          info(`Hook path: ${result.hookPath}`);
+        }
+      } else {
+        error(result.message);
+        process.exit(1);
+      }
+
+      cg.destroy();
+    } catch (err) {
+      captureException(err);
+      error(`Failed to install hooks: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+  });
+
+hooks
+  .command('remove [path]')
+  .description('Remove post-commit git hook')
+  .action(async (pathArg: string | undefined) => {
+    const projectPath = resolveProjectPath(pathArg);
+
+    try {
+      if (!CodeGraph.isInitialized(projectPath)) {
+        error(`CodeGraph not initialized in ${projectPath}`);
+        process.exit(1);
+      }
+
+      const cg = await CodeGraph.open(projectPath);
+      const result = cg.removeGitHooks();
+
+      if (result.success) {
+        success(result.message);
+      } else {
+        error(result.message);
+        process.exit(1);
+      }
+
+      cg.destroy();
+    } catch (err) {
+      captureException(err);
+      error(`Failed to remove hooks: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+  });
+
+hooks
+  .command('status [path]')
+  .description('Check if git hooks are installed')
+  .action(async (pathArg: string | undefined) => {
+    const projectPath = resolveProjectPath(pathArg);
+
+    try {
+      if (!CodeGraph.isInitialized(projectPath)) {
+        error(`CodeGraph not initialized in ${projectPath}`);
+        process.exit(1);
+      }
+
+      const cg = await CodeGraph.open(projectPath);
+
+      if (cg.isGitRepository()) {
+        if (cg.isGitHookInstalled()) {
+          success('Git hook is installed');
+        } else {
+          info('Git hook is not installed');
+          info('Run "codegraph hooks install" to install');
+        }
+      } else {
+        warn('Not a git repository');
+      }
+
+      cg.destroy();
+    } catch (err) {
+      captureException(err);
+      error(`Failed to check hooks: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
   });
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,9 @@ import { GraphTraverser, GraphQueryManager } from './graph';
 import { VectorManager, createVectorManager, EmbeddingProgress } from './vectors';
 import { ContextBuilder, createContextBuilder } from './context';
 import { Mutex, FileLock } from './utils';
+import { GitHooksManager, createGitHooksManager, HookInstallResult, HookRemoveResult } from './sync';
+import { getRuntimeVersion } from './version';
+import { ScipImporter } from './scip';
 
 // Re-export types for consumers
 export * from './types';
@@ -79,6 +82,8 @@ export {
 } from './errors';
 export { Mutex, FileLock, processInBatches, debounce, throttle, MemoryMonitor } from './utils';
 export { MCPServer } from './mcp';
+export { HookInstallResult, HookRemoveResult } from './sync';
+export { getRuntimeVersion } from './version';
 
 /**
  * Options for initializing a new CodeGraph project
@@ -132,6 +137,7 @@ export class CodeGraph {
   private traverser: GraphTraverser;
   private vectorManager: VectorManager | null = null;
   private contextBuilder: ContextBuilder;
+  private gitHooksManager: GitHooksManager;
 
   // Mutex for preventing concurrent indexing operations (in-process)
   private indexMutex = new Mutex();
@@ -152,6 +158,7 @@ export class CodeGraph {
     this.fileLock = new FileLock(
       path.join(projectRoot, '.codegraph', 'codegraph.lock')
     );
+    this.gitHooksManager = createGitHooksManager(projectRoot);
     this.orchestrator = new ExtractionOrchestrator(projectRoot, config, queries);
     this.resolver = createResolver(projectRoot, queries);
     this.graphManager = new GraphQueryManager(queries);
@@ -968,6 +975,85 @@ export class CodeGraph {
       this.vectorManager
     );
     return this.contextBuilder.buildContext(input, options);
+  }
+
+  // ===========================================================================
+  // Git Integration
+  // ===========================================================================
+
+  /**
+   * Check if the project root is a git repository
+   */
+  isGitRepository(): boolean {
+    return this.gitHooksManager.isGitRepository();
+  }
+
+  /**
+   * Check if the codegraph git hook is installed
+   */
+  isGitHookInstalled(): boolean {
+    return this.gitHooksManager.isHookInstalled();
+  }
+
+  /**
+   * Install the codegraph post-commit git hook
+   */
+  installGitHooks(): HookInstallResult {
+    return this.gitHooksManager.installHook();
+  }
+
+  /**
+   * Remove the codegraph post-commit git hook
+   */
+  removeGitHooks(): HookRemoveResult {
+    return this.gitHooksManager.removeHook();
+  }
+
+  /**
+   * Get all metadata key-value pairs
+   */
+  getMetadata(): Record<string, string> | null {
+    try {
+      return this.queries.getAllMetadata();
+    } catch {
+      return null;
+    }
+  }
+
+  // ===========================================================================
+  // SCIP Import
+  // ===========================================================================
+
+  /**
+   * Import SCIP semantic data to create precise cross-reference edges
+   *
+   * @param scipPath - Path to SCIP JSON file (auto-detects if not provided)
+   * @returns Number of edges created and documents processed
+   */
+  importSCIP(scipPath?: string): { edgesCreated: number; documentsProcessed: number } {
+    const importer = new ScipImporter(this.projectRoot, this.queries);
+    if (scipPath) {
+      return importer.importSCIP(scipPath);
+    }
+    const scipFiles = ScipImporter.findSCIPFiles(this.projectRoot);
+    if (scipFiles.length === 0) {
+      return { edgesCreated: 0, documentsProcessed: 0 };
+    }
+    let totalEdges = 0;
+    let totalDocs = 0;
+    for (const file of scipFiles) {
+      const result = importer.importSCIP(file);
+      totalEdges += result.edgesCreated;
+      totalDocs += result.documentsProcessed;
+    }
+    return { edgesCreated: totalEdges, documentsProcessed: totalDocs };
+  }
+
+  /**
+   * Get runtime version information
+   */
+  static getVersion(): { package: string; git: string | null } {
+    return getRuntimeVersion();
   }
 
   // ===========================================================================

--- a/src/scip/index.ts
+++ b/src/scip/index.ts
@@ -1,0 +1,247 @@
+/**
+ * SCIP (Source Code Intelligence Protocol) Importer
+ *
+ * Imports SCIP JSON files to create precise cross-reference edges.
+ * Uses two-pass processing: first collect definitions, then resolve references.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { QueryBuilder } from '../db/queries';
+import { Edge, Node } from '../types';
+import { logDebug, logWarn } from '../errors';
+import { isPathWithinRoot } from '../utils';
+
+interface SCIPDocument {
+  relativePath: string;
+  occurrences?: SCIPOccurrence[];
+  symbols?: SCIPSymbolInfo[];
+}
+
+interface SCIPOccurrence {
+  range: number[];
+  symbol?: string;
+  symbolRoles?: number;
+}
+
+interface SCIPSymbolInfo {
+  symbol: string;
+  documentation?: string[];
+}
+
+const SCIP_ROLE_DEFINITION = 1;
+
+export class ScipImporter {
+  private projectRoot: string;
+  private queries: QueryBuilder;
+  private symbolDefinitions: Map<string, Set<string>> = new Map();
+
+  constructor(projectRoot: string, queries: QueryBuilder) {
+    this.projectRoot = projectRoot;
+    this.queries = queries;
+  }
+
+  /**
+   * Parse a SCIP JSON file into documents
+   */
+  parseSCIPFile(filePath: string): SCIPDocument[] {
+    const fullPath = path.isAbsolute(filePath)
+      ? filePath
+      : path.join(this.projectRoot, filePath);
+
+    if (!isPathWithinRoot(fullPath, this.projectRoot)) {
+      throw new Error('SCIP file path is outside the project root');
+    }
+    if (!fs.existsSync(fullPath)) {
+      throw new Error(`SCIP file not found: ${fullPath}`);
+    }
+
+    const content = fs.readFileSync(fullPath, 'utf-8');
+    const data = JSON.parse(content);
+
+    if (Array.isArray(data)) return data as SCIPDocument[];
+    if (data.documents && Array.isArray(data.documents))
+      return data.documents as SCIPDocument[];
+
+    throw new Error(
+      'Invalid SCIP format: expected {documents:[...]} or array of documents'
+    );
+  }
+
+  /**
+   * Build a map of symbol -> set of files where it's defined (pass 1)
+   */
+  buildSymbolDefinitions(
+    documents: SCIPDocument[]
+  ): Map<string, Set<string>> {
+    const defs = new Map<string, Set<string>>();
+    for (const doc of documents) {
+      if (!doc.occurrences) continue;
+      for (const occ of doc.occurrences) {
+        if (!occ.symbol) continue;
+        const isDefinition = (occ.symbolRoles ?? 0) & SCIP_ROLE_DEFINITION;
+        if (isDefinition) {
+          if (!defs.has(occ.symbol)) defs.set(occ.symbol, new Set());
+          defs.get(occ.symbol)!.add(doc.relativePath);
+        }
+      }
+    }
+    return defs;
+  }
+
+  /**
+   * Import a SCIP file, creating edges for cross-references (pass 2)
+   */
+  importSCIP(
+    scipFilePath: string
+  ): { edgesCreated: number; documentsProcessed: number } {
+    const documents = this.parseSCIPFile(scipFilePath);
+
+    // Content-hash fingerprinting for idempotent imports
+    const fullPath = path.isAbsolute(scipFilePath)
+      ? scipFilePath
+      : path.join(this.projectRoot, scipFilePath);
+    const contentHash = crypto
+      .createHash('sha256')
+      .update(fs.readFileSync(fullPath))
+      .digest('hex');
+
+    const lastHash = this.queries.getMetadata('scip_last_hash');
+    if (lastHash === contentHash) {
+      logDebug('SCIP file unchanged, skipping import', { scipFilePath });
+      return { edgesCreated: 0, documentsProcessed: 0 };
+    }
+
+    // Pass 1: build definitions map
+    this.symbolDefinitions = this.buildSymbolDefinitions(documents);
+
+    let edgesCreated = 0;
+    let documentsProcessed = 0;
+
+    // Pass 2: resolve references
+    for (const doc of documents) {
+      if (!doc.occurrences) continue;
+
+      if (!isPathWithinRoot(doc.relativePath, this.projectRoot)) {
+        logWarn('SCIP document path outside project root', {
+          path: doc.relativePath,
+        });
+        continue;
+      }
+
+      documentsProcessed++;
+      const edges: Edge[] = [];
+
+      for (const occ of doc.occurrences) {
+        if (!occ.symbol) continue;
+
+        const isDefinition = (occ.symbolRoles ?? 0) & SCIP_ROLE_DEFINITION;
+        if (isDefinition) continue;
+
+        const defFiles = this.symbolDefinitions.get(occ.symbol);
+        if (!defFiles) continue;
+
+        const line = occ.range[0] ?? 0;
+        const sourceNodes = this.queries.getNodesByFile(doc.relativePath);
+        const sourceNode = this.findBestSourceNode(sourceNodes, line);
+        if (!sourceNode) continue;
+
+        for (const defFile of defFiles) {
+          if (defFile === doc.relativePath) continue;
+
+          const targetNodes = this.queries.getNodesByFile(defFile);
+          const symbolName = this.extractSymbolName(occ.symbol);
+          const targetNode = targetNodes.find((n) => n.name === symbolName);
+          if (!targetNode) continue;
+
+          edges.push({
+            source: sourceNode.id,
+            target: targetNode.id,
+            kind: 'references',
+            line,
+            column: occ.range[1],
+            metadata: { confidence: 1.0, resolvedBy: 'scip' },
+            provenance: 'scip',
+          });
+        }
+      }
+
+      if (edges.length > 0) {
+        this.queries.insertEdges(edges);
+        edgesCreated += edges.length;
+      }
+    }
+
+    // Record import metadata
+    this.queries.setMetadata('scip_last_hash', contentHash);
+    this.queries.setMetadata(
+      'scip_last_imported_at',
+      new Date().toISOString()
+    );
+    this.queries.setMetadata('scip_edges_created', String(edgesCreated));
+
+    return { edgesCreated, documentsProcessed };
+  }
+
+  /**
+   * Find the closest node to a given line number in a file
+   */
+  private findBestSourceNode(nodes: Node[], line: number): Node | null {
+    let best: Node | null = null;
+    let bestDistance = Infinity;
+
+    // Prefer nodes that contain the line
+    for (const node of nodes) {
+      if (node.startLine === undefined) continue;
+      const distance = Math.abs(node.startLine - line);
+      if (node.startLine <= line && distance < bestDistance) {
+        best = node;
+        bestDistance = distance;
+      }
+    }
+
+    // Fall back to nearest node
+    if (!best) {
+      for (const node of nodes) {
+        if (node.startLine === undefined) continue;
+        const distance = Math.abs(node.startLine - line);
+        if (distance < bestDistance) {
+          best = node;
+          bestDistance = distance;
+        }
+      }
+    }
+
+    return best;
+  }
+
+  /**
+   * Extract the symbol name from a SCIP symbol string
+   */
+  private extractSymbolName(symbol: string): string {
+    const cleaned = symbol.replace(/[().#]+$/, '');
+    const parts = cleaned.split(/[.\s#/]+/);
+    return parts[parts.length - 1] || symbol;
+  }
+
+  /**
+   * Auto-detect SCIP files in the project
+   */
+  static findSCIPFiles(projectRoot: string): string[] {
+    const candidates = [
+      'index.scip',
+      'index.scip.json',
+      'dump.scip',
+      'dump.scip.json',
+      'build/index.scip',
+      'build/index.scip.json',
+      'target/index.scip',
+      'target/index.scip.json',
+    ];
+    const found: string[] = [];
+    for (const c of candidates) {
+      if (fs.existsSync(path.join(projectRoot, c))) found.push(c);
+    }
+    return found;
+  }
+}

--- a/src/sync/git-hooks.ts
+++ b/src/sync/git-hooks.ts
@@ -1,0 +1,259 @@
+/**
+ * Git Hooks Manager
+ *
+ * Installs/removes post-commit hooks to automatically sync the code graph
+ * after commits.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { logDebug, logWarn } from '../errors';
+
+const CODEGRAPH_MARKER = '# codegraph-hook';
+
+const POST_COMMIT_SCRIPT = `#!/bin/sh
+${CODEGRAPH_MARKER}
+# Auto-sync CodeGraph index after commits
+codegraph sync-if-dirty "$GIT_DIR/.." &
+`;
+
+export interface HookInstallResult {
+  success: boolean;
+  message: string;
+  hookPath?: string;
+}
+
+export interface HookRemoveResult {
+  success: boolean;
+  message: string;
+}
+
+export class GitHooksManager {
+  private projectRoot: string;
+
+  constructor(projectRoot: string) {
+    this.projectRoot = projectRoot;
+  }
+
+  /**
+   * Check if the project root is a git repository
+   */
+  isGitRepository(): boolean {
+    const gitDir = this.resolveGitDir();
+    return gitDir !== null;
+  }
+
+  /**
+   * Resolve the .git directory (supports worktrees)
+   */
+  private resolveGitDir(): string | null {
+    const gitPath = path.join(this.projectRoot, '.git');
+
+    if (!fs.existsSync(gitPath)) {
+      return null;
+    }
+
+    const stat = fs.statSync(gitPath);
+    if (stat.isDirectory()) {
+      return gitPath;
+    }
+
+    // Worktree: .git is a file with "gitdir: <path>"
+    if (stat.isFile()) {
+      try {
+        const content = fs.readFileSync(gitPath, 'utf-8').trim();
+        const match = content.match(/^gitdir:\s*(.+)$/);
+        if (match && match[1]) {
+          const resolvedPath = path.isAbsolute(match[1])
+            ? match[1]
+            : path.resolve(this.projectRoot, match[1]);
+          if (fs.existsSync(resolvedPath)) {
+            return resolvedPath;
+          }
+        }
+      } catch (error) {
+        logWarn('Failed to resolve git worktree', {
+          error: String(error),
+        });
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Get the hooks directory path
+   */
+  private getHooksDir(): string | null {
+    const gitDir = this.resolveGitDir();
+    if (!gitDir) return null;
+
+    // Check for core.hooksPath configuration
+    // For simplicity, use the default location
+    return path.join(gitDir, 'hooks');
+  }
+
+  /**
+   * Install the post-commit hook
+   */
+  installHook(): HookInstallResult {
+    if (!this.isGitRepository()) {
+      return {
+        success: false,
+        message: 'Not a git repository',
+      };
+    }
+
+    const hooksDir = this.getHooksDir();
+    if (!hooksDir) {
+      return {
+        success: false,
+        message: 'Could not determine hooks directory',
+      };
+    }
+
+    const hookPath = path.join(hooksDir, 'post-commit');
+
+    try {
+      // Ensure hooks directory exists
+      fs.mkdirSync(hooksDir, { recursive: true });
+
+      if (fs.existsSync(hookPath)) {
+        const existing = fs.readFileSync(hookPath, 'utf-8');
+
+        // Already installed
+        if (existing.includes(CODEGRAPH_MARKER)) {
+          return {
+            success: true,
+            message: 'Hook already installed',
+            hookPath,
+          };
+        }
+
+        // Append to existing hook
+        const updated = existing.trimEnd() + '\n\n' + POST_COMMIT_SCRIPT;
+        fs.writeFileSync(hookPath, updated, { mode: 0o755 });
+        logDebug('Appended codegraph hook to existing post-commit', {
+          hookPath,
+        });
+      } else {
+        // Create new hook
+        fs.writeFileSync(hookPath, POST_COMMIT_SCRIPT, { mode: 0o755 });
+        logDebug('Created codegraph post-commit hook', { hookPath });
+      }
+
+      return {
+        success: true,
+        message: 'Hook installed successfully',
+        hookPath,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message: `Failed to install hook: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  /**
+   * Remove the post-commit hook (or just the codegraph portion)
+   */
+  removeHook(): HookRemoveResult {
+    const hooksDir = this.getHooksDir();
+    if (!hooksDir) {
+      return {
+        success: false,
+        message: 'Could not determine hooks directory',
+      };
+    }
+
+    const hookPath = path.join(hooksDir, 'post-commit');
+
+    if (!fs.existsSync(hookPath)) {
+      return {
+        success: true,
+        message: 'No post-commit hook found',
+      };
+    }
+
+    try {
+      const content = fs.readFileSync(hookPath, 'utf-8');
+
+      if (!content.includes(CODEGRAPH_MARKER)) {
+        return {
+          success: true,
+          message: 'Hook does not contain codegraph section',
+        };
+      }
+
+      // Remove the codegraph section
+      const lines = content.split('\n');
+      const filtered: string[] = [];
+      let inCodegraphSection = false;
+
+      for (const line of lines) {
+        if (line.includes(CODEGRAPH_MARKER)) {
+          inCodegraphSection = true;
+          continue;
+        }
+        if (inCodegraphSection) {
+          // Skip lines until next section or end
+          if (line.startsWith('#') && !line.startsWith('# codegraph')) {
+            inCodegraphSection = false;
+            filtered.push(line);
+          }
+          continue;
+        }
+        filtered.push(line);
+      }
+
+      const remaining = filtered.join('\n').trim();
+
+      if (!remaining || remaining === '#!/bin/sh') {
+        // Nothing left, remove the file
+        fs.unlinkSync(hookPath);
+        logDebug('Removed codegraph post-commit hook file', { hookPath });
+      } else {
+        // Write back without codegraph section
+        fs.writeFileSync(hookPath, remaining + '\n', { mode: 0o755 });
+        logDebug('Removed codegraph section from post-commit hook', {
+          hookPath,
+        });
+      }
+
+      return {
+        success: true,
+        message: 'Hook removed successfully',
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message: `Failed to remove hook: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  /**
+   * Check if the codegraph hook is installed
+   */
+  isHookInstalled(): boolean {
+    const hooksDir = this.getHooksDir();
+    if (!hooksDir) return false;
+
+    const hookPath = path.join(hooksDir, 'post-commit');
+    if (!fs.existsSync(hookPath)) return false;
+
+    try {
+      const content = fs.readFileSync(hookPath, 'utf-8');
+      return content.includes(CODEGRAPH_MARKER);
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Create a GitHooksManager instance
+ */
+export function createGitHooksManager(projectRoot: string): GitHooksManager {
+  return new GitHooksManager(projectRoot);
+}

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -1,17 +1,13 @@
 /**
  * Sync Module
  *
- * Provides synchronization functionality for keeping the code graph
- * up-to-date with file system changes.
- *
- * Note: Git hooks functionality has been removed. CodeGraph sync is now
- * triggered through codegraph's Claude Code hooks integration instead.
- *
- * Components:
- * - Content hashing for change detection (in extraction module)
- * - Incremental reindexing (in extraction module)
+ * Provides synchronization and git hooks functionality for keeping
+ * the code graph up-to-date.
  */
 
-// This module is kept for potential future sync-related exports
-// Currently all sync functionality is in the extraction module
-export {};
+export {
+  GitHooksManager,
+  createGitHooksManager,
+  HookInstallResult,
+  HookRemoveResult,
+} from './git-hooks';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,47 @@
+/**
+ * Version and Provenance Tracking
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+interface RuntimeVersion {
+  package: string;
+  git: string | null;
+}
+
+let cachedVersion: RuntimeVersion | null = null;
+
+export function getRuntimeVersion(): RuntimeVersion {
+  if (cachedVersion) return cachedVersion;
+
+  let packageVersion = 'unknown';
+  try {
+    const pkgPath = path.join(__dirname, '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    packageVersion = pkg.version || 'unknown';
+  } catch {
+    /* Fall back to unknown */
+  }
+
+  let gitVersion: string | null = null;
+  try {
+    const rev = execSync('git rev-parse --short HEAD', {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const status = execSync('git status --porcelain', {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    gitVersion = status.length > 0 ? `${rev}-dirty` : rev;
+  } catch {
+    /* Not a git repo or git not available */
+  }
+
+  cachedVersion = { package: packageVersion, git: gitVersion };
+  return cachedVersion;
+}
+


### PR DESCRIPTION
## Summary
- **SCIP import** (`src/scip/index.ts`): `ScipImporter` class with two-pass SCIP JSON processing (definitions first, then references), content-hash fingerprinting for idempotent imports, and `findSCIPFiles()` auto-detection
- **Git hooks** (`src/sync/git-hooks.ts`): `GitHooksManager` class for installing/removing post-commit hooks with worktree support, marker-based hook identification, and safe append/remove operations
- **Version tracking** (`src/version.ts`): `getRuntimeVersion()` returning package version + git rev with caching
- **CLI enhancements** (`src/bin/codegraph.ts`): `hooks install`/`hooks remove`/`hooks status` commands, `displayIndexStats` in status output, version display
- **Public API** (`src/index.ts`): New methods on CodeGraph class — `importSCIP()`, `getVersion()`, `installGitHooks()`, `removeGitHooks()`, `isGitRepository()`, `isGitHookInstalled()`, `getMetadata()`

## Details

### SCIP Import
The `ScipImporter` processes SCIP (Source Code Intelligence Protocol) JSON files in two passes:
1. **Pass 1** — Build symbol definitions map from SCIP occurrences with `SymbolRole.Definition`
2. **Pass 2** — Resolve references by matching SCIP symbols to indexed CodeGraph nodes using line-proximity matching

Content-hash fingerprinting (SHA-256 of the SCIP file) enables idempotent imports — re-importing the same file is a no-op.

### Git Hooks Manager
The `GitHooksManager` handles post-commit hook installation for automatic `codegraph sync`:
- Resolves `.git` directory correctly for worktrees
- Uses `CODEGRAPH_MARKER` comments to identify managed hook sections
- Safely appends to existing hooks without overwriting user content
- Returns structured `HookInstallResult`/`HookRemoveResult` with status details

### Dead code verification
Every new export has at least one caller within this PR:
- `ScipImporter` → called by `importSCIP()` in `src/index.ts`
- `GitHooksManager` → used in CodeGraph constructor + CLI commands
- `createGitHooksManager` → called in CodeGraph constructor
- `getRuntimeVersion()` → called by CLI status + `CodeGraph.getVersion()`
- `HookInstallResult`/`HookRemoveResult` → used in method signatures

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm test` passes with same baseline (28 pre-existing failures, 326 passing)
- [x] 6 files changed/created: `src/scip/index.ts` (new), `src/sync/git-hooks.ts` (new), `src/version.ts` (new), `src/sync/index.ts`, `src/index.ts`, `src/bin/codegraph.ts`
- [x] All new exports verified to have callers (see dead code verification above)
- [x] Sentry preserved — 17 references in CLI (`initSentry`, `captureException`, error handlers)
- [x] All existing exports from `src/index.ts` preserved
- [x] No upstream features removed