### PR TITLE
fix: load WASM grammars sequentially to avoid Node 20+ race condition

### DIFF
--- a/src/extraction/grammars.ts
+++ b/src/extraction/grammars.ts
@@ -86,21 +86,20 @@ export async function initGrammars(): Promise<void> {
 
   await Parser.init();
 
-  // Load all grammars in parallel
+  // Load grammars sequentially to avoid web-tree-sitter WASM race condition on Node 20+
+  // See: https://github.com/tree-sitter/tree-sitter/issues/2338
   const entries = Object.entries(WASM_GRAMMAR_FILES) as [GrammarLanguage, string][];
-  await Promise.allSettled(
-    entries.map(async ([lang, wasmFile]) => {
-      try {
-        const wasmPath = require.resolve(`tree-sitter-wasms/out/${wasmFile}`);
-        const language = await WasmLanguage.load(wasmPath);
-        languageCache.set(lang, language);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.warn(`[CodeGraph] Failed to load ${lang} grammar — parsing will be unavailable: ${message}`);
-        unavailableGrammarErrors.set(lang, message);
-      }
-    })
-  );
+  for (const [lang, wasmFile] of entries) {
+    try {
+      const wasmPath = require.resolve(`tree-sitter-wasms/out/${wasmFile}`);
+      const language = await WasmLanguage.load(wasmPath);
+      languageCache.set(lang, language);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[CodeGraph] Failed to load ${lang} grammar — parsing will be unavailable: ${message}`);
+      unavailableGrammarErrors.set(lang, message);
+    }
+  }
 
   grammarsInitialized = true;
 }


### PR DESCRIPTION
## Summary

- Replace `Promise.allSettled(entries.map(...))` with a sequential `for...of` loop in `initGrammars()` to avoid a known `web-tree-sitter` WASM race condition on Node.js 19+/20+
- When multiple grammars with external scanners (TypeScript, TSX, C#, Swift, Kotlin, Dart, etc.) are loaded concurrently, V8's WebAssembly runtime hits a symbol resolution race where one grammar's exports overwrite another's GOT entries
- This produces errors like `bad export type for 'tree_sitter_tsx_external_scanner_create': undefined`, causing those languages to silently fail to index

## Root Cause

`web-tree-sitter` WASM instantiation is not safe for concurrent `Language.load()` calls on Node.js 19+ (V8 10.8+). The external scanner symbols from one grammar can collide with another's during parallel initialization.

Documented upstream:
- https://github.com/tree-sitter/tree-sitter/issues/2338
- https://github.com/tree-sitter/tree-sitter-typescript/issues/244

## Test plan

- [x] Verified on Node.js v20.20.0 (Linux x86_64) — all 16 grammars load successfully after the fix
- [x] Before fix: only Python indexed (303 files). After fix: Python + TSX + TypeScript + JavaScript + JSX (408 files)
- [x] No grammar `Failed to load` warnings in output after the change