### PR TITLE
fix(gitignore): anchor "coverage/" to repo root (unblocks src/coverage/, packages/*/coverage/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ dist/
 Thumbs.db
 
 # Test coverage
-coverage/
+/coverage/
 .nyc_output/
 
 # Environment


### PR DESCRIPTION
## Summary

The `coverage/` rule on line 21 of `.gitignore` is unanchored — it matches any `coverage/` directory in the tree, not just the test-output one at the repo root. This is a real footgun: when adding a `src/coverage/` module (or `packages/*/coverage/` in a monorepo), `git add` silently drops the files with no warning.

This bit me on PR #124 — the `src/coverage/` module was written and tested locally, but never made it into the commit because `git add src/coverage/` was silently swallowed. The PR shipped with `__tests__/coverage.test.ts` importing a module that didn't exist; whoever rebases or merges it hits a build failure that's confusing to debug.

The fix anchors the rule to the repo root: `/coverage/`. This still ignores the test-output `coverage/` at root (the original intent) while allowing source paths like `src/coverage/` to be committed normally.

## Test plan

- [x] `git check-ignore -v src/coverage/foo.ts` → no longer matches
- [x] `git check-ignore -v coverage/lcov.info` → still matches the root-level rule
- [x] No code changes; behavior is purely the gitignore semantics

Independent of the issue #120 merge guide — this can land any time and helps every future PR that touches anything named `coverage/` outside the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
