### PR TITLE
fix(config): validate languages from canonical list

### DIFF
--- a/__tests__/foundation.test.ts
+++ b/__tests__/foundation.test.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { CodeGraph } from '../src';
 import { DEFAULT_CONFIG, Node, Edge } from '../src/types';
-import { loadConfig, saveConfig } from '../src/config';
+import { loadConfig, saveConfig, validateConfig } from '../src/config';
 import { isInitialized, getCodeGraphDir, validateDirectory } from '../src/directory';
 import { DatabaseConnection, getDatabasePath } from '../src/db';
 
@@ -204,6 +204,26 @@ describe('CodeGraph Foundation', () => {
       // Verify persistence
       const config = loadConfig(tempDir);
       expect(config.maxFileSize).toBe(999999);
+    });
+
+    it('should accept every supported language in configuration', () => {
+      const config = {
+        ...DEFAULT_CONFIG,
+        rootDir: tempDir,
+        languages: ['php', 'tsx', 'vue', 'liquid', 'pascal', 'scala'],
+      };
+
+      expect(validateConfig(config)).toBe(true);
+    });
+
+    it('should reject unknown languages in configuration', () => {
+      const config = {
+        ...DEFAULT_CONFIG,
+        rootDir: tempDir,
+        languages: ['typescript', 'not-a-language'],
+      };
+
+      expect(validateConfig(config)).toBe(false);
     });
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import picomatch from 'picomatch';
-import { CodeGraphConfig, DEFAULT_CONFIG, Language, NodeKind } from './types';
+import {
+  CodeGraphConfig,
+  DEFAULT_CONFIG,
+  LANGUAGES,
+  NodeKind,
+} from './types';
 import { normalizePath } from './utils';
 
 /**
@@ -72,18 +77,9 @@ export function validateConfig(config: unknown): config is CodeGraphConfig {
   if (!c.include.every((p) => typeof p === 'string')) return false;
   if (!c.exclude.every((p) => typeof p === 'string')) return false;
 
-  // Validate languages
-  const validLanguages: Language[] = [
-    'typescript',
-    'javascript',
-    'python',
-    'go',
-    'rust',
-    'java',
-    'svelte',
-    'unknown',
-  ];
-  if (!c.languages.every((l) => validLanguages.includes(l as Language))) return false;
+  // Validate languages against the canonical list in types.ts.
+  const validLanguages: ReadonlySet<string> = new Set(LANGUAGES);
+  if (!c.languages.every((l) => typeof l === 'string' && validLanguages.has(l))) return false;
 
   // Validate frameworks
   for (const fw of c.frameworks) {


### PR DESCRIPTION
## Summary

- Validate `config.languages` against the canonical `LANGUAGES` list from `src/types.ts`
- Remove the stale hard-coded language allowlist in `src/config.ts`
- Add regression coverage for supported languages that were previously rejected

## Why

`validateConfig()` only allowed a small older subset of languages. Supported languages such as `php`, `tsx`, `vue`, `liquid`, `pascal`, and `scala` could be rejected even though they are valid CodeGraph languages.

## Test plan

- [x] `npx vitest run __tests__/foundation.test.ts`
- [x] `npm run build`
- [x] `npx vitest run __tests__/foundation.test.ts __tests__/search-query-parser.test.ts __tests__/extraction.test.ts -t "supported languages|Configuration|parseQuery"`

Note: `npm test` full suite was attempted on Windows/Node v24.14.1 but failed in unrelated installer/MCP temp cleanup tests and ended with a V8 OOM worker crash.