### PR TITLE
fix(cli): surface lock-acquisition errors and silence Emscripten Aborted() spam

### DIFF
--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -265,6 +265,19 @@ type IndexResult = {
 function printIndexResult(clack: typeof import('@clack/prompts'), result: IndexResult, projectPath?: string): void {
   const hasErrors = result.filesErrored > 0;
 
+  // Surface non-file-level failures (e.g. lock-acquisition failure
+  // when another indexer is running) before the file-count branches.
+  // Without this the CLI falls through to "No files found to index",
+  // which is actively misleading — the index DID run, it just couldn't
+  // get the lock.
+  if (!result.success && !hasErrors && result.filesIndexed === 0) {
+    const generic = result.errors.find((e) => e.severity === 'error');
+    if (generic) {
+      clack.log.error(generic.message);
+      return;
+    }
+  }
+
   if (result.filesIndexed > 0) {
     if (hasErrors) {
       clack.log.success(`Indexed ${formatNumber(result.filesIndexed)} files (${formatNumber(result.filesErrored)} could not be parsed)`);

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -270,12 +270,16 @@ function printIndexResult(clack: typeof import('@clack/prompts'), result: IndexR
   // Without this the CLI falls through to "No files found to index",
   // which is actively misleading — the index DID run, it just couldn't
   // get the lock.
+  //
+  // If success is false but no severity:'error' entry exists in
+  // `result.errors` (degenerate case — shouldn't happen in practice
+  // but worth guarding because the result shape is plumbed through
+  // multiple call sites), fall back to a generic message rather than
+  // continuing to the misleading "No files found" branch or throwing.
   if (!result.success && !hasErrors && result.filesIndexed === 0) {
     const generic = result.errors.find((e) => e.severity === 'error');
-    if (generic) {
-      clack.log.error(generic.message);
-      return;
-    }
+    clack.log.error(generic?.message ?? 'Indexing failed — no further details available');
+    return;
   }
 
   if (result.filesIndexed > 0) {

--- a/src/extraction/parse-worker.ts
+++ b/src/extraction/parse-worker.ts
@@ -17,6 +17,17 @@ import type { Language, ExtractionResult } from '../types';
 // already handles the failure cleanly. Filter these specific lines
 // out at the source. Real diagnostic output (anything we log
 // ourselves) goes through console.* / parentPort and is unaffected.
+//
+// Caveats deliberately accepted:
+//   - Per-call match: each `write()` call is matched in isolation.
+//     If Emscripten ever splits `Aborted(` across two write()s (it
+//     doesn't today — synchronous abort prints the whole line at
+//     once via libc puts) the first fragment would leak. Buffering
+//     across calls would add complexity for a hypothetical case.
+//   - Substring exactness: the prefix `Aborted(` is the literal
+//     Emscripten signature. Any user code that legitimately writes
+//     a stderr line starting with that prefix would also be filtered;
+//     in practice no real diagnostic does.
 {
   const realWrite = process.stderr.write.bind(process.stderr);
   process.stderr.write = ((
@@ -29,6 +40,10 @@ import type { Language, ExtractionResult } from '../types';
       s.startsWith('Aborted(') ||
       s.includes('Build with -sASSERTIONS for more info')
     ) {
+      // Honour the Writable stream contract: callbacks must always
+      // fire even when the write is suppressed, or upstream code
+      // waiting on the drain signal would hang. Both overload forms
+      // are handled (`(chunk, cb)` and `(chunk, encoding, cb)`).
       if (typeof encoding === 'function') encoding();
       else if (cb) cb();
       return true;

--- a/src/extraction/parse-worker.ts
+++ b/src/extraction/parse-worker.ts
@@ -10,6 +10,33 @@ import { extractFromSource } from './tree-sitter';
 import { detectLanguage, loadGrammarsForLanguages, resetParser } from './grammars';
 import type { Language, ExtractionResult } from '../types';
 
+// Emscripten prints `Aborted()` (and a follow-up RuntimeError diag
+// line) directly to stderr when WASM aborts — before the JS catch
+// runs. Worker stderr is inherited by the parent, so each crash leaks
+// a noise line to the user's terminal even though the JS layer
+// already handles the failure cleanly. Filter these specific lines
+// out at the source. Real diagnostic output (anything we log
+// ourselves) goes through console.* / parentPort and is unaffected.
+{
+  const realWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((
+    chunk: string | Uint8Array,
+    encoding?: BufferEncoding | ((err?: Error | null) => void),
+    cb?: (err?: Error | null) => void
+  ): boolean => {
+    const s = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8');
+    if (
+      s.startsWith('Aborted(') ||
+      s.includes('Build with -sASSERTIONS for more info')
+    ) {
+      if (typeof encoding === 'function') encoding();
+      else if (cb) cb();
+      return true;
+    }
+    return realWrite(chunk as never, encoding as never, cb as never);
+  }) as typeof process.stderr.write;
+}
+
 const PARSER_RESET_INTERVAL = 5000;
 const parseCounts = new Map<Language, number>();
 


### PR DESCRIPTION
## Summary

Two small, unrelated CLI cosmetic bugs that show up when the indexer is under load. Both are actively misleading rather than just noisy.

### 1. Lock-acquisition error hidden behind "No files found to index"

`printIndexResult` falls through to `'No files found to index'` whenever `filesIndexed === 0 && filesErrored === 0`. The lock-acquisition path in `indexAll`/`sync` returns `{ success: false, errors: [{ message: 'Could not acquire file lock ...', severity: 'error' }] }`, but `filesErrored` counts only file-level parse failures — so the lock-failure message never gets shown. The user sees "No files found to index" while another indexer is actively running.

Added a check at the top of `printIndexResult` that surfaces the first generic error when `result.success === false`.

### 2. Emscripten Aborted() spam leaking to the parent terminal

When tree-sitter WASM crashes on a pathological file (large generated C/C++ headers, etc.), the parse worker correctly catches the `RuntimeError: memory access out of bounds` and exits with code 1 — but Emscripten itself prints `Aborted()` (and a follow-up `Build with -sASSERTIONS for more info` line) directly to stderr *before* the JS handler runs. Those lines leak to the parent's terminal even though the JS layer recovers cleanly. Re-indexing a repo with WASM-prone files produces dozens of `Aborted()` lines.

Installed a startup-time `process.stderr.write` filter in `parse-worker.ts` that drops only those two specific Emscripten internal lines. Everything we log ourselves (via `console.*` / `parentPort.postMessage`) passes through unchanged.

## Test plan

Verified live against ollama/ollama@v0.22.0 (1.2 GB repo, 1,179 indexed files including vendored llama.cpp / MLX-C):

- [x] `codegraph index` while another indexer is running now shows `Could not acquire file lock - another process may be indexing` (was: "No files found to index")
- [x] Re-index of a repo that had previously triggered WASM-abort lines: 0 `Aborted()` lines (was: 68+)
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
