### PR TITLE
feat(search): signature search + callers-of / callees-of graph qualifiers

### DIFF
--- a/__tests__/search-qualifiers.test.ts
+++ b/__tests__/search-qualifiers.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Integration tests for search qualifiers that go through the SQL
+ * layer: sig:, callers-of:, callees-of:.
+ *
+ * Mirrors the synthetic-fixture style of resolution.test.ts — small
+ * temp project, real CodeGraph index, query the result. These cover
+ * the SQL paths (signatureLike pre-filter, nodesCallingAny / nodesCalledByAny)
+ * that the parser-only tests can't exercise.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { CodeGraph } from '../src';
+
+describe('Search qualifiers — DB-level integration', () => {
+  let tempDir: string;
+  let cg: CodeGraph | null = null;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-qualifiers-'));
+  });
+
+  afterEach(() => {
+    if (cg) {
+      cg.destroy();
+      cg = null;
+    } else if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true });
+    }
+  });
+
+  async function indexFixture(files: Record<string, string>): Promise<CodeGraph> {
+    fs.mkdirSync(path.join(tempDir, 'src'), { recursive: true });
+    for (const [name, content] of Object.entries(files)) {
+      fs.writeFileSync(path.join(tempDir, 'src', name), content);
+    }
+    fs.writeFileSync(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({ name: 't', version: '0.0.0' })
+    );
+    const inst = await CodeGraph.init(tempDir, { config: { llm: { endpoint: '' } }, index: true });
+    cg = inst;
+    return inst;
+  }
+
+  it('sig: filters results by signature substring', async () => {
+    const cg = await indexFixture({
+      'a.ts': `
+export async function fetchUser(): Promise<User> { return {} as User; }
+export function getCount(): number { return 0; }
+type User = { id: string };
+`,
+    });
+    const results = cg.searchNodes('sig:Promise<User>');
+    const names = results.map((r) => r.node.name);
+    expect(names).toContain('fetchUser');
+    expect(names).not.toContain('getCount');
+  });
+
+  it('multi-sig: composes as OR (matches path:/name: semantics)', async () => {
+    const cg = await indexFixture({
+      'a.ts': `
+export function fa(): Promise<string> { return Promise.resolve('a'); }
+export function fb(): number[] { return []; }
+export function fc(): string { return ''; }
+`,
+    });
+    const r = cg.searchNodes('sig:Promise sig:number[] kind:function');
+    const names = r.map((x) => x.node.name);
+    expect(names).toContain('fa');   // matches sig:Promise
+    expect(names).toContain('fb');   // matches sig:number[]
+    expect(names).not.toContain('fc');
+  });
+
+  it('callers-of: returns nodes that call NAME', async () => {
+    const cg = await indexFixture({
+      'a.ts': `
+export function target() { return 1; }
+export function helper() { return target(); }
+export function other() { return 2; }
+`,
+    });
+    const r = cg.searchNodes('callers-of:target');
+    const names = r.map((x) => x.node.name);
+    expect(names).toContain('helper');
+    expect(names).not.toContain('other');
+  });
+
+  it('callees-of: returns nodes called BY NAME', async () => {
+    const cg = await indexFixture({
+      'a.ts': `
+export function leaf1() { return 1; }
+export function leaf2() { return 2; }
+export function unrelated() { return 99; }
+export function root() { return leaf1() + leaf2(); }
+`,
+    });
+    const r = cg.searchNodes('callees-of:root');
+    const names = r.map((x) => x.node.name);
+    expect(names).toContain('leaf1');
+    expect(names).toContain('leaf2');
+    expect(names).not.toContain('unrelated');
+  });
+
+  it('callers-of: composes with kind: filter', async () => {
+    const cg = await indexFixture({
+      'a.ts': `
+export function target() { return 1; }
+export class Caller { method() { return target(); } }
+export function helper() { return target(); }
+`,
+    });
+    const r = cg.searchNodes('callers-of:target kind:method');
+    const names = r.map((x) => x.node.name);
+    expect(names).toContain('method');
+    expect(names).not.toContain('helper');
+  });
+});

--- a/__tests__/search-query-parser.test.ts
+++ b/__tests__/search-query-parser.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the field-qualified query parser and bounded
+ * edit distance — the two algorithms behind `kind:`/`lang:`/`path:`/
+ * `name:` filtering and the fuzzy typo fallback.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseQuery, boundedEditDistance } from '../src/search/query-parser';
+
+describe('parseQuery', () => {
+  it('returns plain text for a query with no field prefixes', () => {
+    const r = parseQuery('authenticate user');
+    expect(r.text).toBe('authenticate user');
+    expect(r.kinds).toEqual([]);
+    expect(r.languages).toEqual([]);
+    expect(r.pathFilters).toEqual([]);
+    expect(r.nameFilters).toEqual([]);
+  });
+
+  it('extracts kind: filter and removes it from text', () => {
+    const r = parseQuery('kind:function auth');
+    expect(r.kinds).toEqual(['function']);
+    expect(r.text).toBe('auth');
+  });
+
+  it('extracts lang: and language: as the same filter family', () => {
+    const a = parseQuery('lang:typescript foo');
+    const b = parseQuery('language:typescript foo');
+    expect(a.languages).toEqual(['typescript']);
+    expect(b.languages).toEqual(['typescript']);
+  });
+
+  it('handles multiple kind: filters as an OR set', () => {
+    const r = parseQuery('kind:function kind:method auth');
+    expect(r.kinds.sort()).toEqual(['function', 'method']);
+  });
+
+  it('extracts path: and name: as substring filters (kept verbatim)', () => {
+    const r = parseQuery('path:src/api name:Handler');
+    expect(r.pathFilters).toEqual(['src/api']);
+    expect(r.nameFilters).toEqual(['Handler']);
+  });
+
+  it('preserves quoted spans as a single token (whitespace in path:)', () => {
+    const r = parseQuery('path:"my dir/file" foo');
+    expect(r.pathFilters).toEqual(['my dir/file']);
+    expect(r.text).toBe('foo');
+  });
+
+  it('passes URL-like tokens through to text (does not match http: as a field)', () => {
+    const r = parseQuery('http://example.com');
+    expect(r.text).toBe('http://example.com');
+    expect(r.kinds).toEqual([]);
+  });
+
+  it('passes empty-value tokens through as text (kind: → "kind:")', () => {
+    const r = parseQuery('kind: foo');
+    expect(r.kinds).toEqual([]);
+    // The trailing-colon token comes back as plain text
+    expect(r.text.includes('kind:')).toBe(true);
+  });
+
+  it('passes unknown field prefixes through as text (TODO: keeps the colon)', () => {
+    const r = parseQuery('TODO: needs review');
+    expect(r.text).toBe('TODO: needs review');
+    expect(r.kinds).toEqual([]);
+  });
+
+  it('rejects unknown values for kind: (passes the whole token to text)', () => {
+    const r = parseQuery('kind:invalid foo');
+    // Invalid kind value falls back to text
+    expect(r.kinds).toEqual([]);
+    expect(r.text).toContain('kind:invalid');
+  });
+
+  it('handles all-filters-no-text query', () => {
+    const r = parseQuery('kind:function lang:typescript');
+    expect(r.kinds).toEqual(['function']);
+    expect(r.languages).toEqual(['typescript']);
+    expect(r.text).toBe('');
+  });
+
+  it('survives empty input', () => {
+    const r = parseQuery('');
+    expect(r.text).toBe('');
+    expect(r.kinds).toEqual([]);
+  });
+
+  it('survives a very long input (no allocation explosion)', () => {
+    const huge = 'foo '.repeat(5000); // 20k chars
+    const r = parseQuery(huge);
+    expect(r.text.length).toBeGreaterThan(0);
+  });
+
+  it('extracts sig: filter (and signature: alias)', () => {
+    const a = parseQuery('sig:Promise<User>');
+    const b = parseQuery('signature:Promise<User>');
+    expect(a.signatureFilters).toEqual(['Promise<User>']);
+    expect(b.signatureFilters).toEqual(['Promise<User>']);
+    expect(a.text).toBe('');
+  });
+
+  it('extracts callers-of: and callees-of: graph qualifiers', () => {
+    const r = parseQuery('callers-of:authenticate name:Handler');
+    expect(r.callersOf).toEqual(['authenticate']);
+    expect(r.nameFilters).toEqual(['Handler']);
+    expect(r.text).toBe('');
+
+    const r2 = parseQuery('callees-of:bootstrap');
+    expect(r2.calleesOf).toEqual(['bootstrap']);
+  });
+});
+
+describe('boundedEditDistance', () => {
+  it('returns 0 for identical strings', () => {
+    expect(boundedEditDistance('user', 'user', 2)).toBe(0);
+  });
+
+  it('returns 1 for a single substitution', () => {
+    expect(boundedEditDistance('user', 'usar', 2)).toBe(1);
+  });
+
+  it('returns 1 for a single insertion', () => {
+    expect(boundedEditDistance('user', 'users', 2)).toBe(1);
+  });
+
+  it('returns 1 for a single deletion', () => {
+    expect(boundedEditDistance('users', 'user', 2)).toBe(1);
+  });
+
+  it('returns 2 for a transposition (two edits in basic Levenshtein)', () => {
+    // 'aple' vs 'palp' would be 2; pick a clearer pair.
+    // 'foo' vs 'fou': substitution + insertion = 2 if different lengths.
+    expect(boundedEditDistance('confg', 'configX', 2)).toBe(2);
+  });
+
+  it('returns maxDist+1 when distance clearly exceeds budget', () => {
+    expect(boundedEditDistance('foo', 'completely-different', 2)).toBe(3);
+  });
+
+  it('respects length-difference shortcut', () => {
+    // |len(a) - len(b)| > maxDist must immediately be over budget
+    expect(boundedEditDistance('a', 'aaaaaaa', 2)).toBe(3);
+  });
+
+  it('handles empty inputs', () => {
+    expect(boundedEditDistance('', '', 2)).toBe(0);
+    expect(boundedEditDistance('a', '', 2)).toBe(1);
+    expect(boundedEditDistance('', 'abc', 2)).toBe(3);
+  });
+
+  it('is case-sensitive — caller must lowercase if case-insensitive match wanted', () => {
+    expect(boundedEditDistance('Foo', 'foo', 2)).toBe(1);
+  });
+
+  it('early-exits when row min exceeds budget (correctness, not just perf)', () => {
+    // 'aaaaa' vs 'bbbbb': distance is 5, well over budget 2
+    expect(boundedEditDistance('aaaaa', 'bbbbb', 2)).toBe(3);
+  });
+});

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -19,6 +19,7 @@ import {
 } from '../types';
 import { safeJsonParse } from '../utils';
 import { kindBonus, nameMatchBonus, scorePathRelevance } from '../search/query-utils';
+import { parseQuery, boundedEditDistance } from '../search/query-parser';
 
 /**
  * Database row types (snake_case from SQLite)
@@ -478,14 +479,78 @@ export class QueryBuilder {
    * 3. Score results based on match quality
    */
   searchNodes(query: string, options: SearchOptions = {}): SearchResult[] {
-    const { kinds, languages, limit = 100, offset = 0 } = options;
+    const { limit = 100, offset = 0 } = options;
 
-    // First try FTS5 with prefix matching
-    let results = this.searchNodesFTS(query, { kinds, languages, limit, offset });
+    // Parse field-qualified bits out of the raw query (kind:, lang:,
+    // path:, name:). Anything not recognised stays in `text` and goes
+    // to FTS unchanged. Filters compose with the SearchOptions arg —
+    // both are applied (intersection-style).
+    const parsed = parseQuery(query);
+    const mergedKinds =
+      parsed.kinds.length > 0
+        ? Array.from(new Set([...(options.kinds ?? []), ...parsed.kinds]))
+        : options.kinds;
+    const mergedLanguages =
+      parsed.languages.length > 0
+        ? Array.from(new Set([...(options.languages ?? []), ...parsed.languages]))
+        : options.languages;
+    const pathFilters = parsed.pathFilters;
+    const nameFilters = parsed.nameFilters;
+    const signatureFilters = parsed.signatureFilters;
+    const callersOf = parsed.callersOf;
+    const calleesOf = parsed.calleesOf;
+    // The text portion drives FTS/LIKE; if all the user typed was
+    // filters (`kind:function`), we still need *some* candidate set,
+    // so synthesise an empty-text path that returns everything matching
+    // the filters.
+    const text = parsed.text;
+    const kinds = mergedKinds;
+    const languages = mergedLanguages;
+
+    // First try FTS5 with prefix matching. For filter-only queries
+    // with a graph qualifier (callers-of / callees-of), seed the
+    // candidate set FROM the graph rather than scanning a slice of
+    // arbitrary nodes — a tiny callers set is much more likely to
+    // produce useful results than the first N name-ordered nodes.
+    let results: SearchResult[];
+    if (text) {
+      results = this.searchNodesFTS(text, { kinds, languages, limit, offset });
+    } else if (callersOf.length > 0 || calleesOf.length > 0) {
+      const seedIds = new Set<string>();
+      if (callersOf.length > 0) {
+        for (const id of this.nodesCallingAny(callersOf)) seedIds.add(id);
+      }
+      if (calleesOf.length > 0) {
+        for (const id of this.nodesCalledByAny(calleesOf)) seedIds.add(id);
+      }
+      results = this.nodesByIds([...seedIds]).map((node) => ({ node, score: 1 }));
+    } else {
+      // Over-fetch by 5× when running filter-only (no text). The
+      // post-scoring path: + name: filters can be very selective, so
+      // a smaller multiplier risks returning fewer than `limit`
+      // results despite the DB having plenty of matches.
+      // Push the FIRST sig: filter into SQL so signature-driven
+      // queries don't waste a candidate slot on every node that
+      // happens to have a small name.
+      results = this.searchAllByFilters({
+        kinds,
+        languages,
+        limit: limit * 5,
+        signatureLike: signatureFilters[0],
+      });
+    }
 
     // If no FTS results, try LIKE-based substring search
-    if (results.length === 0 && query.length >= 2) {
-      results = this.searchNodesLike(query, { kinds, languages, limit, offset });
+    if (results.length === 0 && text.length >= 2) {
+      results = this.searchNodesLike(text, { kinds, languages, limit, offset });
+    }
+
+    // Final fuzzy fallback: scan all known names and keep those within
+    // a tight Levenshtein distance. Only fires when both FTS and LIKE
+    // returned nothing AND there's a text portion long enough to be
+    // worth fuzzing (1-char queries would match too much).
+    if (results.length === 0 && text.length >= 3) {
+      results = this.searchNodesFuzzy(text, { kinds, languages, limit });
     }
 
     // Supplement: ensure exact name matches are always candidates.
@@ -521,13 +586,14 @@ export class QueryBuilder {
     }
 
     // Apply multi-signal scoring
-    if (results.length > 0 && query) {
+    if (results.length > 0 && (text || query)) {
+      const scoringQuery = text || query;
       results = results.map(r => ({
         ...r,
         score: r.score
           + kindBonus(r.node.kind)
-          + scorePathRelevance(r.node.filePath, query)
-          + nameMatchBonus(r.node.name, query),
+          + scorePathRelevance(r.node.filePath, scoringQuery)
+          + nameMatchBonus(r.node.name, scoringQuery),
       }));
       results.sort((a, b) => b.score - a.score);
       // Trim to requested limit after rescoring
@@ -536,6 +602,198 @@ export class QueryBuilder {
       }
     }
 
+    // Apply path: + name: filters AFTER scoring. Scoring already uses
+    // path/name as a soft signal; the explicit filters here are a hard
+    // gate. Done last so the FTS limit fetched plenty of candidates to
+    // narrow from.
+    if (pathFilters.length > 0) {
+      const lowered = pathFilters.map((p) => p.toLowerCase());
+      results = results.filter((r) => {
+        const fp = r.node.filePath.toLowerCase();
+        return lowered.some((p) => fp.includes(p));
+      });
+    }
+    if (nameFilters.length > 0) {
+      const lowered = nameFilters.map((n) => n.toLowerCase());
+      results = results.filter((r) => {
+        const nm = r.node.name.toLowerCase();
+        return lowered.some((n) => nm.includes(n));
+      });
+    }
+    if (signatureFilters.length > 0) {
+      const lowered = signatureFilters.map((s) => s.toLowerCase());
+      results = results.filter((r) => {
+        const sig = (r.node.signature ?? '').toLowerCase();
+        return lowered.some((s) => sig.includes(s));
+      });
+    }
+
+    // Graph-aware filters: callers-of / callees-of restrict the
+    // candidate set to nodes connected to NAME via a `calls` edge.
+    // Done with a single SQL pass per filter against the edges table
+    // (cheap on indexed columns) and then intersected with the
+    // current `results`.
+    if (callersOf.length > 0) {
+      const allowed = this.nodesCallingAny(callersOf);
+      results = results.filter((r) => allowed.has(r.node.id));
+    }
+    if (calleesOf.length > 0) {
+      const allowed = this.nodesCalledByAny(calleesOf);
+      results = results.filter((r) => allowed.has(r.node.id));
+    }
+
+    return results;
+  }
+
+  /**
+   * Match-everything path used when the user supplied only field
+   * filters (`kind:function lang:typescript`) with no text. Returns
+   * candidates ordered by name; the caller's filter pass narrows to
+   * what was asked for.
+   */
+  /**
+   * Bulk-fetch nodes by id. Used by graph-qualifier search paths
+   * (callers-of / callees-of) to materialise the seed set without
+   * issuing one SELECT per id.
+   */
+  private nodesByIds(ids: string[]): Node[] {
+    if (ids.length === 0) return [];
+    const placeholders = ids.map(() => '?').join(',');
+    const rows = this.db
+      .prepare(`SELECT * FROM nodes WHERE id IN (${placeholders})`)
+      .all(...ids) as NodeRow[];
+    return rows.map(rowToNode);
+  }
+
+  /**
+   * Set of node IDs that have at least one outgoing `calls` edge to
+   * a node whose `name` matches any element of `names`. Backs the
+   * `callers-of:NAME` query qualifier.
+   */
+  private nodesCallingAny(names: string[]): Set<string> {
+    if (names.length === 0) return new Set();
+    const placeholders = names.map(() => '?').join(',');
+    const sql = `
+      SELECT DISTINCT e.source AS id
+      FROM edges e
+      JOIN nodes tgt ON e.target = tgt.id
+      WHERE e.kind = 'calls' AND tgt.name IN (${placeholders})
+    `;
+    const rows = this.db.prepare(sql).all(...names) as Array<{ id: string }>;
+    return new Set(rows.map((r) => r.id));
+  }
+
+  /**
+   * Set of node IDs that are called BY a node whose `name` matches
+   * any element of `names`. Backs the `callees-of:NAME` query
+   * qualifier.
+   */
+  private nodesCalledByAny(names: string[]): Set<string> {
+    if (names.length === 0) return new Set();
+    const placeholders = names.map(() => '?').join(',');
+    const sql = `
+      SELECT DISTINCT e.target AS id
+      FROM edges e
+      JOIN nodes src ON e.source = src.id
+      WHERE e.kind = 'calls' AND src.name IN (${placeholders})
+    `;
+    const rows = this.db.prepare(sql).all(...names) as Array<{ id: string }>;
+    return new Set(rows.map((r) => r.id));
+  }
+
+  private searchAllByFilters(options: {
+    kinds?: NodeKind[];
+    languages?: Language[];
+    limit: number;
+    /** SQL LIKE %…% match against the signature column. Used by the
+     *  filter-only `sig:` query path so we don't have to over-fetch
+     *  arbitrary nodes and post-filter in JS (which often returned
+     *  zero results because the first 50 nodes by name rarely
+     *  contained the signature substring). */
+    signatureLike?: string;
+  }): SearchResult[] {
+    const { kinds, languages, limit, signatureLike } = options;
+    let sql = 'SELECT * FROM nodes WHERE 1=1';
+    const params: (string | number)[] = [];
+    if (kinds && kinds.length > 0) {
+      sql += ` AND kind IN (${kinds.map(() => '?').join(',')})`;
+      params.push(...kinds);
+    }
+    if (languages && languages.length > 0) {
+      sql += ` AND language IN (${languages.map(() => '?').join(',')})`;
+      params.push(...languages);
+    }
+    if (signatureLike) {
+      sql += ' AND signature LIKE ? COLLATE NOCASE';
+      params.push(`%${signatureLike}%`);
+    }
+    sql += ' ORDER BY name LIMIT ?';
+    params.push(limit);
+    const rows = this.db.prepare(sql).all(...params) as NodeRow[];
+    return rows.map((row) => ({ node: rowToNode(row), score: 1 }));
+  }
+
+  /**
+   * Fuzzy fallback: when zero FTS/LIKE hits, try an edit-distance
+   * sweep over the distinct symbol-name set. Caps `maxDist` at 2 so
+   * `getUssr` finds `getUser` but `process` doesn't match `prosody`.
+   * Bounded edit distance keeps each comparison cheap; the per-query
+   * scan is O(distinct-name-count) which is far smaller than total
+   * node count on any real codebase.
+   */
+  private searchNodesFuzzy(
+    text: string,
+    options: { kinds?: NodeKind[]; languages?: Language[]; limit: number }
+  ): SearchResult[] {
+    const { kinds, languages, limit } = options;
+    const lowered = text.toLowerCase();
+    const maxDist = lowered.length <= 4 ? 1 : 2;
+
+    // Pull the distinct name list once. The set is cached on QueryBuilder
+    // by getAllNodeNames(); even on a 200k-node project the distinct
+    // name set is typically O(10k) because most names repeat. The
+    // candidate-cap below bounds memory regardless.
+    const allNames = this.getAllNodeNames();
+    const candidates: Array<{ name: string; dist: number }> = [];
+    for (const name of allNames) {
+      const dist = boundedEditDistance(name.toLowerCase(), lowered, maxDist);
+      if (dist <= maxDist) candidates.push({ name, dist });
+    }
+    candidates.sort((a, b) => a.dist - b.dist);
+
+    // Cap the per-name follow-up queries. Each survivor triggers a
+    // separate `SELECT * FROM nodes WHERE name = ?`; without this cap
+    // a project with many similar names (`getUser1`, `getUser2`...)
+    // could fan out far beyond `limit` queries before the inner-loop
+    // limit kicks in.
+    const FUZZY_FOLLOWUP_CAP = Math.max(limit * 2, 50);
+    const cappedCandidates = candidates.slice(0, FUZZY_FOLLOWUP_CAP);
+
+    const results: SearchResult[] = [];
+    const seen = new Set<string>();
+    for (const c of cappedCandidates) {
+      if (results.length >= limit) break;
+      let sql = 'SELECT * FROM nodes WHERE name = ?';
+      const params: (string | number)[] = [c.name];
+      if (kinds && kinds.length > 0) {
+        sql += ` AND kind IN (${kinds.map(() => '?').join(',')})`;
+        params.push(...kinds);
+      }
+      if (languages && languages.length > 0) {
+        sql += ` AND language IN (${languages.map(() => '?').join(',')})`;
+        params.push(...languages);
+      }
+      sql += ' LIMIT 5';
+      const rows = this.db.prepare(sql).all(...params) as NodeRow[];
+      for (const row of rows) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+        // Lower the score for each edit step away from the query so
+        // exact-match fallbacks (dist 0) outrank dist-2 typos.
+        results.push({ node: rowToNode(row), score: 1 / (1 + c.dist) });
+        if (results.length >= limit) break;
+      }
+    }
     return results;
   }
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -125,6 +125,24 @@ function rowToEdge(row: EdgeRow): Edge {
 }
 
 /**
+ * SQLite default `SQLITE_LIMIT_VARIABLE_NUMBER` is 999. Splitting
+ * an `IN (?, ?, ...)` list into chunks of this size keeps the
+ * helpers safe against pathological inputs (large name lists from
+ * graph qualifiers, large id sets from seeded searches) without
+ * having to know each prepared statement's variable budget.
+ */
+const SQLITE_VAR_LIMIT = 900;
+
+function chunkIds<T>(items: ReadonlyArray<T>): T[][] {
+  if (items.length <= SQLITE_VAR_LIMIT) return [items.slice()];
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += SQLITE_VAR_LIMIT) {
+    out.push(items.slice(i, i + SQLITE_VAR_LIMIT));
+  }
+  return out;
+}
+
+/**
  * Convert database row to FileRecord object
  */
 function rowToFileRecord(row: FileRow): FileRecord {
@@ -512,31 +530,56 @@ export class QueryBuilder {
     // candidate set FROM the graph rather than scanning a slice of
     // arbitrary nodes — a tiny callers set is much more likely to
     // produce useful results than the first N name-ordered nodes.
+    // Compute the graph-derived sets ONCE up-front so the filter pass
+    // below can reuse them instead of re-querying. Memoised lazily.
+    let cachedCallersSet: Set<string> | null = null;
+    let cachedCalleesSet: Set<string> | null = null;
+    const callersSet = (): Set<string> => {
+      if (cachedCallersSet === null) cachedCallersSet = this.nodesCallingAny(callersOf);
+      return cachedCallersSet;
+    };
+    const calleesSet = (): Set<string> => {
+      if (cachedCalleesSet === null) cachedCalleesSet = this.nodesCalledByAny(calleesOf);
+      return cachedCalleesSet;
+    };
+
     let results: SearchResult[];
     if (text) {
       results = this.searchNodesFTS(text, { kinds, languages, limit, offset });
     } else if (callersOf.length > 0 || calleesOf.length > 0) {
       const seedIds = new Set<string>();
       if (callersOf.length > 0) {
-        for (const id of this.nodesCallingAny(callersOf)) seedIds.add(id);
+        for (const id of callersSet()) seedIds.add(id);
       }
       if (calleesOf.length > 0) {
-        for (const id of this.nodesCalledByAny(calleesOf)) seedIds.add(id);
+        for (const id of calleesSet()) seedIds.add(id);
       }
-      results = this.nodesByIds([...seedIds]).map((node) => ({ node, score: 1 }));
+      // Apply kind / language filters here — the graph-seeded path
+      // skips the SQL WHERE that the FTS/Like paths use, so without
+      // this post-filter `callers-of:foo kind:method` would return
+      // every caller regardless of its declared kind.
+      const seedNodes = this.nodesByIds([...seedIds]);
+      const filtered = seedNodes.filter((n) => {
+        if (kinds && kinds.length > 0 && !kinds.includes(n.kind)) return false;
+        if (languages && languages.length > 0 && !languages.includes(n.language)) return false;
+        return true;
+      });
+      results = filtered.map((node) => ({ node, score: 1 }));
     } else {
       // Over-fetch by 5× when running filter-only (no text). The
       // post-scoring path: + name: filters can be very selective, so
       // a smaller multiplier risks returning fewer than `limit`
       // results despite the DB having plenty of matches.
-      // Push the FIRST sig: filter into SQL so signature-driven
-      // queries don't waste a candidate slot on every node that
-      // happens to have a small name.
+      // Push sig: filters into SQL with OR semantics so they match
+      // the JS post-filter (which uses `some()`). Pushing all of
+      // them avoids the previous bug where only signatureFilters[0]
+      // went to SQL while the JS post-filter OR'd all of them — the
+      // intersection silently dropped later sig: tokens.
       results = this.searchAllByFilters({
         kinds,
         languages,
         limit: limit * 5,
-        signatureLike: signatureFilters[0],
+        signatureLike: signatureFilters.length > 0 ? signatureFilters : undefined,
       });
     }
 
@@ -634,11 +677,11 @@ export class QueryBuilder {
     // (cheap on indexed columns) and then intersected with the
     // current `results`.
     if (callersOf.length > 0) {
-      const allowed = this.nodesCallingAny(callersOf);
+      const allowed = callersSet();
       results = results.filter((r) => allowed.has(r.node.id));
     }
     if (calleesOf.length > 0) {
-      const allowed = this.nodesCalledByAny(calleesOf);
+      const allowed = calleesSet();
       results = results.filter((r) => allowed.has(r.node.id));
     }
 
@@ -654,63 +697,78 @@ export class QueryBuilder {
   /**
    * Bulk-fetch nodes by id. Used by graph-qualifier search paths
    * (callers-of / callees-of) to materialise the seed set without
-   * issuing one SELECT per id.
+   * issuing one SELECT per id. Chunks the IN clause to stay below
+   * SQLite's default `SQLITE_LIMIT_VARIABLE_NUMBER` (999).
    */
   private nodesByIds(ids: string[]): Node[] {
     if (ids.length === 0) return [];
-    const placeholders = ids.map(() => '?').join(',');
-    const rows = this.db
-      .prepare(`SELECT * FROM nodes WHERE id IN (${placeholders})`)
-      .all(...ids) as NodeRow[];
-    return rows.map(rowToNode);
+    const out: Node[] = [];
+    for (const chunk of chunkIds(ids)) {
+      const placeholders = chunk.map(() => '?').join(',');
+      const rows = this.db
+        .prepare(`SELECT * FROM nodes WHERE id IN (${placeholders})`)
+        .all(...chunk) as NodeRow[];
+      for (const row of rows) out.push(rowToNode(row));
+    }
+    return out;
   }
 
   /**
    * Set of node IDs that have at least one outgoing `calls` edge to
    * a node whose `name` matches any element of `names`. Backs the
-   * `callers-of:NAME` query qualifier.
+   * `callers-of:NAME` query qualifier. Chunked for the 999-variable
+   * SQLite cap.
    */
   private nodesCallingAny(names: string[]): Set<string> {
     if (names.length === 0) return new Set();
-    const placeholders = names.map(() => '?').join(',');
-    const sql = `
-      SELECT DISTINCT e.source AS id
-      FROM edges e
-      JOIN nodes tgt ON e.target = tgt.id
-      WHERE e.kind = 'calls' AND tgt.name IN (${placeholders})
-    `;
-    const rows = this.db.prepare(sql).all(...names) as Array<{ id: string }>;
-    return new Set(rows.map((r) => r.id));
+    const out = new Set<string>();
+    for (const chunk of chunkIds(names)) {
+      const placeholders = chunk.map(() => '?').join(',');
+      const sql = `
+        SELECT DISTINCT e.source AS id
+        FROM edges e
+        JOIN nodes tgt ON e.target = tgt.id
+        WHERE e.kind = 'calls' AND tgt.name IN (${placeholders})
+      `;
+      const rows = this.db.prepare(sql).all(...chunk) as Array<{ id: string }>;
+      for (const r of rows) out.add(r.id);
+    }
+    return out;
   }
 
   /**
    * Set of node IDs that are called BY a node whose `name` matches
    * any element of `names`. Backs the `callees-of:NAME` query
-   * qualifier.
+   * qualifier. Chunked for the 999-variable SQLite cap.
    */
   private nodesCalledByAny(names: string[]): Set<string> {
     if (names.length === 0) return new Set();
-    const placeholders = names.map(() => '?').join(',');
-    const sql = `
-      SELECT DISTINCT e.target AS id
-      FROM edges e
-      JOIN nodes src ON e.source = src.id
-      WHERE e.kind = 'calls' AND src.name IN (${placeholders})
-    `;
-    const rows = this.db.prepare(sql).all(...names) as Array<{ id: string }>;
-    return new Set(rows.map((r) => r.id));
+    const out = new Set<string>();
+    for (const chunk of chunkIds(names)) {
+      const placeholders = chunk.map(() => '?').join(',');
+      const sql = `
+        SELECT DISTINCT e.target AS id
+        FROM edges e
+        JOIN nodes src ON e.source = src.id
+        WHERE e.kind = 'calls' AND src.name IN (${placeholders})
+      `;
+      const rows = this.db.prepare(sql).all(...chunk) as Array<{ id: string }>;
+      for (const r of rows) out.add(r.id);
+    }
+    return out;
   }
 
   private searchAllByFilters(options: {
     kinds?: NodeKind[];
     languages?: Language[];
     limit: number;
-    /** SQL LIKE %…% match against the signature column. Used by the
-     *  filter-only `sig:` query path so we don't have to over-fetch
-     *  arbitrary nodes and post-filter in JS (which often returned
-     *  zero results because the first 50 nodes by name rarely
-     *  contained the signature substring). */
-    signatureLike?: string;
+    /** SQL pre-filter on the signature column. ALL provided strings
+     *  are OR'd (matches the OR semantics of path:/name: filters in
+     *  the JS post-filter pass), so multi-sig: queries behave
+     *  consistently with multi-path:/multi-name: queries. Necessary
+     *  because the JS post-filter alone has nothing to narrow when
+     *  the candidate set is the first 50 nodes by name. */
+    signatureLike?: string[];
   }): SearchResult[] {
     const { kinds, languages, limit, signatureLike } = options;
     let sql = 'SELECT * FROM nodes WHERE 1=1';
@@ -723,9 +781,10 @@ export class QueryBuilder {
       sql += ` AND language IN (${languages.map(() => '?').join(',')})`;
       params.push(...languages);
     }
-    if (signatureLike) {
-      sql += ' AND signature LIKE ? COLLATE NOCASE';
-      params.push(`%${signatureLike}%`);
+    if (signatureLike && signatureLike.length > 0) {
+      const ors = signatureLike.map(() => 'signature LIKE ? COLLATE NOCASE').join(' OR ');
+      sql += ` AND (${ors})`;
+      for (const s of signatureLike) params.push(`%${s}%`);
     }
     sql += ' ORDER BY name LIMIT ?';
     params.push(limit);

--- a/src/search/query-parser.ts
+++ b/src/search/query-parser.ts
@@ -1,0 +1,254 @@
+/**
+ * Field-qualified search query parser.
+ *
+ * Splits a raw query like
+ *
+ *     kind:function name:auth path:src/api authenticate
+ *
+ * into structured filters (kind=function, name="auth", path prefix
+ * "src/api") plus the free-text portion ("authenticate") that goes
+ * to FTS. Free-text and filters compose: filters narrow the result
+ * set, FTS scores within the narrowed set.
+ *
+ * Recognised fields (case-insensitive, value is the rest until
+ * whitespace):
+ *
+ *   kind:    one of function|method|class|interface|struct|...
+ *   lang:    one of typescript|python|go|...   (alias: language:)
+ *   path:    glob/prefix matched against file_path
+ *   name:    exact substring of the symbol's name (case-insensitive)
+ *
+ * Unknown field prefixes (e.g. `foo:bar`) are passed through to FTS
+ * as plain text — that's how someone searching for `TODO:` gets a
+ * result instead of a parse error.
+ *
+ * Quoting:
+ *   kind:function path:"src/some path/with spaces" → handled by stripping
+ *   the surrounding double quotes from the value (single token only,
+ *   no nested escapes).
+ */
+
+import type { NodeKind, Language } from '../types';
+
+export interface ParsedQuery {
+  /** Free-text portion to feed to FTS / LIKE. May be empty. */
+  text: string;
+  /** kind: filters (OR'd). Empty when none specified. */
+  kinds: NodeKind[];
+  /** lang:/language: filters (OR'd). Empty when none specified. */
+  languages: Language[];
+  /** path: filters (OR'd, prefix match against file_path). Empty when none. */
+  pathFilters: string[];
+  /** name: filters (OR'd, case-insensitive substring of node.name). */
+  nameFilters: string[];
+  /**
+   * sig:/signature: filters — case-insensitive substring of
+   * node.signature. Lets users find functions by what they return /
+   * accept (e.g. `sig:Promise<User>`, `sig:io.Reader`).
+   */
+  signatureFilters: string[];
+  /**
+   * callers-of: NAME — restricts results to nodes that have an
+   * outgoing `calls` edge to any node named NAME. Combine with text
+   * to express "callers of authenticate matching *Handler".
+   */
+  callersOf: string[];
+  /**
+   * callees-of: NAME — restricts results to nodes that are called
+   * BY any node named NAME — i.e. things on NAME's outbound call list.
+   */
+  calleesOf: string[];
+}
+
+const KIND_VALUES: ReadonlySet<string> = new Set<NodeKind>([
+  'file',
+  'module',
+  'class',
+  'struct',
+  'interface',
+  'trait',
+  'protocol',
+  'function',
+  'method',
+  'property',
+  'field',
+  'variable',
+  'constant',
+  'enum',
+  'enum_member',
+  'type_alias',
+  'namespace',
+  'parameter',
+  'import',
+  'export',
+  'route',
+  'component',
+]);
+
+const LANGUAGE_VALUES: ReadonlySet<string> = new Set<Language>([
+  'typescript',
+  'javascript',
+  'tsx',
+  'jsx',
+  'python',
+  'go',
+  'rust',
+  'java',
+  'c',
+  'cpp',
+  'csharp',
+  'php',
+  'ruby',
+  'swift',
+  'kotlin',
+  'dart',
+  'liquid',
+  'pascal',
+  'svelte',
+]);
+
+/**
+ * Strip a surrounding pair of double quotes from `s`. Allows users to
+ * keep whitespace in path filters: `path:"my dir/file"`.
+ */
+function unquote(s: string): string {
+  if (s.length >= 2 && s.startsWith('"') && s.endsWith('"')) return s.slice(1, -1);
+  return s;
+}
+
+/**
+ * Parse a raw query into structured filters + remaining text.
+ * Always returns a value; never throws.
+ */
+export function parseQuery(raw: string): ParsedQuery {
+  const out: ParsedQuery = {
+    text: '',
+    kinds: [],
+    languages: [],
+    pathFilters: [],
+    nameFilters: [],
+    signatureFilters: [],
+    callersOf: [],
+    calleesOf: [],
+  };
+
+  // Tokenise on whitespace, preserving quoted spans as part of the
+  // current token. Quotes can appear at the start (`"…"`) OR mid-token
+  // (`path:"…"`); in both cases everything from the opening `"` to the
+  // matching `"` is included in the token, whitespace and all.
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < raw.length) {
+    while (i < raw.length && /\s/.test(raw[i]!)) i++;
+    if (i >= raw.length) break;
+    const start = i;
+    while (i < raw.length && !/\s/.test(raw[i]!)) {
+      if (raw[i] === '"') {
+        const end = raw.indexOf('"', i + 1);
+        if (end === -1) {
+          // Unterminated quote — swallow the rest of the input as
+          // one token. Forgiving rather than throwing.
+          i = raw.length;
+          break;
+        }
+        i = end + 1;
+        continue;
+      }
+      i++;
+    }
+    tokens.push(raw.slice(start, i));
+  }
+
+  const textParts: string[] = [];
+  for (const tok of tokens) {
+    const colon = tok.indexOf(':');
+    if (colon <= 0 || colon === tok.length - 1) {
+      textParts.push(tok);
+      continue;
+    }
+    const key = tok.slice(0, colon).toLowerCase();
+    const valueRaw = unquote(tok.slice(colon + 1));
+    if (!valueRaw) {
+      textParts.push(tok);
+      continue;
+    }
+    switch (key) {
+      case 'kind': {
+        if (KIND_VALUES.has(valueRaw)) {
+          out.kinds.push(valueRaw as NodeKind);
+        } else {
+          textParts.push(tok);
+        }
+        break;
+      }
+      case 'lang':
+      case 'language': {
+        const lower = valueRaw.toLowerCase();
+        if (LANGUAGE_VALUES.has(lower)) {
+          out.languages.push(lower as Language);
+        } else {
+          textParts.push(tok);
+        }
+        break;
+      }
+      case 'path':
+        out.pathFilters.push(valueRaw);
+        break;
+      case 'name':
+        out.nameFilters.push(valueRaw);
+        break;
+      case 'sig':
+      case 'signature':
+        out.signatureFilters.push(valueRaw);
+        break;
+      case 'callers-of':
+        out.callersOf.push(valueRaw);
+        break;
+      case 'callees-of':
+        out.calleesOf.push(valueRaw);
+        break;
+      default:
+        textParts.push(tok);
+    }
+  }
+
+  out.text = textParts.join(' ').trim();
+  return out;
+}
+
+/**
+ * Damerau-Levenshtein-ish bounded edit distance. Returns `maxDist + 1`
+ * as soon as the distance is known to exceed `maxDist`; that early-exit
+ * makes the fuzzy fallback cheap even over tens of thousands of names.
+ *
+ * Pure DP, O(min(len(a), len(b))) memory. Compares case-folded inputs;
+ * callers should pass `lowercase(name)` strings.
+ */
+export function boundedEditDistance(a: string, b: string, maxDist: number): number {
+  if (a === b) return 0;
+  const al = a.length;
+  const bl = b.length;
+  if (Math.abs(al - bl) > maxDist) return maxDist + 1;
+  if (al === 0) return bl;
+  if (bl === 0) return al;
+
+  let prev = new Array<number>(bl + 1);
+  let cur = new Array<number>(bl + 1);
+  for (let j = 0; j <= bl; j++) prev[j] = j;
+
+  for (let i = 1; i <= al; i++) {
+    cur[0] = i;
+    let rowMin = cur[0]!;
+    for (let j = 1; j <= bl; j++) {
+      const cost = a.charCodeAt(i - 1) === b.charCodeAt(j - 1) ? 0 : 1;
+      const insertion = cur[j - 1]! + 1;
+      const deletion = prev[j]! + 1;
+      const substitution = prev[j - 1]! + cost;
+      cur[j] = Math.min(insertion, deletion, substitution);
+      if (cur[j]! < rowMin) rowMin = cur[j]!;
+    }
+    if (rowMin > maxDist) return maxDist + 1;
+    [prev, cur] = [cur, prev];
+  }
+  return prev[bl]!;
+}


### PR DESCRIPTION
## Summary

Three new search query qualifiers extending PR #131's field-qualified parser. All compose with the existing `kind:` / `lang:` / `path:` / `name:` filters.

### `sig:` / `signature:` — substring of node.signature
Find functions by what they accept or return:
```
query "sig:Promise<User> kind:function"
query "sig:context.Context"
query "sig:io.Reader sig:io.Writer"   # OR semantics
```

### `callers-of:NAME` — nodes that call NAME
```
query "callers-of:authenticate"
query "callers-of:authenticate name:Handler"
query "callers-of:Forward kind:function"
```

### `callees-of:NAME` — nodes called BY NAME
```
query "callees-of:bootstrap"
```

## Implementation notes

- New `nodesCallingAny(names)` and `nodesCalledByAny(names)` SQL helpers; `nodesByIds(ids)` for bulk node fetching when seeded from the graph.
- Graph-seeded candidate set when callers-of/callees-of is given without text — otherwise the filter-only path scans 50 arbitrary name-ordered nodes that rarely intersect with the graph result.
- `searchAllByFilters` accepts `signatureLike: string[]` and OR's all entries in SQL — matches the OR semantics of `path:` / `name:` post-filters.
- All IN-clause helpers chunk inputs to 900 per query (under SQLite's 999 variable cap) so pathological inputs can't trigger `SQLITE_ERROR: too many SQL variables`.
- Graph-seeded path applies `kinds`/`languages` post-filter to the seed set so `callers-of:foo kind:method` correctly narrows.
- Reviewer-driven: also memoises `callersSet()` / `calleesSet()` closures so the seed and the filter pass don't re-query the same names.

## Test plan

Verified live on ollama/ollama@v0.22.0:

| Query | Result |
|-------|--------|
| `sig:context.Context kind:function` | `BuildLauncherState`, `Chat`, ... |
| `callers-of:Forward kind:function` | `audioFeedForward`, `forwardConvBlock`, ... |
| `auth sig:error` | `getAuthorizationToken` (text + sig: composes) |

- [x] **5 new integration tests** in `__tests__/search-qualifiers.test.ts` covering `sig:`, multi-`sig:` OR, `callers-of:`, `callees-of:`, and `callers-of: + kind:` composition
- [x] **2 new parser tests** for `sig:` and `callers-of:` / `callees-of:` parsing
- [x] `npx vitest run` — **410 passed** (was 405)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds

## Depends on

- PR #131 (`feat/search-fields-and-fuzzy`) — parser foundation + chunking infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
