### PR TITLE
fix(db): native SQLite backend on Node 24 (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   setup is actually fast. `codegraph uninit` removes any hooks it installed.
 
 ### Changed
+- **Minimum Node.js is now 20** (was 18). Node 18 is end-of-life and the
+  native SQLite binding (`better-sqlite3` 12.x) no longer ships a Node 18
+  prebuilt binary. Node 22 LTS and Node 24 get the native backend out of the
+  box; on other Node versions CodeGraph still runs via the WASM fallback
+  (slower, but functional). Node 25+ remains blocked (V8 WASM JIT crash, see
+  [#81](https://github.com/colbymchenry/codegraph/issues/81)).
 - **MCP / explore**: `codegraph_explore` output is now adaptive to project
   size. The tool used to apply a fixed 35KB cap regardless of how large the
   codebase was, which on small projects (~100 files) produced bigger
@@ -57,6 +63,20 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Thanks to [@essopsp](https://github.com/essopsp) for the repro.
 
 ### Fixed
+- **Native SQLite backend on Node 24**: indexing on Node 24 always dropped to
+  the 5-10x-slower WASM backend, printing a `better-sqlite3 unavailable`
+  warning that `npm rebuild better-sqlite3` / `xcode-select --install` could
+  not clear ([#203](https://github.com/colbymchenry/codegraph/issues/203)).
+  The bundled `better-sqlite3` was pinned to a v11 release that ships no
+  prebuilt binary for Node 24's ABI (`node-v137`), so every Node 24 install
+  silently degraded — and because CodeGraph is usually installed globally, the
+  `npm install` / `npm rebuild` people ran in their own project never touched
+  CodeGraph's copy. CodeGraph now requires `better-sqlite3` `^12.4.1`, whose
+  prebuilds include Node 24, so a fresh install on Node 22 or Node 24 gets the
+  native backend with no compiler. On an already-broken install, reinstall
+  CodeGraph (e.g. `npm install -g @colbymchenry/codegraph`) to pull the new
+  binding; `codegraph status` should then report `Backend: native`. Thanks to
+  [@Finndersen](https://github.com/Finndersen) for the report.
 - **MCP**: tools no longer fail with "CodeGraph not initialized" when the index
   actually exists. This hit clients that launch the MCP server from a directory
   other than your project and don't report a workspace root in `initialize`

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,10 +31,10 @@
         "vitest": "^2.1.9"
       },
       "engines": {
-        "node": ">=18.0.0 <25.0.0"
+        "node": ">=20.0.0 <25.0.0"
       },
       "optionalDependencies": {
-        "better-sqlite3": "^11.0.0"
+        "better-sqlite3": "^12.4.1"
       }
     },
     "node_modules/@clack/core": {
@@ -992,15 +992,18 @@
       "optional": true
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     "vitest": "^2.1.9"
   },
   "optionalDependencies": {
-    "better-sqlite3": "^11.0.0"
+    "better-sqlite3": "^12.4.1"
   },
   "engines": {
-    "node": ">=18.0.0 <25.0.0"
+    "node": ">=20.0.0 <25.0.0"
   }
 }


### PR DESCRIPTION
## Problem

On Node 24, `codegraph init -i` always fell back to the WASM SQLite backend, printing a `better-sqlite3 unavailable` warning that no amount of `npm rebuild better-sqlite3` / `xcode-select --install` could clear.

Root cause: `optionalDependencies.better-sqlite3` was pinned to `^11.0.0`. The latest v11 (`11.10.0`) ships **no prebuilt binary for Node 24's ABI (`node-v137`)** and predates Node 24, so the optional dependency silently failed to load → WASM fallback. Compounded by the fact that CodeGraph is usually installed globally: the `npm install` / `npm rebuild` users ran in their own project never touched CodeGraph's copy.

## Fix

- `better-sqlite3` `^11.0.0` → `^12.4.1` — the first 12.x release whose prebuilds include Node 24 (`node-v137`).
- `engines.node` `>=18.0.0` → `>=20.0.0` — Node 18 is EOL and dropped from better-sqlite3 12.x prebuilds.

## Verification (real macOS, Node 24.15.0, ABI 137)

- `npm install better-sqlite3@^12.4.1` pulls the prebuilt `12.10.0` binary — confirmed native **even with the compiler sabotaged** (`CC=CXX=/usr/bin/false`, installs in 768 ms), proving no compiler is required.
- `codegraph init -i` → no WASM banner; `codegraph status` → `Backend: native`.
- Full test suite: 639/639 pass on Node 22 (the 11→12 bump is API-compatible).

## Note

`12.10.0` prebuilds Node 22 and Node 24; Node 20/21/23 fall to the WASM fallback (still functional). Node 22 and Node 24 are the active LTS lines.

Thanks to @Finndersen for the clear report.

Fixes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)