### PR TITLE
fix(installer): use opencode config dir on Windows

### DIFF
--- a/__tests__/installer-targets.test.ts
+++ b/__tests__/installer-targets.test.ts
@@ -55,6 +55,16 @@ function setHome(dir: string): { restore: () => void } {
   };
 }
 
+function setPlatform(platform: NodeJS.Platform): { restore: () => void } {
+  const previous = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value: platform });
+  return {
+    restore() {
+      if (previous) Object.defineProperty(process, 'platform', previous);
+    },
+  };
+}
+
 describe('Installer targets — contract', () => {
   let tmpHome: string;
   let tmpCwd: string;
@@ -233,6 +243,33 @@ describe('Installer targets — partial-state idempotency', () => {
     expect(result.files[0].action).toBe('created');
   });
 
+  it('opencode: Windows global install uses ~/.config/opencode instead of APPDATA', () => {
+    const platform = setPlatform('win32');
+    const appData = path.join(tmpHome, 'AppData', 'Roaming');
+    const prevAppData = process.env.APPDATA;
+    const prevXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.APPDATA = appData;
+    delete process.env.XDG_CONFIG_HOME;
+
+    try {
+      const opencode = getTarget('opencode')!;
+      const result = opencode.install('global', { autoAllow: true });
+      const configFile = path.join(tmpHome, '.config', 'opencode', 'opencode.jsonc');
+      const instructionsFile = path.join(tmpHome, '.config', 'opencode', 'AGENTS.md');
+      const appDataConfigFile = path.join(appData, 'opencode', 'opencode.jsonc');
+
+      expect(result.files.map((f) => f.path)).toContain(configFile);
+      expect(result.files.map((f) => f.path)).toContain(instructionsFile);
+      expect(fs.existsSync(configFile)).toBe(true);
+      expect(fs.existsSync(instructionsFile)).toBe(true);
+      expect(fs.existsSync(appDataConfigFile)).toBe(false);
+    } finally {
+      platform.restore();
+      if (prevAppData === undefined) delete process.env.APPDATA; else process.env.APPDATA = prevAppData;
+      if (prevXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME; else process.env.XDG_CONFIG_HOME = prevXdgConfigHome;
+    }
+  });
+
   it('opencode: preserves line and block comments through install + idempotent re-run', () => {
     const opencode = getTarget('opencode')!;
     const dir = path.join(tmpHome, '.config', 'opencode');
@@ -311,10 +348,10 @@ describe('Installer targets — partial-state idempotency', () => {
   it('opencode: local install writes ./opencode.jsonc and ./AGENTS.md in cwd', () => {
     const opencode = getTarget('opencode')!;
     const result = opencode.install('local', { autoAllow: true });
-    const paths = result.files.map((f) => f.path.replace(/\\/g, '/'));
-    // macOS realpath shenanigans (/var vs /private/var) — suffix match.
-    expect(paths.some((p) => p.endsWith('/opencode.jsonc'))).toBe(true);
-    expect(paths.some((p) => p.endsWith('/AGENTS.md'))).toBe(true);
+    const paths = result.files.map((f) => f.path);
+    // Avoid absolute-path quirks (/var vs /private/var, or \ vs /).
+    expect(paths.some((p) => path.basename(p) === 'opencode.jsonc')).toBe(true);
+    expect(paths.some((p) => path.basename(p) === 'AGENTS.md')).toBe(true);
   });
 
   it('hermes: install adds codegraph MCP server and cli toolset, preserving existing yaml', () => {

--- a/src/installer/targets/opencode.ts
+++ b/src/installer/targets/opencode.ts
@@ -2,7 +2,7 @@
  * opencode target.
  *
  *   - MCP server entry to `~/.config/opencode/opencode.jsonc` (global,
- *     XDG-style; `%APPDATA%/opencode/opencode.jsonc` on Windows) or
+ *     XDG-style, including on Windows) or
  *     `./opencode.jsonc` (local). Falls back to `opencode.json` when a
  *     `.json` file already exists; defaults new installs to `.jsonc`
  *     because that's what opencode itself creates on first run.
@@ -50,11 +50,8 @@ import {
 } from '../instructions-template';
 
 function globalConfigDir(): string {
-  if (process.platform === 'win32') {
-    const appData = process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming');
-    return path.join(appData, 'opencode');
-  }
-  // XDG_CONFIG_HOME if set, else ~/.config — matches opencode's docs.
+  // OpenCode documents the same ~/.config/opencode global config path
+  // on Windows too; do not route Windows installs through APPDATA.
   const xdg = process.env.XDG_CONFIG_HOME && process.env.XDG_CONFIG_HOME.trim().length > 0
     ? process.env.XDG_CONFIG_HOME
     : path.join(os.homedir(), '.config');


### PR DESCRIPTION
## Summary

- Route global opencode installs to `~/.config/opencode` on Windows instead of `%APPDATA%/opencode`.
- Keep the existing `XDG_CONFIG_HOME` override behavior for global installs.
- Add a Windows regression test that sets `APPDATA` and verifies CodeGraph writes both `opencode.jsonc` and `AGENTS.md` under `~/.config/opencode`.
- Make one existing local opencode path assertion separator-agnostic so the installer target test runs cleanly on Windows.

Closes #186.

## Why

OpenCode documents the global config path as `~/.config/opencode/opencode.json`, and #186 reports that the installer-created `%APPDATA%/opencode` config is not the file OpenCode reads on Windows. That makes `codegraph install --target=opencode` appear successful while the MCP server and instructions do not load.

## Duplicate check

Checked recent/open PRs for opencode. #162 and #163 already merged the multi-target installer and `.jsonc`/`AGENTS.md` support, but they do not address the Windows `%APPDATA%` path. I did not find an open PR covering #186.

## Test plan

- `node node_modules/vitest/vitest.mjs run __tests__/installer-targets.test.ts` — 57 passed
- `node node_modules/typescript/bin/tsc --noEmit`