### PR TITLE
feat(installer): add GitHub Copilot CLI installer target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Installer**: GitHub Copilot CLI installer target — `codegraph install` now auto-configures Copilot CLI alongside Claude Code, Cursor, Codex CLI, and opencode. Supports global installation at `~/.copilot/mcp-config.json` and `~/.copilot/AGENTS.md`.
 - **MCP / explore**: `codegraph_explore` source sections now carry line
   numbers (cat -n style `<num>\t<code>`, matching the Read tool). This lets
   the agent cite `file:line` straight from the explore payload instead of

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # CodeGraph
 
-### Supercharge Claude Code, Cursor, Codex, and OpenCode with Semantic Code Intelligence
+### Supercharge Claude Code, Cursor, Codex, OpenCode, and GitHub Copilot CLI with Semantic Code Intelligence
 
 **94% fewer tool calls · 77% faster exploration · 100% local**
 
@@ -18,6 +18,7 @@
 [![Cursor](https://img.shields.io/badge/Cursor-supported-blueviolet.svg)](#)
 [![Codex CLI](https://img.shields.io/badge/Codex_CLI-supported-blueviolet.svg)](#)
 [![opencode](https://img.shields.io/badge/opencode-supported-blueviolet.svg)](#)
+[![Copilot CLI](https://img.shields.io/badge/Copilot_CLI-supported-blueviolet.svg)](#)
 
 <br />
 
@@ -27,7 +28,7 @@
 npx @colbymchenry/codegraph
 ```
 
-<sub>Interactive installer auto-configures your agent(s) — Claude Code, Cursor, Codex CLI, opencode</sub>
+<sub>Interactive installer auto-configures your agent(s) — Claude Code, Cursor, Codex CLI, opencode, GitHub Copilot CLI</sub>
 
 #### Initialize Projects
 

--- a/__tests__/installer-targets.test.ts
+++ b/__tests__/installer-targets.test.ts
@@ -467,6 +467,164 @@ describe('Installer targets — TOML serializer (Codex backbone)', () => {
   });
 });
 
+describe('Copilot CLI target — specific edge cases', () => {
+  let tmpHome: string;
+  let tmpCwd: string;
+  let origCwd: string;
+  let homeRestore: { restore: () => void };
+
+  beforeEach(() => {
+    tmpHome = mkTmpDir('home');
+    tmpCwd = mkTmpDir('cwd');
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+    homeRestore = setHome(tmpHome);
+  });
+
+  afterEach(() => {
+    homeRestore.restore();
+    process.chdir(origCwd);
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    fs.rmSync(tmpCwd, { recursive: true, force: true });
+  });
+
+  it('copilot: preserves existing sibling MCP servers in mcp-config.json', () => {
+    const copilot = getTarget('copilot')!;
+    const dir = path.join(tmpHome, '.copilot');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'mcp-config.json');
+    const seed = {
+      mcpServers: {
+        aspire: {
+          type: 'local',
+          command: 'aspire',
+          args: ['agent', 'mcp'],
+          tools: ['*'],
+        },
+      },
+    };
+    fs.writeFileSync(file, JSON.stringify(seed, null, 2) + '\n');
+
+    copilot.install('global', { autoAllow: true });
+
+    const after = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(after.mcpServers.aspire).toBeDefined();
+    expect(after.mcpServers.codegraph).toBeDefined();
+    expect(after.mcpServers.codegraph.type).toBe('local');
+    expect(after.mcpServers.codegraph.tools).toEqual(['*']);
+  });
+
+  it('copilot: handles empty or missing mcp-config.json gracefully', () => {
+    const copilot = getTarget('copilot')!;
+    // No pre-existing config
+    const result = copilot.install('global', { autoAllow: true });
+    const mcpPath = path.join(tmpHome, '.copilot', 'mcp-config.json');
+    
+    expect(fs.existsSync(mcpPath)).toBe(true);
+    const config = JSON.parse(fs.readFileSync(mcpPath, 'utf-8'));
+    expect(config.mcpServers.codegraph).toBeDefined();
+    expect(result.files.find((f) => f.path === mcpPath)?.action).toBe('created');
+  });
+
+  it('copilot: install() called with location=local returns empty files array with note', () => {
+    const copilot = getTarget('copilot')!;
+    const result = copilot.install('local', { autoAllow: true });
+    
+    expect(result.files).toEqual([]);
+    expect(result.notes).toBeDefined();
+    expect(result.notes?.[0]).toContain('no project-local config');
+    expect(result.notes?.[0]).toContain('--location=global');
+  });
+
+  it('copilot: uninstall when nothing installed returns not-found actions', () => {
+    const copilot = getTarget('copilot')!;
+    // No install, just uninstall
+    const result = copilot.uninstall('global');
+    
+    expect(result.files.length).toBeGreaterThan(0);
+    // MCP config should be not-found (no config file), AGENTS.md should be kept (file doesn't exist)
+    const mcpFile = result.files.find((f) => f.path.includes('mcp-config.json'));
+    const agentsFile = result.files.find((f) => f.path.includes('AGENTS.md'));
+    expect(mcpFile?.action).toBe('not-found');
+    expect(agentsFile?.action).toBe('kept');
+  });
+
+  it('copilot: printConfig(local) returns message about global-only support', () => {
+    const copilot = getTarget('copilot')!;
+    const output = copilot.printConfig('local');
+    
+    expect(output).toContain('no project-local config');
+    expect(output).toContain('--location=global');
+  });
+
+  it('copilot: printConfig(global) returns valid JSON with Copilot-specific fields', () => {
+    const copilot = getTarget('copilot')!;
+    const output = copilot.printConfig('global');
+    
+    expect(output).toContain('mcp-config.json');
+    expect(output).toContain('"type": "local"');
+    expect(output).toContain('"tools"');
+    
+    // Extract JSON block and validate it parses
+    const jsonMatch = output.match(/\{[\s\S]*\}/);
+    expect(jsonMatch).toBeTruthy();
+    const parsed = JSON.parse(jsonMatch![0]);
+    expect(parsed.mcpServers.codegraph.type).toBe('local');
+    expect(parsed.mcpServers.codegraph.tools).toEqual(['*']);
+  });
+
+  it('copilot: AGENTS.md install preserves pre-existing user content outside markers', () => {
+    const copilot = getTarget('copilot')!;
+    const dir = path.join(tmpHome, '.copilot');
+    fs.mkdirSync(dir, { recursive: true });
+    const agentsMd = path.join(dir, 'AGENTS.md');
+    fs.writeFileSync(agentsMd, '# My Copilot instructions\n\nAlways use TypeScript.\n');
+
+    copilot.install('global', { autoAllow: true });
+    const body = fs.readFileSync(agentsMd, 'utf-8');
+    
+    expect(body).toContain('# My Copilot instructions');
+    expect(body).toContain('Always use TypeScript.');
+    expect(body).toContain('<!-- CODEGRAPH_START -->');
+    expect(body).toContain('codegraph_callers');
+  });
+
+  it('copilot: uninstall strips only the codegraph block from AGENTS.md', () => {
+    const copilot = getTarget('copilot')!;
+    const dir = path.join(tmpHome, '.copilot');
+    fs.mkdirSync(dir, { recursive: true });
+    const agentsMd = path.join(dir, 'AGENTS.md');
+    fs.writeFileSync(agentsMd, '# My Copilot instructions\n\nAlways use TypeScript.\n');
+
+    copilot.install('global', { autoAllow: true });
+    copilot.uninstall('global');
+
+    const body = fs.readFileSync(agentsMd, 'utf-8');
+    expect(body).toContain('# My Copilot instructions');
+    expect(body).toContain('Always use TypeScript.');
+    expect(body).not.toContain('CODEGRAPH_START');
+    expect(body).not.toContain('codegraph_callers');
+  });
+
+  it('copilot: detect.installed is true when .copilot dir exists', () => {
+    const copilot = getTarget('copilot')!;
+    const dir = path.join(tmpHome, '.copilot');
+    fs.mkdirSync(dir, { recursive: true });
+
+    const detection = copilot.detect('global');
+    expect(detection.installed).toBe(true);
+    expect(detection.alreadyConfigured).toBe(false);
+  });
+
+  it('copilot: detect.alreadyConfigured is true after install', () => {
+    const copilot = getTarget('copilot')!;
+    expect(copilot.detect('global').alreadyConfigured).toBe(false);
+
+    copilot.install('global', { autoAllow: true });
+    expect(copilot.detect('global').alreadyConfigured).toBe(true);
+  });
+});
+
 function listAllFiles(dir: string): string[] {
   if (!fs.existsSync(dir)) return [];
   const out: string[] = [];

--- a/src/installer/targets/copilot.ts
+++ b/src/installer/targets/copilot.ts
@@ -1,0 +1,184 @@
+/**
+ * GitHub Copilot CLI target.
+ *
+ *   - MCP server entry to `~/.copilot/mcp-config.json` (global only).
+ *   - Instructions to `~/.copilot/AGENTS.md`.
+ *
+ * Copilot CLI as of 2026-05 has no project-local config concept —
+ * everything lives under `~/.copilot/`. `supportsLocation('local')`
+ * returns false; the orchestrator skips Copilot when the user picks
+ * the local install location.
+ *
+ * No permissions concept (uses runtime `--allow-tool` flags).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  AgentTarget,
+  DetectionResult,
+  InstallOptions,
+  Location,
+  WriteResult,
+} from './types';
+import {
+  getMcpServerConfig,
+  jsonDeepEqual,
+  readJsonFile,
+  removeMarkedSection,
+  replaceOrAppendMarkedSection,
+  writeJsonFile,
+} from './shared';
+import {
+  CODEGRAPH_SECTION_END,
+  CODEGRAPH_SECTION_START,
+  INSTRUCTIONS_TEMPLATE,
+} from '../instructions-template';
+
+function configDir(): string {
+  return path.join(os.homedir(), '.copilot');
+}
+function mcpConfigPath(): string {
+  return path.join(configDir(), 'mcp-config.json');
+}
+function instructionsPath(): string {
+  return path.join(configDir(), 'AGENTS.md');
+}
+
+class CopilotTarget implements AgentTarget {
+  readonly id = 'copilot' as const;
+  readonly displayName = 'GitHub Copilot CLI';
+  readonly docsUrl = 'https://docs.github.com/copilot/using-github-copilot/using-github-copilot-in-the-command-line';
+
+  supportsLocation(loc: Location): boolean {
+    return loc === 'global';
+  }
+
+  detect(loc: Location): DetectionResult {
+    if (loc !== 'global') {
+      return { installed: false, alreadyConfigured: false };
+    }
+    const mcpPath = mcpConfigPath();
+    let alreadyConfigured = false;
+    if (fs.existsSync(mcpPath)) {
+      try {
+        const config = readJsonFile(mcpPath);
+        alreadyConfigured = !!config.mcpServers?.codegraph;
+      } catch { /* ignore */ }
+    }
+    const installed = fs.existsSync(configDir());
+    return { installed, alreadyConfigured, configPath: mcpPath };
+  }
+
+  install(loc: Location, _opts: InstallOptions): WriteResult {
+    if (loc !== 'global') {
+      return {
+        files: [],
+        notes: ['Copilot CLI has no project-local config — re-run with --location=global to install.'],
+      };
+    }
+    const files: WriteResult['files'] = [];
+
+    files.push(writeMcpEntry());
+    files.push(writeInstructionsEntry());
+
+    return { files };
+  }
+
+  uninstall(loc: Location): WriteResult {
+    if (loc !== 'global') return { files: [] };
+    const files: WriteResult['files'] = [];
+
+    // 1. MCP server entry
+    const mcpPath = mcpConfigPath();
+    const config = readJsonFile(mcpPath);
+    if (config.mcpServers?.codegraph) {
+      delete config.mcpServers.codegraph;
+      if (Object.keys(config.mcpServers).length === 0) {
+        delete config.mcpServers;
+      }
+      writeJsonFile(mcpPath, config);
+      files.push({ path: mcpPath, action: 'removed' });
+    } else {
+      files.push({ path: mcpPath, action: 'not-found' });
+    }
+
+    // 2. Instructions
+    const instr = instructionsPath();
+    const action = removeMarkedSection(instr, CODEGRAPH_SECTION_START, CODEGRAPH_SECTION_END);
+    files.push({ path: instr, action });
+
+    return { files };
+  }
+
+  printConfig(loc: Location): string {
+    if (loc !== 'global') {
+      return '# Copilot CLI has no project-local config — use --location=global.\n';
+    }
+    const target = mcpConfigPath();
+    const mcp = getMcpServerConfig();
+    // Copilot-specific: add "type" and "tools" fields
+    const copilotEntry = {
+      type: 'local',
+      command: mcp.command,
+      args: mcp.args,
+      tools: ['*'],
+    };
+    const snippet = JSON.stringify({ mcpServers: { codegraph: copilotEntry } }, null, 2);
+    return `# Add to ${target}\n\n${snippet}\n`;
+  }
+
+  describePaths(loc: Location): string[] {
+    if (loc !== 'global') return [];
+    return [mcpConfigPath(), instructionsPath()];
+  }
+}
+
+function writeMcpEntry(): WriteResult['files'][number] {
+  const file = mcpConfigPath();
+  const dir = path.dirname(file);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  const existing = readJsonFile(file);
+  const before = existing.mcpServers?.codegraph;
+  const baseMcp = getMcpServerConfig();
+  
+  // Copilot-specific: add "type" and "tools" fields
+  const after = {
+    type: 'local',
+    command: baseMcp.command,
+    args: baseMcp.args,
+    tools: ['*'],
+  };
+
+  if (jsonDeepEqual(before, after)) {
+    return { path: file, action: 'unchanged' };
+  }
+
+  const created = !fs.existsSync(file);
+  if (!existing.mcpServers) existing.mcpServers = {};
+  existing.mcpServers.codegraph = after;
+  writeJsonFile(file, existing);
+  return { path: file, action: created ? 'created' : 'updated' };
+}
+
+function writeInstructionsEntry(): WriteResult['files'][number] {
+  const file = instructionsPath();
+  const dir = path.dirname(file);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  const action = replaceOrAppendMarkedSection(
+    file,
+    INSTRUCTIONS_TEMPLATE,
+    CODEGRAPH_SECTION_START,
+    CODEGRAPH_SECTION_END,
+  );
+  const mapped: 'created' | 'updated' | 'unchanged' =
+    action === 'created' ? 'created'
+      : action === 'unchanged' ? 'unchanged'
+        : 'updated';
+  return { path: file, action: mapped };
+}
+
+export const copilotTarget: AgentTarget = new CopilotTarget();

--- a/src/installer/targets/registry.ts
+++ b/src/installer/targets/registry.ts
@@ -12,12 +12,14 @@ import { claudeTarget } from './claude';
 import { cursorTarget } from './cursor';
 import { codexTarget } from './codex';
 import { opencodeTarget } from './opencode';
+import { copilotTarget } from './copilot';
 
 export const ALL_TARGETS: readonly AgentTarget[] = Object.freeze([
   claudeTarget,
   cursorTarget,
   codexTarget,
   opencodeTarget,
+  copilotTarget,
 ]);
 
 export function getTarget(id: string): AgentTarget | undefined {

--- a/src/installer/targets/types.ts
+++ b/src/installer/targets/types.ts
@@ -19,7 +19,7 @@ export type Location = 'global' | 'local';
  * lookup. New targets add a value here when they're added to the
  * registry. Keep these short and lowercase.
  */
-export type TargetId = 'claude' | 'cursor' | 'codex' | 'opencode';
+export type TargetId = 'claude' | 'cursor' | 'codex' | 'opencode' | 'copilot';
 
 /**
  * Result of `target.detect(location)`.


### PR DESCRIPTION
# feat: add GitHub Copilot CLI installer target

## Description

Adds GitHub Copilot CLI as the fifth installer target alongside Claude Code, Cursor, Codex CLI, and opencode.

## Changes

- **New file**: `src/installer/targets/copilot.ts` - CopilotTarget implementation
- **Updated**: `TargetId` type to include `'copilot'`
- **Updated**: `ALL_TARGETS` registry to include `copilotTarget`
- **Tests**: 10 new Copilot-specific edge case tests + full coverage in parameterized contract tests
- **Docs**: Updated README badges and supported agents list
- **Changelog**: Documented new feature in [Unreleased] section

## Implementation Details

The target follows the same architectural pattern as existing targets:

- **Global-only support** (like Codex) - no project-local config concept
- **MCP server config** at `~/.copilot/mcp-config.json`
- **Agent instructions** at `~/.copilot/AGENTS.md`
- **Copilot-specific fields**: `"type": "local"` and `"tools": ["*"]"`
- **Sibling preservation**: Existing MCP servers are preserved during install/uninstall
- **Idempotent operations**: Re-running install reports "unchanged" when already configured

## Testing

- ✅ All new Copilot tests pass (10/10)
- ✅ All parameterized contract tests pass for Copilot
- ✅ Existing test suite: 622/631 passing (9 pre-existing failures unrelated to this PR)
- ✅ Manual verification completed:
  - Fresh install → files created correctly
  - Idempotency → re-run reports "unchanged"
  - Sibling preservation → aspire MCP server preserved
  - Uninstall → codegraph removed, siblings preserved
  - Print config → valid JSON output

## Installation Example

```bash
# Global install
npx @colbymchenry/codegraph install --target=copilot --location=global

# Verify
gh copilot mcp list
# Output: codegraph (local)
```