### PR TITLE
fix: validate projectPath in MCP tool handler to prevent sensitive directory access

### DIFF
--- a/__tests__/security.test.ts
+++ b/__tests__/security.test.ts
@@ -307,6 +307,34 @@ describe('MCP Input Validation', () => {
     const result = await handler.execute('codegraph_search', { query: 'example', limit: -5 });
     expect(result.isError).toBeFalsy();
   });
+
+  // #230: getCodeGraph must reject a sensitive system directory passed as
+  // projectPath before opening it. The error surfaces through execute()'s
+  // catch as an isError result. /etc is sensitive on POSIX; C:\Windows on
+  // Windows (path.resolve is platform-specific, so each case is gated).
+  it.runIf(process.platform !== 'win32')(
+    'rejects a sensitive POSIX projectPath (/etc) via the MCP handler',
+    async () => {
+      const result = await handler.execute('codegraph_search', {
+        query: 'example',
+        projectPath: '/etc',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/sensitive system directory/i);
+    }
+  );
+
+  it.runIf(process.platform === 'win32')(
+    'rejects a sensitive Windows projectPath (C:\\Windows) via the MCP handler',
+    async () => {
+      const result = await handler.execute('codegraph_search', {
+        query: 'example',
+        projectPath: 'C:\\Windows',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/sensitive system directory/i);
+    }
+  );
 });
 
 describe('Atomic Writes', () => {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -15,7 +15,7 @@ import {
   readFileSync,
   writeSync,
 } from 'fs';
-import { clamp, validatePathWithinRoot } from '../utils';
+import { clamp, validatePathWithinRoot, validateProjectPath } from '../utils';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -577,6 +577,12 @@ export class ToolHandler {
     // Check cache first (using original path as key)
     if (this.projectCache.has(projectPath)) {
       return this.projectCache.get(projectPath)!;
+    }
+
+    // Validate the path is safe before opening
+    const pathError = validateProjectPath(projectPath);
+    if (pathError) {
+      throw new Error(pathError);
     }
 
     // Walk up parent directories to find nearest .codegraph/

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -579,10 +579,16 @@ export class ToolHandler {
       return this.projectCache.get(projectPath)!;
     }
 
-    // Validate the path is safe before opening
-    const pathError = validateProjectPath(projectPath);
-    if (pathError) {
-      throw new Error(pathError);
+    // Reject sensitive system directories before opening. Only validate a
+    // path that actually exists — a nested or not-yet-created sub-path of a
+    // real project must still be allowed to resolve UP to its .codegraph/
+    // root below (issue #238), so we don't run the existence-checking
+    // validator on paths that are meant to walk up.
+    if (existsSync(projectPath)) {
+      const pathError = validateProjectPath(projectPath);
+      if (pathError) {
+        throw new Error(pathError);
+      }
     }
 
     // Walk up parent directories to find nearest .codegraph/


### PR DESCRIPTION
## Summary

The `projectPath` parameter accepted by all MCP tools passes through `getCodeGraph()` without calling `validateProjectPath()`, allowing cross-project queries to target sensitive system directories (`/`, `/etc`, `~/.ssh`, `~/.aws`, `C:\Windows`, etc.).

This adds the existing `validateProjectPath()` check inside `ToolHandler.getCodeGraph()` before any filesystem traversal occurs.

## What changed

- Import `validateProjectPath` from `../utils` in `src/mcp/tools.ts`
- Call `validateProjectPath(projectPath)` after the cache check and before `findNearestCodeGraphRoot()`

## Why

`validateProjectPath()` already exists and blocks sensitive paths, but was not wired into the MCP tool handler's cross-project code path. A malicious or compromised MCP client could pass `projectPath` pointing to sensitive directories.

## Testing

- All 33 existing security tests pass
- All core tests (foundation, explore-output-budget, symbol-lookup) pass
- TypeScript compiles cleanly with `--noEmit`