### PR TITLE
fix: Prevent FK constraint failure from nodes with empty names

### DIFF
--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -644,24 +644,40 @@ export class ExtractionOrchestrator {
       this.queries.deleteFile(filePath);
     }
 
+    // Filter out nodes with missing required fields before insertion.
+    // This prevents FK violations when edges reference nodes that would
+    // be silently skipped by insertNode() (see issue #42).
+    const validNodes = result.nodes.filter((n) => n.id && n.kind && n.name && n.filePath && n.language);
+
     // Insert nodes
-    if (result.nodes.length > 0) {
-      this.queries.insertNodes(result.nodes);
+    if (validNodes.length > 0) {
+      this.queries.insertNodes(validNodes);
     }
 
-    // Insert edges
+    // Filter edges to only reference nodes that were actually inserted
     if (result.edges.length > 0) {
-      this.queries.insertEdges(result.edges);
+      const insertedIds = new Set(validNodes.map((n) => n.id));
+      const validEdges = result.edges.filter(
+        (e) => insertedIds.has(e.source) && insertedIds.has(e.target)
+      );
+      if (validEdges.length > 0) {
+        this.queries.insertEdges(validEdges);
+      }
     }
 
     // Insert unresolved references in batch with denormalized filePath/language
     if (result.unresolvedReferences.length > 0) {
-      const refsWithContext = result.unresolvedReferences.map((ref) => ({
-        ...ref,
-        filePath: ref.filePath ?? filePath,
-        language: ref.language ?? language,
-      }));
-      this.queries.insertUnresolvedRefsBatch(refsWithContext);
+      const insertedIds = new Set(validNodes.map((n) => n.id));
+      const refsWithContext = result.unresolvedReferences
+        .filter((ref) => insertedIds.has(ref.fromNodeId))
+        .map((ref) => ({
+          ...ref,
+          filePath: ref.filePath ?? filePath,
+          language: ref.language ?? language,
+        }));
+      if (refsWithContext.length > 0) {
+        this.queries.insertUnresolvedRefsBatch(refsWithContext);
+      }
     }
 
     // Insert file record

--- a/src/extraction/tree-sitter.ts
+++ b/src/extraction/tree-sitter.ts
@@ -1086,7 +1086,13 @@ export class TreeSitterExtractor {
     name: string,
     node: SyntaxNode,
     extra?: Partial<Node>
-  ): Node {
+  ): Node | null {
+    // Skip nodes with empty/missing names — they are not meaningful symbols
+    // and would cause FK violations when edges reference them (see issue #42)
+    if (!name) {
+      return null;
+    }
+
     const id = generateNodeId(this.filePath, kind, name, node.startPosition.row + 1);
 
     const newNode: Node = {
@@ -1209,6 +1215,7 @@ export class TreeSitterExtractor {
       isAsync,
       isStatic,
     });
+    if (!funcNode) return;
 
     // Push to stack and visit body
     this.nodeStack.push(funcNode.id);
@@ -1238,6 +1245,7 @@ export class TreeSitterExtractor {
       visibility,
       isExported,
     });
+    if (!classNode) return;
 
     // Extract extends/implements
     this.extractInheritance(node, classNode.id);
@@ -1291,6 +1299,7 @@ export class TreeSitterExtractor {
       isAsync,
       isStatic,
     });
+    if (!methodNode) return;
 
     // Push to stack and visit body
     this.nodeStack.push(methodNode.id);
@@ -1340,6 +1349,7 @@ export class TreeSitterExtractor {
       visibility,
       isExported,
     });
+    if (!structNode) return;
 
     // Push to stack for field extraction
     this.nodeStack.push(structNode.id);
@@ -2214,24 +2224,28 @@ export class TreeSitterExtractor {
 
     if (declClass) {
       const classNode = this.createNode('class', name, node);
-      // Extract inheritance from typeref children of declClass
-      this.extractPascalInheritance(declClass, classNode.id);
-      // Visit class body
-      this.nodeStack.push(classNode.id);
-      for (let i = 0; i < declClass.namedChildCount; i++) {
-        const child = declClass.namedChild(i);
-        if (child) this.visitNode(child);
+      if (classNode) {
+        // Extract inheritance from typeref children of declClass
+        this.extractPascalInheritance(declClass, classNode.id);
+        // Visit class body
+        this.nodeStack.push(classNode.id);
+        for (let i = 0; i < declClass.namedChildCount; i++) {
+          const child = declClass.namedChild(i);
+          if (child) this.visitNode(child);
+        }
+        this.nodeStack.pop();
       }
-      this.nodeStack.pop();
     } else if (declIntf) {
       const ifaceNode = this.createNode('interface', name, node);
-      // Visit interface members
-      this.nodeStack.push(ifaceNode.id);
-      for (let i = 0; i < declIntf.namedChildCount; i++) {
-        const child = declIntf.namedChild(i);
-        if (child) this.visitNode(child);
+      if (ifaceNode) {
+        // Visit interface members
+        this.nodeStack.push(ifaceNode.id);
+        for (let i = 0; i < declIntf.namedChildCount; i++) {
+          const child = declIntf.namedChild(i);
+          if (child) this.visitNode(child);
+        }
+        this.nodeStack.pop();
       }
-      this.nodeStack.pop();
     } else if (typeChild) {
       // Check if it contains a declEnum
       const declEnum = typeChild.namedChildren.find(
@@ -2239,18 +2253,20 @@ export class TreeSitterExtractor {
       );
       if (declEnum) {
         const enumNode = this.createNode('enum', name, node);
-        // Extract enum members
-        this.nodeStack.push(enumNode.id);
-        for (let i = 0; i < declEnum.namedChildCount; i++) {
-          const child = declEnum.namedChild(i);
-          if (child?.type === 'declEnumValue') {
-            const memberName = getChildByField(child, 'name');
-            if (memberName) {
-              this.createNode('enum_member', getNodeText(memberName, this.source), child);
+        if (enumNode) {
+          // Extract enum members
+          this.nodeStack.push(enumNode.id);
+          for (let i = 0; i < declEnum.namedChildCount; i++) {
+            const child = declEnum.namedChild(i);
+            if (child?.type === 'declEnumValue') {
+              const memberName = getChildByField(child, 'name');
+              if (memberName) {
+                this.createNode('enum_member', getNodeText(memberName, this.source), child);
+              }
             }
           }
+          this.nodeStack.pop();
         }
-        this.nodeStack.pop();
       } else {
         // Simple type alias: type TFoo = string / type TFoo = Integer
         this.createNode('type_alias', name, node);


### PR DESCRIPTION
## Summary

Fixes #42 — `FOREIGN KEY constraint failed` when indexing C/C++ header files.

**Root cause:** Tree-sitter can produce function nodes with empty names from complex C/C++ declarators (e.g. macro-generated declarations in `.h` files). These nodes were silently skipped by `insertNode()` validation, but their containment edges were still inserted into the database — causing a FK violation since the target node didn't exist.

**Two-layer fix:**
- **Extraction layer:** `createNode()` now returns `null` for empty names, preventing the node and its containment edges from ever being created. All 7 callers that use the return value handle the `null` case.
- **Storage layer (safety net):** `storeExtractionResult()` now filters edges and unresolved references to only include those referencing nodes that passed validation, preventing any future FK violations from similar edge cases.

## Test plan

- [x] All 396 existing tests pass
- [ ] Verify indexing a C/C++ project with complex header files (macro-heavy `.h` files)
- [ ] Verify the reporter's project from #42 indexes without FK errors