### PR TITLE
fix(cli): hard-exit on Node 25.x instead of soft warning + cryptic crash

### DIFF
--- a/__tests__/node-version-check.test.ts
+++ b/__tests__/node-version-check.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Pin the Node-25 block banner content. The banner replaced a soft
+ * `console.warn` because the warning was scrolling off-screen before
+ * the OOM crash 30 seconds later, generating duplicate bug reports
+ * (#54, #81, #140). The recipe and override env var below are
+ * load-bearing — if any of them get edited away, this test catches it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildNode25BlockBanner } from '../src/bin/node-version-check';
+
+describe('buildNode25BlockBanner', () => {
+  it('embeds the reported Node version in the header', () => {
+    expect(buildNode25BlockBanner('25.9.0')).toContain(
+      'Unsupported Node.js version: 25.9.0'
+    );
+  });
+
+  it('names the V8 turboshaft WASM root cause and the OOM symptom', () => {
+    const banner = buildNode25BlockBanner('25.7.0');
+    expect(banner).toContain('V8 WASM JIT');
+    expect(banner).toContain('turboshaft');
+    expect(banner).toContain('Fatal process out of memory: Zone');
+  });
+
+  it('points users to Node 22 LTS via nvm and Homebrew', () => {
+    const banner = buildNode25BlockBanner('25.7.0');
+    expect(banner).toContain('Node.js 22 LTS');
+    expect(banner).toContain('nvm install 22');
+    expect(banner).toContain('brew install node@22');
+  });
+
+  it('documents the CODEGRAPH_ALLOW_UNSAFE_NODE override', () => {
+    const banner = buildNode25BlockBanner('25.7.0');
+    expect(banner).toContain('CODEGRAPH_ALLOW_UNSAFE_NODE=1');
+  });
+
+  it('links to issue #81 for the root-cause writeup', () => {
+    expect(buildNode25BlockBanner('25.7.0')).toContain(
+      'github.com/colbymchenry/codegraph/issues/81'
+    );
+  });
+});

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -24,6 +24,8 @@ import * as fs from 'fs';
 import { getCodeGraphDir, isInitialized } from '../directory';
 import { createShimmerProgress } from '../ui/shimmer-progress';
 
+import { buildNode25BlockBanner } from './node-version-check';
+
 // Lazy-load heavy modules (CodeGraph, runInstaller) to keep CLI startup fast.
 async function loadCodeGraph(): Promise<typeof import('../index')> {
   try {
@@ -44,20 +46,21 @@ async function loadCodeGraph(): Promise<typeof import('../index')> {
 const importESM = new Function('specifier', 'return import(specifier)') as
   (specifier: string) => Promise<typeof import('@clack/prompts')>;
 
-// Warn about unsupported Node.js versions (Node 25+ has V8 turboshaft WASM bugs)
+// Block CodeGraph on Node.js 25.x — V8's turboshaft WASM JIT has a Zone
+// allocator bug that reliably crashes when compiling tree-sitter
+// grammars (see #54, #81, #140). The previous behaviour was a soft
+// console.warn that scrolls off-screen before the OOM crash 30 seconds
+// later, leading to a steady stream of "what is this OOM" reports.
+// Hard-exit before any WASM work; allow override via env var for users
+// who patched V8 themselves or want to test a future fix.
 const nodeVersion = process.versions.node;
 const nodeMajor = parseInt(nodeVersion.split('.')[0] ?? '0', 10);
 if (nodeMajor >= 25) {
-  console.warn(
-    '\x1b[33m⚠\x1b[0m  CodeGraph may crash on Node.js %s due to a V8 WASM compiler bug in Node 25+.',
-    nodeVersion
-  );
-  console.warn(
-    '   Please use Node.js 22 LTS instead: https://nodejs.org/en/download'
-  );
-  console.warn(
-    '   See: https://github.com/colbymchenry/codegraph/issues/81\n'
-  );
+  process.stderr.write(buildNode25BlockBanner(nodeVersion) + '\n');
+  if (!process.env.CODEGRAPH_ALLOW_UNSAFE_NODE) {
+    process.exit(1);
+  }
+  // Override active — banner shown for visibility, continuing.
 }
 
 // Check if running with no arguments - run installer

--- a/src/bin/node-version-check.ts
+++ b/src/bin/node-version-check.ts
@@ -1,0 +1,36 @@
+/**
+ * Node.js version compatibility check.
+ *
+ * Node 25.x has a V8 turboshaft WASM JIT Zone allocator bug that
+ * reliably crashes CodeGraph with `Fatal process out of memory: Zone`
+ * during tree-sitter grammar compilation. This module owns the
+ * user-facing banner shown before exit. Kept side-effect-free so it's
+ * safe to import from tests without triggering CLI bootstrap.
+ */
+
+/**
+ * Build the bordered banner shown when CodeGraph detects an
+ * unsupported Node.js major version (currently 25+). Pinned via unit
+ * test so the recovery commands and override instructions can't be
+ * silently stripped by future edits.
+ */
+export function buildNode25BlockBanner(nodeVersion: string): string {
+  const sep = '─'.repeat(72);
+  return [
+    sep,
+    `[CodeGraph] Unsupported Node.js version: ${nodeVersion}`,
+    sep,
+    'Node.js 25.x has a V8 WASM JIT (turboshaft) Zone allocator bug that',
+    'crashes with `Fatal process out of memory: Zone` when CodeGraph',
+    'compiles tree-sitter grammars. CodeGraph WILL crash on this Node',
+    'version mid-indexing. See https://github.com/colbymchenry/codegraph/issues/81',
+    '',
+    'Fix: install Node.js 22 LTS:',
+    '  nvm install 22 && nvm use 22                          # nvm',
+    '  brew install node@22 && brew link --overwrite --force node@22  # Homebrew',
+    '',
+    'To override (NOT recommended — you will likely OOM):',
+    '  CODEGRAPH_ALLOW_UNSAFE_NODE=1 codegraph ...',
+    sep,
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary

- Closes #140 and stops the recurring duplicates of #54 / #81 (Node 25.x V8 turboshaft WASM JIT Zone allocator bug).
- Existing defenses (engines `<25.0.0`, lazy grammars #61, startup `console.warn`) aren't enough — npm `engines` is a soft warning by default, and the runtime warning is a single yellow line that scrolls off-screen before the OOM crash 30 seconds later. Users connect the crash to "CodeGraph is broken" rather than "I'm on Node 25" and file a fresh issue.
- This PR turns the soft warning into a hard exit: bordered banner with the V8 root cause + Node 22 LTS install commands, then `exit(1)` BEFORE any tree-sitter import triggers WASM JIT. Override available via `CODEGRAPH_ALLOW_UNSAFE_NODE=1`.

## What changed

| Before | After |
|---|---|
| `console.warn` yellow line, init continues, OOM crash mid-indexing | Bordered banner, `exit(1)` before any WASM work |
| No way to know what `Fatal process out of memory: Zone` means | Banner names the V8 turboshaft bug, embeds the detected Node version, links to #81 |
| No escape hatch | `CODEGRAPH_ALLOW_UNSAFE_NODE=1` restores the warn-and-continue behavior |

Banner content (verified by 5 unit tests so future edits can't silently strip the recovery commands or override hint):

```
────────────────────────────────────────────────────────────────────────
[CodeGraph] Unsupported Node.js version: 25.9.0
────────────────────────────────────────────────────────────────────────
Node.js 25.x has a V8 WASM JIT (turboshaft) Zone allocator bug that
crashes with `Fatal process out of memory: Zone` when CodeGraph
compiles tree-sitter grammars. CodeGraph WILL crash on this Node
version mid-indexing. See https://github.com/colbymchenry/codegraph/issues/81

Fix: install Node.js 22 LTS:
  nvm install 22 && nvm use 22                          # nvm
  brew install node@22 && brew link --overwrite --force node@22  # Homebrew

To override (NOT recommended — you will likely OOM):
  CODEGRAPH_ALLOW_UNSAFE_NODE=1 codegraph ...
────────────────────────────────────────────────────────────────────────
```

The banner builder lives in a new `src/bin/node-version-check.ts` so it's importable from tests without dragging in CLI bootstrap side-effects.

## Test plan

- [x] `npm test` — 514/514 passing (was 509; +5 new tests pin the banner content)
- [x] Hard-exit verified: temporarily flipped the threshold to 22 in `dist/`, ran `node dist/bin/codegraph.js status` on Node 22.20.0 → banner printed, exit code 1, no further work happened
- [x] Override verified: same setup with `CODEGRAPH_ALLOW_UNSAFE_NODE=1` → banner printed, CLI continued and ran the status command normally
- [x] No-op on supported Node verified: full test suite ran on Node 22 with the threshold at 25 (default), nothing fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)