### PR TITLE
docs(readme): add Arch Linux installation for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,9 @@ The `.codegraph/config.json` file controls indexing:
   # Linux (RHEL / Fedora)
   sudo yum groupinstall "Development Tools"
 
+  # Linux (Arch / Arch-based)
+  sudo pacman -S base-devel python
+
   # Then rebuild on any platform:
   npm rebuild better-sqlite3
 

--- a/__tests__/sqlite-backend.test.ts
+++ b/__tests__/sqlite-backend.test.ts
@@ -23,6 +23,7 @@ describe('buildWasmFallbackBanner — fix-recipe content', () => {
     expect(banner).toContain('5-10x slower');
     expect(banner).toContain('xcode-select --install');
     expect(banner).toContain('apt install build-essential');
+    expect(banner).toContain('pacman -S base-devel');
     expect(banner).toContain('npm rebuild better-sqlite3');
     expect(banner).toContain('npm install better-sqlite3 --save');
     expect(banner).toContain('codegraph status');
@@ -44,8 +45,9 @@ describe('buildWasmFallbackBanner — fix-recipe content', () => {
 });
 
 describe('WASM_FALLBACK_FIX_RECIPE — single source of truth', () => {
-  it('mentions the three recovery commands', () => {
+  it('mentions the recovery commands', () => {
     expect(WASM_FALLBACK_FIX_RECIPE).toContain('xcode-select --install');
+    expect(WASM_FALLBACK_FIX_RECIPE).toContain('pacman -S base-devel');
     expect(WASM_FALLBACK_FIX_RECIPE).toContain('npm rebuild better-sqlite3');
     expect(WASM_FALLBACK_FIX_RECIPE).toContain(
       'npm install better-sqlite3 --save'

--- a/src/db/sqlite-adapter.ts
+++ b/src/db/sqlite-adapter.ts
@@ -28,7 +28,7 @@ export type SqliteBackend = 'native' | 'wasm';
  * stderr banner and the MCP status formatter.
  */
 export const WASM_FALLBACK_FIX_RECIPE =
-  '`xcode-select --install` (macOS) or `apt install build-essential` (Debian/Ubuntu), ' +
+  '`xcode-select --install` (macOS), `apt install build-essential` (Debian/Ubuntu), or `pacman -S base-devel` (Arch), ' +
   'then `npm rebuild better-sqlite3`, or `npm install better-sqlite3 --save` to force-include it.';
 
 /**
@@ -55,6 +55,7 @@ export function buildWasmFallbackBanner(nativeError?: string): string {
     'Fix on Linux:',
     '  sudo apt install build-essential python3 make    # Debian/Ubuntu',
     '  # or: sudo yum groupinstall "Development Tools"  # RHEL/Fedora',
+    '  # or: sudo pacman -S base-devel python           # Arch Linux',
     '  npm rebuild better-sqlite3',
     '',
     'Or force-include as a hard dependency on any platform:',


### PR DESCRIPTION
This pull request improves support and guidance for Arch Linux users who may encounter issues with missing native build tools when using `better-sqlite3`. The changes update installation instructions and recovery messages to include Arch Linux-specific commands, and ensure that tests cover these updates.

**Documentation and user guidance improvements:**

* Updated the installation instructions in `README.md` to include the Arch Linux command for installing development tools and Python (`sudo pacman -S base-devel python`).
* Enhanced the `WASM_FALLBACK_FIX_RECIPE` message in `src/db/sqlite-adapter.ts` to mention the Arch Linux command (`pacman -S base-devel`) alongside existing macOS and Debian/Ubuntu instructions.
* Updated the `buildWasmFallbackBanner` function to include an Arch Linux-specific fix command (`sudo pacman -S base-devel python`).

**Test coverage:**

* Added test assertions in `__tests__/sqlite-backend.test.ts` to verify that the Arch Linux command appears in the fallback banner and recovery recipe. [[1]](diffhunk://#diff-50da6379f0bde85ea592d978e8381d0f5aa7b423f4f97f793c9bccd49525ce1cR26) [[2]](diffhunk://#diff-50da6379f0bde85ea592d978e8381d0f5aa7b423f4f97f793c9bccd49525ce1cL47-R50)