### PR TITLE
docs(readme): add Vue to the Supported Languages table

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ The `.codegraph/config.json` file controls indexing:
 | Kotlin | `.kt`, `.kts` | Full support |
 | Dart | `.dart` | Full support |
 | Svelte | `.svelte` | Full support (script extraction, Svelte 5 runes, SvelteKit routes) |
+| Vue | `.vue` | Full support (script + script-setup extraction, Nuxt page/API/middleware routes) |
 | Liquid | `.liquid` | Full support |
 | Pascal / Delphi | `.pas`, `.dpr`, `.dpk`, `.lpr` | Full support (classes, records, interfaces, enums, DFM/FMX form files) |
 


### PR DESCRIPTION
Followup to #66 — Vue support landed but the README languages table was never updated. One-line addition between Svelte and Liquid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)