### PR TITLE
fix(sync): stop reporting git-untracked files as pending after sync (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,18 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Thanks to [@essopsp](https://github.com/essopsp) for the repro.
 
 ### Fixed
+- **Sync / status**: git-untracked files are no longer reported as pending
+  "Added" forever. After `codegraph sync` indexed a newly-created untracked
+  source file, `codegraph status` kept listing it under Pending Changes and
+  every subsequent `sync` re-indexed it from scratch — even though its symbols
+  were already queryable. Change detection trusted `git status` and counted
+  every untracked (`??`) entry as new without checking the index, but indexing
+  a file doesn't make git track it, so the file stayed `??` and got re-added on
+  each run. CodeGraph now hash-compares untracked files against the index the
+  same way it does tracked files: a file counts as "added" only if it's missing
+  from the index, "modified" if its contents changed, and is skipped otherwise.
+  Closes [#206](https://github.com/colbymchenry/codegraph/issues/206). Thanks to
+  [@15290391025](https://github.com/15290391025) for the report.
 - **Indexing**: `codegraph init -i` now finds source inside nested, independent
   git repositories — separate clones living inside the workspace that are **not**
   git submodules (common in CMake "super-repo" layouts). When the top-level

--- a/__tests__/sync.test.ts
+++ b/__tests__/sync.test.ts
@@ -225,6 +225,50 @@ describe('Sync Module', () => {
       expect(nodes.length).toBeGreaterThan(0);
     });
 
+    it('should stop reporting untracked files once they are indexed (issue #206)', async () => {
+      // Untracked files stay `??` in git status even after codegraph indexes
+      // them. Change detection must compare them against the DB by hash, not
+      // report every untracked file as "added" on every sync/status.
+      fs.writeFileSync(
+        path.join(testDir, 'src', 'new.ts'),
+        `export function newFunc() { return 42; }`
+      );
+
+      // First sync indexes the untracked file.
+      const first = await cg.sync();
+      expect(first.filesAdded).toBe(1);
+
+      // The file is still untracked in git, but now lives in the DB.
+      expect(cg.searchNodes('newFunc').length).toBeGreaterThan(0);
+
+      // status must not keep flagging it as a pending addition...
+      const changes = cg.getChangedFiles();
+      expect(changes.added).not.toContain('src/new.ts');
+      expect(changes.modified).not.toContain('src/new.ts');
+
+      // ...and a second sync must be a no-op for it.
+      const second = await cg.sync();
+      expect(second.filesAdded).toBe(0);
+      expect(second.filesModified).toBe(0);
+    });
+
+    it('should re-index an untracked file when its contents change', async () => {
+      const filePath = path.join(testDir, 'src', 'new.ts');
+      fs.writeFileSync(filePath, `export function newFunc() { return 42; }`);
+      await cg.sync();
+
+      // Modify the still-untracked file.
+      fs.writeFileSync(filePath, `export function renamedFunc() { return 7; }`);
+
+      const changes = cg.getChangedFiles();
+      expect(changes.modified).toContain('src/new.ts');
+
+      const result = await cg.sync();
+      expect(result.filesModified).toBe(1);
+      expect(cg.searchNodes('renamedFunc').length).toBeGreaterThan(0);
+      expect(cg.searchNodes('newFunc').length).toBe(0);
+    });
+
     it('should detect deleted files via git', async () => {
       fs.unlinkSync(path.join(testDir, 'src', 'index.ts'));
 

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -1261,8 +1261,12 @@ export class ExtractionOrchestrator {
         }
       }
 
-      // Handle modified files — read + hash only these files
-      for (const filePath of gitChanges.modified) {
+      // Handle modified + added files — read + hash only these. Untracked
+      // (`??`) files stay untracked in git even after we index them, so they
+      // can't be trusted as "new": re-hash and compare against the DB exactly
+      // like modified files. Otherwise every sync re-indexes them and status
+      // reports them as pending forever. (See issue #206.)
+      for (const filePath of [...gitChanges.modified, ...gitChanges.added]) {
         const fullPath = path.join(this.rootDir, filePath);
         let content: string;
         try {
@@ -1284,13 +1288,6 @@ export class ExtractionOrchestrator {
           changedFilePaths.push(filePath);
           filesModified++;
         }
-      }
-
-      // Handle added (untracked) files
-      for (const filePath of gitChanges.added) {
-        filesToIndex.push(filePath);
-        changedFilePaths.push(filePath);
-        filesAdded++;
       }
     } else {
       // === Fallback: full scan (non-git project or git failure) ===
@@ -1395,8 +1392,11 @@ export class ExtractionOrchestrator {
         }
       }
 
-      // Modified files — read + hash only these, compare with DB
-      for (const filePath of gitChanges.modified) {
+      // Modified + added files — read + hash, compare with DB. Untracked (`??`)
+      // files stay untracked in git even after indexing, so they must be
+      // hash-compared like modified files instead of always counting as added —
+      // otherwise status reports them as pending forever. (See issue #206.)
+      for (const filePath of [...gitChanges.modified, ...gitChanges.added]) {
         const fullPath = path.join(this.rootDir, filePath);
         let content: string;
         try {
@@ -1414,11 +1414,6 @@ export class ExtractionOrchestrator {
         } else if (tracked.contentHash !== contentHash) {
           modified.push(filePath);
         }
-      }
-
-      // Added (untracked) files
-      for (const filePath of gitChanges.added) {
-        added.push(filePath);
       }
 
       return { added, modified, removed };


### PR DESCRIPTION
## Summary

Fixes #206 — `codegraph status` reported git-untracked files as pending **Added** forever, and every `codegraph sync` re-indexed them, even though their symbols were already queryable.

## Root cause

Both git fast-paths in `ExtractionOrchestrator` (`sync()` and `getChangedFiles()`, in `src/extraction/index.ts`) classified every untracked (`??`) file as "added" without consulting the index. Indexing a file into `.codegraph/codegraph.db` doesn't make git *track* it — the file stays `??` in `git status` — so on the next run it was re-reported as a pending addition and re-indexed from scratch. The git-`modified` branch already did the right thing (read → hash → compare against the index); the git-`added` branch skipped that check. The non-git fallback path was already correct, which matches the reporter's observation that this was specific to git untracked files.

## Fix

Merge the `modified` + `added` handling in each git fast-path into one hash-compared loop, so untracked files get the same treatment as tracked ones:

- **added** only if the file is missing from the index,
- **modified** if its contents changed,
- **skipped** otherwise.

The non-git fallback path is unchanged.

## Testing

- Added two regression tests in `__tests__/sync.test.ts`. (The existing untracked-file test only checked the *first* sync, which is why this slipped through.) Both fail on the old code and pass after the fix.
- Verified **live through the real `codegraph` CLI**, A/B'd against the pre-fix build:

  | Step | Pre-fix | Post-fix |
  |---|---|---|
  | `status` after `init -i` | `added: 3` ❌ | `added: 0` ✅ |
  | `status` after `sync` | `added: 3` ❌ | `added: 0` ✅ |
  | repeat `sync` | re-adds every run | no-op ✅ |
  | query symbol from untracked file | — | found ✅ |

- Full suite: **643/643 pass**; `tsc --noEmit` clean.

Reported by @15290391025 — thanks for the precise, well-isolated repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
