### PR TITLE
docs(readme): add Initialize Projects snippet to Get Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ npx @colbymchenry/codegraph
 
 ![1_C_VYnhpys0UHrOuOgpgoyw](https://github.com/user-attachments/assets/f168182f-4d9a-44e0-94d7-08d018cc8a3a)
 
+#### Initialize Projects
+
+```bash
+cd your-project
+codegraph init -i
+```
+
 </div>
 
 ---


### PR DESCRIPTION
Adds the per-project init snippet (`cd your-project / codegraph init -i`) under the top-level Get Started section, so users see the full happy path before scrolling to Quick Start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)