### PR TITLE
feat(mcp): surface project root in codegraph_status + actionable errors

### DIFF
--- a/__tests__/mcp-status.test.ts
+++ b/__tests__/mcp-status.test.ts
@@ -1,0 +1,140 @@
+/**
+ * codegraph_status output: project-root surfacing + multi-project list.
+ *
+ * Regression guard for the friction point where an agent calling MCP
+ * tools couldn't tell which project the server's default points at,
+ * so couldn't tell whether to start passing `projectPath` on later
+ * calls. status's first line must always answer that.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { CodeGraph } from '../src';
+import { ToolHandler } from '../src/mcp/tools';
+
+function tempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cg-mcp-status-'));
+}
+
+function cleanup(dir: string): void {
+  if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true });
+}
+
+async function makeProject(dir: string, file: string): Promise<CodeGraph> {
+  fs.mkdirSync(path.join(dir, 'src'));
+  fs.writeFileSync(
+    path.join(dir, 'src', file),
+    `export function f(): number { return 1; }\n`
+  );
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: path.basename(dir), version: '0.0.0' })
+  );
+  const cg = await CodeGraph.init(dir, { config: { llm: { endpoint: '' } } });
+  await cg.indexAll({ summarize: false });
+  return cg;
+}
+
+describe('codegraph_status — project-root surfacing', () => {
+  let dirs: string[] = [];
+  let cgs: CodeGraph[] = [];
+  let handler: ToolHandler | null = null;
+
+  beforeEach(() => {
+    dirs = [];
+    cgs = [];
+    handler = null;
+  });
+
+  afterEach(() => {
+    // Close any cached projects the handler opened — otherwise we
+    // leak SQLite handles + leave WAL files in tmp.
+    handler?.closeAll();
+    for (const cg of cgs) {
+      try {
+        cg.close();
+      } catch {
+        /* idempotent — already closed by closeAll() */
+      }
+    }
+    for (const d of dirs) cleanup(d);
+  });
+
+  it('shows the project root labelled as "default" when the server has a default and projectPath is omitted', async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    const cg = await makeProject(dir, 'a.ts');
+    cgs.push(cg);
+
+    handler = new ToolHandler(cg);
+    const result = await handler.execute('codegraph_status', {});
+    const text = result.content[0]?.text ?? '';
+
+    expect(text).toMatch(new RegExp(`Project root.*\`${path.resolve(dir)}\``));
+    expect(text).toMatch(/default/);
+    expect(text).toMatch(/server CWD at startup/);
+  });
+
+  it('shows the project root labelled as "from `projectPath`" when projectPath is supplied', async () => {
+    const defaultDir = tempDir();
+    const otherDir = tempDir();
+    dirs.push(defaultDir, otherDir);
+    const defaultCg = await makeProject(defaultDir, 'a.ts');
+    cgs.push(defaultCg);
+    // Initialize the second project's .codegraph/ but don't keep our
+    // own handle — the ToolHandler will open it via projectPath and
+    // own its lifecycle through projectCache.
+    const tmpCg = await makeProject(otherDir, 'b.ts');
+    tmpCg.close();
+
+    handler = new ToolHandler(defaultCg);
+    const result = await handler.execute('codegraph_status', { projectPath: otherDir });
+    const text = result.content[0]?.text ?? '';
+
+    expect(text).toMatch(new RegExp(`Project root.*\`${path.resolve(otherDir)}\``));
+    expect(text).toMatch(/from `projectPath` argument/);
+  });
+
+  it('lists other projects the server has open under "Other projects this server has open"', async () => {
+    const defaultDir = tempDir();
+    const otherDir = tempDir();
+    dirs.push(defaultDir, otherDir);
+    const defaultCg = await makeProject(defaultDir, 'a.ts');
+    cgs.push(defaultCg);
+    const tmpCg = await makeProject(otherDir, 'b.ts');
+    tmpCg.close();
+
+    handler = new ToolHandler(defaultCg);
+    // Prime the cache with the second project.
+    await handler.execute('codegraph_status', { projectPath: otherDir });
+    // Now query the default — it should mention the other project.
+    const result = await handler.execute('codegraph_status', {});
+    const text = result.content[0]?.text ?? '';
+
+    expect(text).toMatch(/### Other projects this server has open/);
+    expect(text).toContain(path.resolve(otherDir));
+  });
+
+  it('throws an actionable error suggesting `projectPath` when no default and projectPath omitted', async () => {
+    handler = new ToolHandler(null);
+    const result = await handler.execute('codegraph_status', {});
+    expect(result.isError).toBe(true);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toMatch(/No default codegraph project/);
+    expect(text).toMatch(/projectPath/);
+    expect(text).toMatch(/codegraph init/);
+  });
+
+  it('throws an actionable error pointing at the supplied path when projectPath has no .codegraph/', async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    // Note: we deliberately did NOT call makeProject — there's no .codegraph/.
+    handler = new ToolHandler(null);
+    const result = await handler.execute('codegraph_status', { projectPath: dir });
+    expect(result.isError).toBe(true);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toMatch(/No \.codegraph\/ found/);
+    expect(text).toContain(dir);
+  });
+});

--- a/__tests__/mcp-tool-registry.test.ts
+++ b/__tests__/mcp-tool-registry.test.ts
@@ -73,7 +73,10 @@ describe('MCP tool registry — single source of truth', () => {
     expect(result.isError).toBe(true);
     // Generic tool-execution-failed envelope from execute()'s catch block.
     expect(result.content[0]?.text).toMatch(/Tool execution failed/);
-    // Specifically because no CodeGraph was bound:
-    expect(result.content[0]?.text).toMatch(/CodeGraph not initialized/);
+    // Specifically because no CodeGraph was bound — the message
+    // should point the agent at `projectPath` as a remediation since
+    // the MCP server has no default project.
+    expect(result.content[0]?.text).toMatch(/No default codegraph project/);
+    expect(result.content[0]?.text).toMatch(/projectPath/);
   });
 });

--- a/__tests__/mcp-tool-registry.test.ts
+++ b/__tests__/mcp-tool-registry.test.ts
@@ -1,0 +1,79 @@
+/**
+ * MCP tool registry: structural invariants.
+ *
+ * Guards against the failure mode where a future PR adds a
+ * ToolModule but forgets to implement the matching `handle<Name>`
+ * method on ToolHandler (or vice versa).
+ */
+import { describe, it, expect } from 'vitest';
+import { getToolModules, tools as registryTools } from '../src/mcp/tools/registry';
+import { ToolHandler, tools } from '../src/mcp/tools';
+
+describe('MCP tool registry — single source of truth', () => {
+  it('every tool module has a non-empty name and description', () => {
+    for (const m of getToolModules()) {
+      expect(m.definition.name).toMatch(/^codegraph_[a-z_]+$/);
+      expect(m.definition.description.length).toBeGreaterThan(20);
+    }
+  });
+
+  it('handlerKey is a string starting with "handle"', () => {
+    for (const m of getToolModules()) {
+      expect(m.handlerKey).toMatch(/^handle[A-Z][A-Za-z]+$/);
+    }
+  });
+
+  it('every registered tool has a corresponding ToolHandler method', () => {
+    const handler = new ToolHandler(null);
+    for (const m of getToolModules()) {
+      const fn = (handler as unknown as Record<string, unknown>)[m.handlerKey];
+      expect(typeof fn).toBe('function');
+    }
+  });
+
+  it('exported `tools` array exactly mirrors the registry', () => {
+    const fromRegistry = registryTools.map((t) => t.name).sort();
+    const fromExport = tools.map((t) => t.name).sort();
+    expect(fromExport).toEqual(fromRegistry);
+  });
+
+  it('all 9 main-line tools are registered (regression guard)', () => {
+    const expected = [
+      'codegraph_callees',
+      'codegraph_callers',
+      'codegraph_context',
+      'codegraph_explore',
+      'codegraph_files',
+      'codegraph_impact',
+      'codegraph_node',
+      'codegraph_search',
+      'codegraph_status',
+    ];
+    const actual = getToolModules()
+      .map((m) => m.definition.name)
+      .sort();
+    expect(actual).toEqual(expected);
+  });
+
+  it('execute() reports unknown-tool errors', async () => {
+    const handler = new ToolHandler(null);
+    const result = await handler.execute('codegraph_does_not_exist', {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/Unknown tool/);
+  });
+
+  it('execute() actually dispatches to the registered handler (no broken `this` binding)', async () => {
+    // No CodeGraph instance is bound, so handlers that call
+    // `getCodeGraph()` will throw — the dispatch should catch it
+    // and return an error result. The point of this test is to
+    // confirm the registry lookup + `this[handlerKey](args)` chain
+    // reaches an actual method body, not that the body succeeds.
+    const handler = new ToolHandler(null);
+    const result = await handler.execute('codegraph_status', {});
+    expect(result.isError).toBe(true);
+    // Generic tool-execution-failed envelope from execute()'s catch block.
+    expect(result.content[0]?.text).toMatch(/Tool execution failed/);
+    // Specifically because no CodeGraph was bound:
+    expect(result.content[0]?.text).toMatch(/CodeGraph not initialized/);
+  });
+});

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -18,7 +18,8 @@
 import * as path from 'path';
 import CodeGraph, { findNearestCodeGraphRoot } from '../index';
 import { StdioTransport, JsonRpcRequest, JsonRpcNotification, ErrorCodes } from './transport';
-import { tools, ToolHandler } from './tools';
+import { ToolHandler } from './tools';
+import { getToolModule } from './tools/registry';
 
 /**
  * Convert a file:// URI to a filesystem path.
@@ -309,8 +310,9 @@ export class MCPServer {
     const toolName = params.name;
     const toolArgs = params.arguments || {};
 
-    // Validate tool exists
-    const tool = tools.find(t => t.name === toolName);
+    // Validate tool exists — O(1) Map lookup against the registry,
+    // matches the path `ToolHandler.execute()` uses internally.
+    const tool = getToolModule(toolName)?.definition;
     if (!tool) {
       this.transport.sendError(
         request.id,

--- a/src/mcp/tool-types.ts
+++ b/src/mcp/tool-types.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared MCP tool types.
+ *
+ * Lives in its own module so per-tool files in `./tools/` and
+ * the legacy class wrapper in `./tools.ts` can import the same
+ * type definitions without a circular dependency.
+ */
+
+export interface PropertySchema {
+  type: string;
+  description: string;
+  enum?: string[];
+  default?: unknown;
+}
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: 'object';
+    properties: Record<string, PropertySchema>;
+    required?: string[];
+  };
+}
+
+export interface ToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+/**
+ * Shared `projectPath` schema property — every tool's inputSchema
+ * accepts it for cross-project queries.
+ */
+export const projectPathProperty: PropertySchema = {
+  type: 'string',
+  description:
+    'Path to a different project with .codegraph/ initialized. If omitted, uses current project. Use this to query other codebases.',
+};

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -126,7 +126,12 @@ export class ToolHandler implements ToolHandlerLike {
   private getCodeGraph(projectPath?: string): CodeGraph {
     if (!projectPath) {
       if (!this.cg) {
-        throw new Error('CodeGraph not initialized for this project. Run \'codegraph init\' first.');
+        throw new Error(
+          'No default codegraph project for this MCP server.\n' +
+            'Either: (a) restart the MCP server from a directory containing .codegraph/, ' +
+            '(b) run `codegraph init` in the current directory, or ' +
+            '(c) pass `projectPath` pointing to a directory that already has .codegraph/.'
+        );
       }
       return this.cg;
     }
@@ -140,7 +145,10 @@ export class ToolHandler implements ToolHandlerLike {
     const resolvedRoot = findNearestCodeGraphRoot(projectPath);
 
     if (!resolvedRoot) {
-      throw new Error(`CodeGraph not initialized in ${projectPath}. Run 'codegraph init' in that project first.`);
+      throw new Error(
+        `No .codegraph/ found at or above ${projectPath}. ` +
+          `Run \`codegraph init\` in that project first, or pass a different projectPath.`
+      );
     }
 
     // Check if we already have this resolved root cached (different path, same project)
@@ -735,9 +743,32 @@ export class ToolHandler implements ToolHandlerLike {
     const cg = this.getCodeGraph(args.projectPath as string | undefined);
     const stats = cg.getStats();
 
+    // Tell the agent *which* project this status is for and how it was
+    // selected. The friction point this addresses: when an MCP server's
+    // default project doesn't match what the user wants, the agent
+    // can't tell from any other tool's output whether to start passing
+    // `projectPath`. Surfacing the project root here makes the
+    // mismatch visible on the very first call.
+    //
+    // Note: `getCodeGraph(undefined)` always returns `this.cg` or
+    // throws, so when `args.projectPath` is undefined the project IS
+    // the default — no third "resolved from cache" branch needed.
+    const projectRoot = cg.getProjectRoot();
+    // Path equality below is strict-string. `path.resolve` doesn't
+    // normalise case, so on macOS/Windows (case-insensitive FS) a
+    // client-supplied `rootUri` with different capitalisation than the
+    // server's CWD would compare unequal — see the `otherRoots` Set
+    // below where we still dedup on the resolved root string.
+    const defaultRoot = this.cg?.getProjectRoot() ?? null;
+    const sourceLabel =
+      args.projectPath !== undefined
+        ? '(from `projectPath` argument)'
+        : '(default — server CWD at startup)';
+
     const lines: string[] = [
       '## CodeGraph Status',
       '',
+      `**Project root:** \`${projectRoot}\` ${sourceLabel}`,
       `**Files indexed:** ${stats.fileCount}`,
       `**Total nodes:** ${stats.nodeCount}`,
       `**Total edges:** ${stats.edgeCount}`,
@@ -757,6 +788,22 @@ export class ToolHandler implements ToolHandlerLike {
       if ((count as number) > 0) {
         lines.push(`- ${lang}: ${count}`);
       }
+    }
+
+    // List other projects the server already has open. Helpful when an
+    // agent is working across a monorepo or several adjacent repos —
+    // they can pick a `projectPath` from a known-good list instead of
+    // guessing.
+    const otherRoots = new Set<string>();
+    if (defaultRoot && defaultRoot !== projectRoot) otherRoots.add(defaultRoot);
+    for (const cached of this.projectCache.values()) {
+      const root = cached.getProjectRoot();
+      if (root !== projectRoot) otherRoots.add(root);
+    }
+    if (otherRoots.size > 0) {
+      lines.push('', '### Other projects this server has open');
+      for (const root of otherRoots) lines.push(`- \`${root}\``);
+      lines.push('', 'Pass `projectPath` to query any of these (or any other directory containing `.codegraph/`).');
     }
 
     return this.textResult(lines.join('\n'));

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -11,6 +11,25 @@ import { writeFileSync, readFileSync, existsSync } from 'fs';
 import { clamp, validatePathWithinRoot } from '../utils';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import type { ToolDefinition, ToolResult } from './tool-types';
+import type { ToolHandlerLike } from './tools/types';
+import { getToolModule, tools as registryTools } from './tools/registry';
+
+// Re-export shared types so existing consumers (`import { ToolDefinition,
+// ToolResult } from './tools'`) keep working unchanged.
+export type { ToolDefinition, ToolResult } from './tool-types';
+
+/**
+ * The MCP `list_tools` array, derived from the per-tool registry
+ * (`./tools/<name>.ts`). Adding a new tool no longer touches this
+ * array — drop a file in `./tools/` and add it to
+ * `./tools/registry.ts`.
+ *
+ * Typed as a mutable array (matching the original export shape)
+ * even though the underlying registry produces a readonly value;
+ * we slice() to materialize a fresh, mutable copy at module load.
+ */
+export const tools: ToolDefinition[] = registryTools.slice();
 
 /** Maximum output length to prevent context bloat (characters) */
 const MAX_OUTPUT_LENGTH = 15000;
@@ -42,248 +61,6 @@ function markSessionConsulted(sessionId: string): void {
   }
 }
 
-/**
- * MCP Tool definition
- */
-export interface ToolDefinition {
-  name: string;
-  description: string;
-  inputSchema: {
-    type: 'object';
-    properties: Record<string, PropertySchema>;
-    required?: string[];
-  };
-}
-
-interface PropertySchema {
-  type: string;
-  description: string;
-  enum?: string[];
-  default?: unknown;
-}
-
-/**
- * Tool execution result
- */
-export interface ToolResult {
-  content: Array<{
-    type: 'text';
-    text: string;
-  }>;
-  isError?: boolean;
-}
-
-/**
- * Common projectPath property for cross-project queries
- */
-const projectPathProperty: PropertySchema = {
-  type: 'string',
-  description: 'Path to a different project with .codegraph/ initialized. If omitted, uses current project. Use this to query other codebases.',
-};
-
-/**
- * All CodeGraph MCP tools
- *
- * Designed for minimal context usage - use codegraph_context as the primary tool,
- * and only use other tools for targeted follow-up queries.
- *
- * All tools support cross-project queries via the optional `projectPath` parameter.
- */
-export const tools: ToolDefinition[] = [
-  {
-    name: 'codegraph_search',
-    description: 'Quick symbol search by name. Returns locations only (no code). Use codegraph_context instead for comprehensive task context.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        query: {
-          type: 'string',
-          description: 'Symbol name or partial name (e.g., "auth", "signIn", "UserService")',
-        },
-        kind: {
-          type: 'string',
-          description: 'Filter by node kind',
-          enum: ['function', 'method', 'class', 'interface', 'type', 'variable', 'route', 'component'],
-        },
-        limit: {
-          type: 'number',
-          description: 'Maximum results (default: 10)',
-          default: 10,
-        },
-        projectPath: projectPathProperty,
-      },
-      required: ['query'],
-    },
-  },
-  {
-    name: 'codegraph_context',
-    description: 'PRIMARY TOOL: Build comprehensive context for a task. Returns entry points, related symbols, and key code - often enough to understand the codebase without additional tool calls. NOTE: This provides CODE context, not product requirements. For new features, still clarify UX/behavior questions with the user before implementing.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        task: {
-          type: 'string',
-          description: 'Description of the task, bug, or feature to build context for',
-        },
-        maxNodes: {
-          type: 'number',
-          description: 'Maximum symbols to include (default: 20)',
-          default: 20,
-        },
-        includeCode: {
-          type: 'boolean',
-          description: 'Include code snippets for key symbols (default: true)',
-          default: true,
-        },
-        projectPath: projectPathProperty,
-      },
-      required: ['task'],
-    },
-  },
-  {
-    name: 'codegraph_callers',
-    description: 'Find all functions/methods that call a specific symbol. Useful for understanding usage patterns and impact of changes.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        symbol: {
-          type: 'string',
-          description: 'Name of the function, method, or class to find callers for',
-        },
-        limit: {
-          type: 'number',
-          description: 'Maximum number of callers to return (default: 20)',
-          default: 20,
-        },
-        projectPath: projectPathProperty,
-      },
-      required: ['symbol'],
-    },
-  },
-  {
-    name: 'codegraph_callees',
-    description: 'Find all functions/methods that a specific symbol calls. Useful for understanding dependencies and code flow.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        symbol: {
-          type: 'string',
-          description: 'Name of the function, method, or class to find callees for',
-        },
-        limit: {
-          type: 'number',
-          description: 'Maximum number of callees to return (default: 20)',
-          default: 20,
-        },
-        projectPath: projectPathProperty,
-      },
-      required: ['symbol'],
-    },
-  },
-  {
-    name: 'codegraph_impact',
-    description: 'Analyze the impact radius of changing a symbol. Shows what code could be affected by modifications.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        symbol: {
-          type: 'string',
-          description: 'Name of the symbol to analyze impact for',
-        },
-        depth: {
-          type: 'number',
-          description: 'How many levels of dependencies to traverse (default: 2)',
-          default: 2,
-        },
-        projectPath: projectPathProperty,
-      },
-      required: ['symbol'],
-    },
-  },
-  {
-    name: 'codegraph_node',
-    description: 'Get detailed information about a specific code symbol. Use includeCode=true only when you need the full source code - otherwise just get location and signature to minimize context usage.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        symbol: {
-          type: 'string',
-          description: 'Name of the symbol to get details for',
-        },
-        includeCode: {
-          type: 'boolean',
-          description: 'Include full source code (default: false to minimize context)',
-          default: false,
-        },
-        projectPath: projectPathProperty,
-      },
-      required: ['symbol'],
-    },
-  },
-  {
-    name: 'codegraph_explore',
-    description: 'Deep exploration tool — returns comprehensive context for a topic in a SINGLE call. Groups all relevant source code by file (contiguous sections, not snippets), includes a relationship map, and uses deeper graph traversal. Designed to replace multiple codegraph_node + file Read calls. Use this instead of codegraph_context when you need thorough understanding. IMPORTANT: Use specific symbol names, file names, or short code terms in your query — NOT natural language sentences. Before calling this, use codegraph_search to discover relevant symbol names, then include those names in your query. Bad: "how are agent prompts loaded and passed to the CLI". Good: "readAgentsFromDirectory createClaudeSession chat-manager agents.ts".',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        query: {
-          type: 'string',
-          description: 'Symbol names, file names, or short code terms to explore (e.g., "AuthService loginUser session-manager", "GraphTraverser BFS impact traversal.ts"). Use codegraph_search first to find relevant names.',
-        },
-        maxFiles: {
-          type: 'number',
-          description: 'Maximum number of files to include source code from (default: 12)',
-          default: 12,
-        },
-        projectPath: projectPathProperty,
-      },
-      required: ['query'],
-    },
-  },
-  {
-    name: 'codegraph_status',
-    description: 'Get the status of the CodeGraph index, including statistics about indexed files, nodes, and edges.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        projectPath: projectPathProperty,
-      },
-    },
-  },
-  {
-    name: 'codegraph_files',
-    description: 'REQUIRED for file/folder exploration. Get the project file structure from the CodeGraph index. Returns a tree view of all indexed files with metadata (language, symbol count). Much faster than Glob/filesystem scanning. Use this FIRST when exploring project structure, finding files, or understanding codebase organization.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        path: {
-          type: 'string',
-          description: 'Filter to files under this directory path (e.g., "src/components"). Returns all files if not specified.',
-        },
-        pattern: {
-          type: 'string',
-          description: 'Filter files matching this glob pattern (e.g., "*.tsx", "**/*.test.ts")',
-        },
-        format: {
-          type: 'string',
-          description: 'Output format: "tree" (hierarchical, default), "flat" (simple list), "grouped" (by language)',
-          enum: ['tree', 'flat', 'grouped'],
-          default: 'tree',
-        },
-        includeMetadata: {
-          type: 'boolean',
-          description: 'Include file metadata like language and symbol count (default: true)',
-          default: true,
-        },
-        maxDepth: {
-          type: 'number',
-          description: 'Maximum directory depth to show (default: unlimited)',
-        },
-        projectPath: projectPathProperty,
-      },
-    },
-  },
-];
 
 /**
  * Tool handler that executes tools against a CodeGraph instance
@@ -291,7 +68,7 @@ export const tools: ToolDefinition[] = [
  * Supports cross-project queries via the projectPath parameter.
  * Other projects are opened on-demand and cached for performance.
  */
-export class ToolHandler {
+export class ToolHandler implements ToolHandlerLike {
   // Cache of opened CodeGraph instances for cross-project queries
   private projectCache: Map<string, CodeGraph> = new Map();
 
@@ -404,32 +181,24 @@ export class ToolHandler {
   }
 
   /**
-   * Execute a tool by name
+   * Execute a tool by name.
+   *
+   * The dispatch table lives in `./tools/registry.ts` — this method
+   * just looks up the tool's `handlerKey` and invokes the matching
+   * `handle<Name>` method on this class. Adding a new tool means
+   * registering a `ToolModule` (one new file under `./tools/`,
+   * one entry in the registry) plus implementing
+   * `handle<Name>(args)` here.
    */
   async execute(toolName: string, args: Record<string, unknown>): Promise<ToolResult> {
     try {
-      switch (toolName) {
-        case 'codegraph_search':
-          return await this.handleSearch(args);
-        case 'codegraph_context':
-          return await this.handleContext(args);
-        case 'codegraph_callers':
-          return await this.handleCallers(args);
-        case 'codegraph_callees':
-          return await this.handleCallees(args);
-        case 'codegraph_impact':
-          return await this.handleImpact(args);
-        case 'codegraph_explore':
-          return await this.handleExplore(args);
-        case 'codegraph_node':
-          return await this.handleNode(args);
-        case 'codegraph_status':
-          return await this.handleStatus(args);
-        case 'codegraph_files':
-          return await this.handleFiles(args);
-        default:
-          return this.errorResult(`Unknown tool: ${toolName}`);
-      }
+      const mod = getToolModule(toolName);
+      if (!mod) return this.errorResult(`Unknown tool: ${toolName}`);
+      // `implements ToolHandlerLike` makes this lookup type-safe:
+      // `mod.handlerKey` is constrained to `HandlerKey`, and every
+      // member of that union maps to an `(args) => Promise<ToolResult>`
+      // method on `this` (verified at compile time, not at runtime).
+      return await this[mod.handlerKey](args);
     } catch (err) {
       return this.errorResult(`Tool execution failed: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -438,7 +207,7 @@ export class ToolHandler {
   /**
    * Handle codegraph_search
    */
-  private async handleSearch(args: Record<string, unknown>): Promise<ToolResult> {
+  async handleSearch(args: Record<string, unknown>): Promise<ToolResult> {
     const query = this.validateString(args.query, 'query');
     if (typeof query !== 'string') return query;
 
@@ -463,7 +232,7 @@ export class ToolHandler {
   /**
    * Handle codegraph_context
    */
-  private async handleContext(args: Record<string, unknown>): Promise<ToolResult> {
+  async handleContext(args: Record<string, unknown>): Promise<ToolResult> {
     const task = this.validateString(args.task, 'task');
     if (typeof task !== 'string') return task;
 
@@ -529,7 +298,7 @@ export class ToolHandler {
   /**
    * Handle codegraph_callers
    */
-  private async handleCallers(args: Record<string, unknown>): Promise<ToolResult> {
+  async handleCallers(args: Record<string, unknown>): Promise<ToolResult> {
     const symbol = this.validateString(args.symbol, 'symbol');
     if (typeof symbol !== 'string') return symbol;
 
@@ -564,7 +333,7 @@ export class ToolHandler {
   /**
    * Handle codegraph_callees
    */
-  private async handleCallees(args: Record<string, unknown>): Promise<ToolResult> {
+  async handleCallees(args: Record<string, unknown>): Promise<ToolResult> {
     const symbol = this.validateString(args.symbol, 'symbol');
     if (typeof symbol !== 'string') return symbol;
 
@@ -599,7 +368,7 @@ export class ToolHandler {
   /**
    * Handle codegraph_impact
    */
-  private async handleImpact(args: Record<string, unknown>): Promise<ToolResult> {
+  async handleImpact(args: Record<string, unknown>): Promise<ToolResult> {
     const symbol = this.validateString(args.symbol, 'symbol');
     if (typeof symbol !== 'string') return symbol;
 
@@ -650,7 +419,7 @@ export class ToolHandler {
    * then read contiguous file sections covering all symbols per file.
    * This replaces multiple codegraph_node + Read calls.
    */
-  private async handleExplore(args: Record<string, unknown>): Promise<ToolResult> {
+  async handleExplore(args: Record<string, unknown>): Promise<ToolResult> {
     const query = this.validateString(args.query, 'query');
     if (typeof query !== 'string') return query;
 
@@ -936,7 +705,7 @@ export class ToolHandler {
   /**
    * Handle codegraph_node
    */
-  private async handleNode(args: Record<string, unknown>): Promise<ToolResult> {
+  async handleNode(args: Record<string, unknown>): Promise<ToolResult> {
     const symbol = this.validateString(args.symbol, 'symbol');
     if (typeof symbol !== 'string') return symbol;
 
@@ -962,7 +731,7 @@ export class ToolHandler {
   /**
    * Handle codegraph_status
    */
-  private async handleStatus(args: Record<string, unknown>): Promise<ToolResult> {
+  async handleStatus(args: Record<string, unknown>): Promise<ToolResult> {
     const cg = this.getCodeGraph(args.projectPath as string | undefined);
     const stats = cg.getStats();
 
@@ -996,7 +765,7 @@ export class ToolHandler {
   /**
    * Handle codegraph_files - get project file structure from the index
    */
-  private async handleFiles(args: Record<string, unknown>): Promise<ToolResult> {
+  async handleFiles(args: Record<string, unknown>): Promise<ToolResult> {
     const cg = this.getCodeGraph(args.projectPath as string | undefined);
     const pathFilter = args.path as string | undefined;
     const pattern = args.pattern as string | undefined;
@@ -1364,13 +1133,13 @@ export class ToolHandler {
     return context.summary || 'No context found';
   }
 
-  private textResult(text: string): ToolResult {
+  textResult(text: string): ToolResult {
     return {
       content: [{ type: 'text', text }],
     };
   }
 
-  private errorResult(message: string): ToolResult {
+  errorResult(message: string): ToolResult {
     return {
       content: [{ type: 'text', text: `Error: ${message}` }],
       isError: true,

--- a/src/mcp/tools/callees.ts
+++ b/src/mcp/tools/callees.ts
@@ -1,0 +1,27 @@
+import { projectPathProperty } from '../tool-types';
+import type { ToolModule } from './types';
+
+export const CALLEES_TOOL: ToolModule = {
+  definition: {
+    name: 'codegraph_callees',
+    description:
+      'Find all functions/methods that a specific symbol calls. Useful for understanding dependencies and code flow.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        symbol: {
+          type: 'string',
+          description: 'Name of the function, method, or class to find callees for',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of callees to return (default: 20)',
+          default: 20,
+        },
+        projectPath: projectPathProperty,
+      },
+      required: ['symbol'],
+    },
+  },
+  handlerKey: 'handleCallees',
+};

--- a/src/mcp/tools/callers.ts
+++ b/src/mcp/tools/callers.ts
@@ -1,0 +1,27 @@
+import { projectPathProperty } from '../tool-types';
+import type { ToolModule } from './types';
+
+export const CALLERS_TOOL: ToolModule = {
+  definition: {
+    name: 'codegraph_callers',
+    description:
+      'Find all functions/methods that call a specific symbol. Useful for understanding usage patterns and impact of changes.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        symbol: {
+          type: 'string',
+          description: 'Name of the function, method, or class to find callers for',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of callers to return (default: 20)',
+          default: 20,
+        },
+        projectPath: projectPathProperty,
+      },
+      required: ['symbol'],
+    },
+  },
+  handlerKey: 'handleCallers',
+};

--- a/src/mcp/tools/context.ts
+++ b/src/mcp/tools/context.ts
@@ -1,0 +1,32 @@
+import { projectPathProperty } from '../tool-types';
+import type { ToolModule } from './types';
+
+export const CONTEXT_TOOL: ToolModule = {
+  definition: {
+    name: 'codegraph_context',
+    description:
+      'PRIMARY TOOL: Build comprehensive context for a task. Returns entry points, related symbols, and key code - often enough to understand the codebase without additional tool calls. NOTE: This provides CODE context, not product requirements. For new features, still clarify UX/behavior questions with the user before implementing.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task: {
+          type: 'string',
+          description: 'Description of the task, bug, or feature to build context for',
+        },
+        maxNodes: {
+          type: 'number',
+          description: 'Maximum symbols to include (default: 20)',
+          default: 20,
+        },
+        includeCode: {
+          type: 'boolean',
+          description: 'Include code snippets for key symbols (default: true)',
+          default: true,
+        },
+        projectPath: projectPathProperty,
+      },
+      required: ['task'],
+    },
+  },
+  handlerKey: 'handleContext',
+};

--- a/src/mcp/tools/explore.ts
+++ b/src/mcp/tools/explore.ts
@@ -1,0 +1,28 @@
+import { projectPathProperty } from '../tool-types';
+import type { ToolModule } from './types';
+
+export const EXPLORE_TOOL: ToolModule = {
+  definition: {
+    name: 'codegraph_explore',
+    description:
+      'Deep exploration tool — returns comprehensive context for a topic in a SINGLE call. Groups all relevant source code by file (contiguous sections, not snippets), includes a relationship map, and uses deeper graph traversal. Designed to replace multiple codegraph_node + file Read calls. Use this instead of codegraph_context when you need thorough understanding. IMPORTANT: Use specific symbol names, file names, or short code terms in your query — NOT natural language sentences. Before calling this, use codegraph_search to discover relevant symbol names, then include those names in your query. Bad: "how are agent prompts loaded and passed to the CLI". Good: "readAgentsFromDirectory createClaudeSession chat-manager agents.ts".',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'Symbol names, file names, or short code terms to explore (e.g., "AuthService loginUser session-manager", "GraphTraverser BFS impact traversal.ts"). Use codegraph_search first to find relevant names.',
+        },
+        maxFiles: {
+          type: 'number',
+          description: 'Maximum number of files to include source code from (default: 12)',
+          default: 12,
+        },
+        projectPath: projectPathProperty,
+      },
+      required: ['query'],
+    },
+  },
+  handlerKey: 'handleExplore',
+};

--- a/src/mcp/tools/files.ts
+++ b/src/mcp/tools/files.ts
@@ -1,0 +1,40 @@
+import { projectPathProperty } from '../tool-types';
+import type { ToolModule } from './types';
+
+export const FILES_TOOL: ToolModule = {
+  definition: {
+    name: 'codegraph_files',
+    description:
+      'REQUIRED for file/folder exploration. Get the project file structure from the CodeGraph index. Returns a tree view of all indexed files with metadata (language, symbol count). Much faster than Glob/filesystem scanning. Use this FIRST when exploring project structure, finding files, or understanding codebase organization.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Filter to files under this directory path (e.g., "src/components"). Returns all files if not specified.',
+        },
+        pattern: {
+          type: 'string',
+          description: 'Filter files matching this glob pattern (e.g., "*.tsx", "**/*.test.ts")',
+        },
+        format: {
+          type: 'string',
+          description: 'Output format: "tree" (hierarchical, default), "flat" (simple list), "grouped" (by language)',
+          enum: ['tree', 'flat', 'grouped'],
+          default: 'tree',
+        },
+        includeMetadata: {
+          type: 'boolean',
+          description: 'Include file metadata like language and symbol count (default: true)',
+          default: true,
+        },
+        maxDepth: {
+          type: 'number',
+          description: 'Maximum directory depth to show (default: unlimited)',
+        },
+        projectPath: projectPathProperty,
+      },
+    },
+  },
+  handlerKey: 'handleFiles',
+};

--- a/src/mcp/tools/impact.ts
+++ b/src/mcp/tools/impact.ts
@@ -1,0 +1,27 @@
+import { projectPathProperty } from '../tool-types';
+import type { ToolModule } from './types';
+
+export const IMPACT_TOOL: ToolModule = {
+  definition: {
+    name: 'codegraph_impact',
+    description:
+      'Analyze the impact radius of changing a symbol. Shows what code could be affected by modifications.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        symbol: {
+          type: 'string',
+          description: 'Name of the symbol to analyze impact for',
+        },
+        depth: {
+          type: 'number',
+          description: 'How many levels of dependencies to traverse (default: 2)',
+          default: 2,
+        },
+        projectPath: projectPathProperty,
+      },
+      required: ['symbol'],
+    },
+  },
+  handlerKey: 'handleImpact',
+};

--- a/src/mcp/tools/node.ts
+++ b/src/mcp/tools/node.ts
@@ -1,0 +1,27 @@
+import { projectPathProperty } from '../tool-types';
+import type { ToolModule } from './types';
+
+export const NODE_TOOL: ToolModule = {
+  definition: {
+    name: 'codegraph_node',
+    description:
+      'Get detailed information about a specific code symbol. Use includeCode=true only when you need the full source code - otherwise just get location and signature to minimize context usage.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        symbol: {
+          type: 'string',
+          description: 'Name of the symbol to get details for',
+        },
+        includeCode: {
+          type: 'boolean',
+          description: 'Include full source code (default: false to minimize context)',
+          default: false,
+        },
+        projectPath: projectPathProperty,
+      },
+      required: ['symbol'],
+    },
+  },
+  handlerKey: 'handleNode',
+};

--- a/src/mcp/tools/registry.ts
+++ b/src/mcp/tools/registry.ts
@@ -1,0 +1,65 @@
+/**
+ * MCP tool registry.
+ *
+ * Adding a new MCP tool is:
+ *
+ *   1. Create `src/mcp/tools/<name>.ts` exporting an
+ *      `<NAME>_TOOL: ToolModule` constant (definition + handlerKey).
+ *   2. Add **one** import line and **one** array entry to this file.
+ *   3. Add a `handle<Name>` method on `ToolHandler` in `../tools.ts`,
+ *      and add the new key to `HandlerKey` in `./types.ts`.
+ *
+ * The third step is currently the only "shared method on a single
+ * class" surface that competing PRs can collide on. Extracting
+ * handler bodies into per-tool files (so step 3 also becomes a
+ * single-file addition) is left as a follow-up.
+ */
+
+import type { ToolDefinition } from '../tool-types';
+import type { ToolModule } from './types';
+
+import { CALLEES_TOOL } from './callees';
+import { CALLERS_TOOL } from './callers';
+import { CONTEXT_TOOL } from './context';
+import { EXPLORE_TOOL } from './explore';
+import { FILES_TOOL } from './files';
+import { IMPACT_TOOL } from './impact';
+import { NODE_TOOL } from './node';
+import { SEARCH_TOOL } from './search';
+import { STATUS_TOOL } from './status';
+
+const ALL_TOOLS: readonly ToolModule[] = [
+  CALLEES_TOOL,
+  CALLERS_TOOL,
+  CONTEXT_TOOL,
+  EXPLORE_TOOL,
+  FILES_TOOL,
+  IMPACT_TOOL,
+  NODE_TOOL,
+  SEARCH_TOOL,
+  STATUS_TOOL,
+];
+
+let byName: Map<string, ToolModule> | null = null;
+function ensureIndex(): Map<string, ToolModule> {
+  if (byName) return byName;
+  byName = new Map();
+  for (const t of ALL_TOOLS) byName.set(t.definition.name, t);
+  return byName;
+}
+
+export function getToolModules(): readonly ToolModule[] {
+  return ALL_TOOLS;
+}
+
+export function getToolModule(name: string): ToolModule | undefined {
+  return ensureIndex().get(name);
+}
+
+/**
+ * The `tools[]` array advertised in MCP `list_tools`. Derived from
+ * the registry; sorted alphabetically by tool name for stable output.
+ */
+export const tools: readonly ToolDefinition[] = ALL_TOOLS
+  .map((t) => t.definition)
+  .sort((a, b) => a.name.localeCompare(b.name));

--- a/src/mcp/tools/search.ts
+++ b/src/mcp/tools/search.ts
@@ -1,0 +1,32 @@
+import { projectPathProperty } from '../tool-types';
+import type { ToolModule } from './types';
+
+export const SEARCH_TOOL: ToolModule = {
+  definition: {
+    name: 'codegraph_search',
+    description:
+      'Quick symbol search by name. Returns locations only (no code). Use codegraph_context instead for comprehensive task context.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Symbol name or partial name (e.g., "auth", "signIn", "UserService")',
+        },
+        kind: {
+          type: 'string',
+          description: 'Filter by node kind',
+          enum: ['function', 'method', 'class', 'interface', 'type', 'variable', 'route', 'component'],
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum results (default: 10)',
+          default: 10,
+        },
+        projectPath: projectPathProperty,
+      },
+      required: ['query'],
+    },
+  },
+  handlerKey: 'handleSearch',
+};

--- a/src/mcp/tools/status.ts
+++ b/src/mcp/tools/status.ts
@@ -1,0 +1,17 @@
+import { projectPathProperty } from '../tool-types';
+import type { ToolModule } from './types';
+
+export const STATUS_TOOL: ToolModule = {
+  definition: {
+    name: 'codegraph_status',
+    description:
+      'Get the status of the CodeGraph index, including statistics about indexed files, nodes, and edges.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: projectPathProperty,
+      },
+    },
+  },
+  handlerKey: 'handleStatus',
+};

--- a/src/mcp/tools/status.ts
+++ b/src/mcp/tools/status.ts
@@ -5,7 +5,7 @@ export const STATUS_TOOL: ToolModule = {
   definition: {
     name: 'codegraph_status',
     description:
-      'Get the status of the CodeGraph index, including statistics about indexed files, nodes, and edges.',
+      "Get the status of the CodeGraph index: project root + how it was selected (default vs `projectPath`), file/node/edge counts, languages, plus any other projects the MCP server has open. Call this FIRST in a session when you don't know which project the MCP server's default points at — its `Project root` field tells you whether to start passing `projectPath` on subsequent calls.",
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/mcp/tools/types.ts
+++ b/src/mcp/tools/types.ts
@@ -1,0 +1,50 @@
+/**
+ * MCP tool registry types.
+ *
+ * Each tool ships its own self-contained `ToolModule` (definition
+ * + handler-key reference) so adding an MCP tool is a single-file
+ * addition for the metadata and dispatch entry. The actual handler
+ * bodies still live as methods on the `ToolHandler` class in
+ * `../tools.ts` (the helpers they call are tightly coupled and a
+ * full body extraction is left as a follow-up); each tool's
+ * `handlerKey` is the string name of the method to invoke.
+ *
+ * The registry (`./registry`) imports each module and exposes
+ * `tools[]` (for `list_tools`) plus a `getModule(name)` lookup
+ * used by `ToolHandler.execute`.
+ */
+
+import type { ToolDefinition, ToolResult } from '../tool-types';
+
+/**
+ * Names of methods on `ToolHandler` that can serve as tool handlers.
+ * Kept as a string union (not a `keyof ToolHandler` lookup) to
+ * avoid a circular import — the type list is the source of truth
+ * and is checked structurally at the call site in `execute()`.
+ */
+export type HandlerKey =
+  | 'handleSearch'
+  | 'handleContext'
+  | 'handleCallers'
+  | 'handleCallees'
+  | 'handleImpact'
+  | 'handleExplore'
+  | 'handleNode'
+  | 'handleStatus'
+  | 'handleFiles';
+
+/**
+ * The minimum surface a `ToolHandler`-shaped object exposes for
+ * dispatch. Extending `HandlerKey` adds a new entry here too.
+ */
+export type ToolHandlerLike = {
+  [K in HandlerKey]: (args: Record<string, unknown>) => Promise<ToolResult>;
+} & {
+  errorResult(message: string): ToolResult;
+};
+
+export interface ToolModule {
+  readonly definition: ToolDefinition;
+  /** Method name on `ToolHandler` that runs this tool. */
+  readonly handlerKey: HandlerKey;
+}


### PR DESCRIPTION
> **🔗 Stacked on #117 (MCP tool registry).** Until that lands, this PR's diff transitively includes the refactor commit. The intrinsic addition for *this* PR is just the changes in `src/mcp/tools.ts` (handler + error surface), `src/mcp/tools/status.ts` (description), and the new tests — see "Files changed" below. After #117 lands, the diff auto-cleans.

## Summary

Closes a real ergonomics gap I hit running the MCP server in an agentic flow: when the server's default project doesn't match the codebase the agent wants to query, **every tool call has to pass `projectPath`**, but the agent has no way of knowing whether to do that — no tool surfaces the default. The agent guesses, gets back `CodeGraph not initialized`, guesses again. The error even pointed at the wrong remediation (`codegraph init` instead of `pass projectPath`).

## What changes

**`codegraph_status` now leads with the project identity:**

```
## CodeGraph Status

**Project root:** `/Users/foo/projects/codegraph` (default — server CWD at startup)
**Files indexed:** 153
...

### Other projects this server has open
- `/Users/foo/projects/some-other-repo`

Pass `projectPath` to query any of these (or any other directory containing `.codegraph/`).
```

The label is `(default — server CWD at startup)` or `(from \`projectPath\` argument)`. One look at `status` answers "do I need to start passing projectPath?" — which previously required an unrelated tool call to fail first.

**Errors are rewritten with concrete next steps:**

| Situation | Old | New |
|---|---|---|
| No default, no `projectPath` | `CodeGraph not initialized for this project. Run 'codegraph init' first.` | Three-way: restart server / `codegraph init` / pass `projectPath` |
| `projectPath` supplied, no `.codegraph/` found | `CodeGraph not initialized in {path}. Run 'codegraph init' in that project first.` | `No .codegraph/ found at or above {path}. Run \`codegraph init\` in that project first, or pass a different projectPath.` |

**`STATUS_TOOL` description nudges agents to call status FIRST** in unfamiliar sessions, so the project-identity check is the natural opening move.

## Independent reviewer pass

Caught and fixed three issues before opening:

1. The third `'(resolved from cache)'` sourceLabel branch was **unreachable** — `getCodeGraph(undefined)` always returns `this.cg` or throws, so when `args.projectPath` is undefined the project IS the default. Collapsed to a binary ternary with a comment explaining why.
2. The new test file **leaked SQLite handles** — `handler.closeAll()` was never called, leaving cached project connections open across tests. Fixed via `afterEach` cleanup + idempotent double-close handling.
3. **macOS/Windows case-insensitive-FS edge case** — `path.resolve` doesn't normalise case, so a client-supplied `rootUri` with different capitalisation than `process.cwd()` could compare unequal under strict-string equality. Documented as a comment; deferred a `realpath`-based fix until someone actually hits it.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — **799/799 tests pass**
- [x] New tests in `__tests__/mcp-status.test.ts` (5 cases):
  - Default-project label
  - `projectPath`-argument label
  - "Other projects this server has open" list when cache has multiple entries
  - Actionable error when no default and no `projectPath`
  - Actionable error pointing at the supplied path when `.codegraph/` is missing there
- [x] Updated `__tests__/mcp-tool-registry.test.ts` regex for the new error wording
- [x] Live smoke test against codegraph's own indexed tree — all four user-facing strings render correctly

## Files changed

| File | Change |
|---|---|
| `src/mcp/tools.ts` | `handleStatus` rewrite + `getCodeGraph` error rewrite |
| `src/mcp/tools/status.ts` | Tool description nudges agents to call status FIRST |
| `__tests__/mcp-status.test.ts` | New: 5 focused tests |
| `__tests__/mcp-tool-registry.test.ts` | Updated regex for new error wording |

## Pairs naturally with #121

The MCP-instructions playbook from #121 tells the agent *which* tool to call for each intent. This PR makes sure the answer to *"is the project root what I expect?"* is always one tool call away and self-explanatory — exactly the kind of "tier-1 first" check the playbook recommends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
