### PR TITLE
perf(db): drop redundant idx_edges_source / idx_edges_target

### DIFF
--- a/__tests__/foundation.test.ts
+++ b/__tests__/foundation.test.ts
@@ -305,7 +305,7 @@ describe('Database Connection', () => {
 
     const version = db.getSchemaVersion();
     expect(version).not.toBeNull();
-    expect(version?.version).toBe(3);
+    expect(version?.version).toBe(4);
 
     db.close();
   });

--- a/__tests__/pr19-improvements.test.ts
+++ b/__tests__/pr19-improvements.test.ts
@@ -299,7 +299,7 @@ describe('Best-Candidate Resolution', () => {
 describe('Schema v2 Migration', () => {
   it.skipIf(!HAS_SQLITE)('should have correct current schema version', async () => {
     const { CURRENT_SCHEMA_VERSION } = await import('../src/db/migrations');
-    expect(CURRENT_SCHEMA_VERSION).toBe(3);
+    expect(CURRENT_SCHEMA_VERSION).toBe(4);
   });
 
   it.skipIf(!HAS_SQLITE)('should have migration for version 2', async () => {

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -9,7 +9,7 @@ import { SqliteDatabase } from './sqlite-adapter';
 /**
  * Current schema version
  */
-export const CURRENT_SCHEMA_VERSION = 3;
+export const CURRENT_SCHEMA_VERSION = 4;
 
 /**
  * Migration definition
@@ -51,6 +51,17 @@ const migrations: Migration[] = [
     up: (db) => {
       db.exec(`
         CREATE INDEX IF NOT EXISTS idx_nodes_lower_name ON nodes(lower(name));
+      `);
+    },
+  },
+  {
+    version: 4,
+    description:
+      'Drop redundant idx_edges_source / idx_edges_target (covered by source_kind / target_kind composites)',
+    up: (db) => {
+      db.exec(`
+        DROP INDEX IF EXISTS idx_edges_source;
+        DROP INDEX IF EXISTS idx_edges_target;
       `);
     },
   },

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -122,9 +122,12 @@ CREATE TRIGGER IF NOT EXISTS nodes_au AFTER UPDATE ON nodes BEGIN
     VALUES (NEW.rowid, NEW.id, NEW.name, NEW.qualified_name, NEW.docstring, NEW.signature);
 END;
 
--- Edge indexes
-CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source);
-CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target);
+-- Edge indexes.
+-- idx_edges_source / idx_edges_target are intentionally omitted —
+-- the (source, kind) and (target, kind) composites below cover the
+-- corresponding source-only / target-only lookups via SQLite's
+-- left-prefix scan, so the narrow indexes are dead weight on writes.
+-- Migration v4 drops them on existing databases.
 CREATE INDEX IF NOT EXISTS idx_edges_kind ON edges(kind);
 CREATE INDEX IF NOT EXISTS idx_edges_source_kind ON edges(source, kind);
 CREATE INDEX IF NOT EXISTS idx_edges_target_kind ON edges(target, kind);


### PR DESCRIPTION
## Summary

- Drops two narrow edge indexes (`idx_edges_source`, `idx_edges_target`) that are fully covered by the existing `(source, kind)` and `(target, kind)` composites via SQLite's left-prefix scan.
- Adds migration v4 (`CURRENT_SCHEMA_VERSION` 3 → 4) to drop them on existing databases; fresh-DB schema no longer creates them.

Salvaged from #122, which bundled the same fix with the unmerged file-based migrations refactor. This is the standalone, inline-migration version.

## Why it's safe

| Query shape | Old plan | New plan |
|---|---|---|
| `WHERE source = ?` | `idx_edges_source` | `idx_edges_source_kind` (left-prefix, covering) |
| `WHERE target = ?` | `idx_edges_target` | `idx_edges_target_kind` (left-prefix, covering) |
| `WHERE source = ? AND kind = ?` | `idx_edges_source_kind` | unchanged |
| `WHERE target = ? AND kind = ?` | `idx_edges_target_kind` | unchanged |

## Empirical numbers (from #122's spike on 50K-node / 250K-edge DB)

- DB size: 34.7 MB → 27.0 MB (-22.2%)
- Bulk insert (250K edges): 590ms → 431ms (1.37× faster)
- source/target lookup latency: no regression

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 416/416 pass
- [x] Updated schema-version expectation in `foundation.test.ts` and `pr19-improvements.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)