### PR TITLE
docs: README setup for non-Claude MCP clients (opencode, Cursor, LangChain, Agent SDK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ fi
 
 ## MCP Tools
 
-When running as an MCP server, CodeGraph exposes these tools to Claude Code:
+When running as an MCP server, CodeGraph exposes these tools to any MCP-compatible AI assistant:
 
 | Tool | Purpose |
 |------|---------|
@@ -328,6 +328,110 @@ When running as an MCP server, CodeGraph exposes these tools to Claude Code:
 | `codegraph_node` | Get details about a specific symbol (optionally with source code) |
 | `codegraph_files` | Get indexed file structure (faster than filesystem scanning) |
 | `codegraph_status` | Check index health and statistics |
+
+---
+
+## Using with Other MCP Clients
+
+The MCP server runs over **stdio** and works with any MCP-compatible client — not just Claude Code. The interactive installer is Claude Code-specific (it writes `~/.claude.json`), so for other clients you'll want the manual setup.
+
+**Common steps for every client:**
+
+```bash
+npm install -g @colbymchenry/codegraph     # so `codegraph` is on PATH
+cd your-project
+codegraph init -i                           # initialize + index this project
+```
+
+Then point your MCP client at `codegraph serve --mcp` using whatever config shape it expects:
+
+### opencode
+
+In `opencode.json` (project) or `~/.config/opencode/opencode.json` (global):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "codegraph": {
+      "type": "local",
+      "command": ["codegraph", "serve", "--mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+
+### Cursor
+
+In `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project):
+
+```json
+{
+  "mcpServers": {
+    "codegraph": {
+      "command": "codegraph",
+      "args": ["serve", "--mcp"]
+    }
+  }
+}
+```
+
+### LangChain (`MultiServerMCPClient`)
+
+The CodeGraph server speaks stdio, not SSE — pass `transport: "stdio"`:
+
+```python
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+client = MultiServerMCPClient({
+    "codegraph": {
+        "command": "codegraph",
+        "args": ["serve", "--mcp"],
+        "transport": "stdio",
+    }
+})
+tools = await client.get_tools()
+```
+
+### Claude Agent SDK
+
+Pass the server in `mcpServers` (TypeScript) or `mcp_servers` (Python) when calling `query()`:
+
+```python
+from claude_agent_sdk import query, ClaudeAgentOptions
+
+options = ClaudeAgentOptions(
+    mcp_servers={
+        "codegraph": {
+            "command": "codegraph",
+            "args": ["serve", "--mcp"],
+        }
+    },
+    allowed_tools=["mcp__codegraph__*"],
+)
+
+async for message in query(prompt="Where is auth handled?", options=options):
+    ...
+```
+
+### Anything else (generic stdio MCP)
+
+Most MCP clients (Continue, Zed, custom integrations, etc.) accept some variation of `command` + `args`. The values are always:
+
+| Field | Value |
+|-------|-------|
+| Command | `codegraph` |
+| Args | `["serve", "--mcp"]` |
+| Transport | `stdio` |
+
+The server reads the project root from the MCP `initialize` request's `rootUri` (set by the client when it connects). If your client doesn't send a `rootUri`, pass the project path explicitly:
+
+```bash
+codegraph serve --mcp --path /absolute/path/to/project
+```
+
+> **Note:** CodeGraph's MCP server does **not** speak SSE/HTTP. If your client only supports `url` + `transport: "sse"`, you'll need to wrap stdio with a bridge like [supergateway](https://github.com/supercorp-ai/supergateway).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a **"Using with Other MCP Clients"** section to the README. The current README only documents the Claude Code / `~/.claude.json` setup, which leaves users of other MCP clients (opencode, Cursor, LangChain, the Anthropic Agent SDK) guessing at the right config shape — that's what issues #65 and #79 ask for.

Closes #65, #79.

## What's added

A new section right after the existing **MCP Tools** table, covering five client shapes:

- **opencode** — `opencode.json` `mcp.<name>` block with `type: "local"` + `command` array
- **Cursor** — `~/.cursor/mcp.json` `mcpServers.<name>` block (Anthropic-style stdio shape)
- **LangChain** (`MultiServerMCPClient`) — Python dict with `command` / `args` / `transport: "stdio"`. Issue #65 was specifically tripping on SSE config — the section calls out that the server is stdio-only.
- **Claude Agent SDK** — Python `ClaudeAgentOptions(mcp_servers=...)` with `allowed_tools=["mcp__codegraph__*"]`
- **Generic stdio MCP** fallback — a 3-row table (`command`, `args`, `transport`) for any other client, plus a note about `--path` for clients that don't send `rootUri` in the initialize request

A closing note points SSE-only clients at [supergateway](https://github.com/supercorp-ai/supergateway) as a stdio→SSE bridge.

## Test plan

- [x] Reviewed the rendered Markdown locally
- [x] Verified the field names against each client's actual docs:
  - opencode: https://opencode.ai/docs/mcp-servers/
  - Claude Agent SDK: https://code.claude.com/docs/en/agent-sdk/mcp
  - LangChain: langchain-ai/langchain-mcp-adapters README
- [x] Verified `codegraph serve --mcp --path <dir>` flag exists in `src/bin/codegraph.ts:1031`
- [x] Verified the server reads `rootUri` from the `initialize` request in `src/mcp/index.ts:257`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
