### PR TITLE
feat: add Jupyter notebook (.ipynb) indexing support

### DIFF
--- a/__tests__/extraction.test.ts
+++ b/__tests__/extraction.test.ts
@@ -3722,3 +3722,157 @@ class Svc {
     expect(decoratedNode?.name).toBe('method');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Jupyter Notebook Extraction
+// ---------------------------------------------------------------------------
+
+describe('Jupyter Notebook Extraction', () => {
+  it('detects .ipynb files as jupyter language', () => {
+    expect(detectLanguage('analysis.ipynb')).toBe('jupyter');
+  });
+
+  it('reports jupyter as a supported language', () => {
+    expect(isLanguageSupported('jupyter')).toBe(true);
+  });
+
+  it('includes jupyter in getSupportedLanguages()', () => {
+    expect(getSupportedLanguages()).toContain('jupyter');
+  });
+
+  const minimalNotebook = (cells: object[]) =>
+    JSON.stringify({
+      nbformat: 4,
+      metadata: { kernelspec: { language: 'python' } },
+      cells,
+    });
+
+  it('extracts a function from a code cell', () => {
+    const notebook = minimalNotebook([
+      {
+        cell_type: 'code',
+        source: ['def greet(name):\n', '    return f"Hello {name}"\n'],
+        metadata: {},
+      },
+    ]);
+    const result = extractFromSource('notebook.ipynb', notebook);
+
+    const funcNode = result.nodes.find((n) => n.kind === 'function');
+    expect(funcNode).toBeDefined();
+    expect(funcNode?.name).toBe('greet');
+    expect(funcNode?.language).toBe('jupyter');
+    expect(funcNode?.filePath).toBe('notebook.ipynb');
+  });
+
+  it('extracts a class from a code cell', () => {
+    const notebook = minimalNotebook([
+      {
+        cell_type: 'code',
+        source: 'class DataProcessor:\n    def run(self):\n        pass\n',
+        metadata: {},
+      },
+    ]);
+    const result = extractFromSource('notebook.ipynb', notebook);
+
+    const classNode = result.nodes.find((n) => n.kind === 'class');
+    expect(classNode).toBeDefined();
+    expect(classNode?.name).toBe('DataProcessor');
+  });
+
+  it('creates a module node for the notebook', () => {
+    const notebook = minimalNotebook([
+      { cell_type: 'code', source: 'x = 1\n', metadata: {} },
+    ]);
+    const result = extractFromSource('my_analysis.ipynb', notebook);
+
+    const moduleNode = result.nodes.find((n) => n.kind === 'module');
+    expect(moduleNode).toBeDefined();
+    expect(moduleNode?.name).toBe('my_analysis');
+    expect(moduleNode?.language).toBe('jupyter');
+  });
+
+  it('ignores markdown cells', () => {
+    const notebook = minimalNotebook([
+      { cell_type: 'markdown', source: '# Title\n\nSome text.', metadata: {} },
+      {
+        cell_type: 'code',
+        source: 'def only_function():\n    pass\n',
+        metadata: {},
+      },
+    ]);
+    const result = extractFromSource('notebook.ipynb', notebook);
+    const functions = result.nodes.filter((n) => n.kind === 'function');
+    expect(functions).toHaveLength(1);
+    expect(functions[0]?.name).toBe('only_function');
+  });
+
+  it('strips IPython line magics without breaking parse', () => {
+    const notebook = minimalNotebook([
+      {
+        cell_type: 'code',
+        source: '%matplotlib inline\ndef plot_data(df):\n    pass\n',
+        metadata: {},
+      },
+    ]);
+    const result = extractFromSource('notebook.ipynb', notebook);
+    // No parse errors from the magic
+    const errors = result.errors.filter((e) => e.severity === 'error');
+    expect(errors).toHaveLength(0);
+    // Function still extracted
+    const funcNode = result.nodes.find((n) => n.kind === 'function');
+    expect(funcNode?.name).toBe('plot_data');
+  });
+
+  it('strips shell commands without breaking parse', () => {
+    const notebook = minimalNotebook([
+      {
+        cell_type: 'code',
+        source: '!pip install pandas\nimport pandas as pd\n',
+        metadata: {},
+      },
+    ]);
+    const result = extractFromSource('notebook.ipynb', notebook);
+    const errors = result.errors.filter((e) => e.severity === 'error');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('offsets line numbers across multiple cells', () => {
+    const cell0 = 'def first():\n    pass\n'; // 2 lines
+    const cell1 = 'def second():\n    pass\n'; // starts after cell0
+
+    const notebook = minimalNotebook([
+      { cell_type: 'code', source: cell0, metadata: {} },
+      { cell_type: 'code', source: cell1, metadata: {} },
+    ]);
+    const result = extractFromSource('notebook.ipynb', notebook);
+
+    const first = result.nodes.find((n) => n.name === 'first');
+    const second = result.nodes.find((n) => n.name === 'second');
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    // second must start after first ends
+    expect(second!.startLine).toBeGreaterThan(first!.endLine);
+  });
+
+  it('returns an error node for malformed JSON', () => {
+    const result = extractFromSource('bad.ipynb', '{ not valid json }');
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]?.code).toBe('parse_error');
+  });
+
+  it('skips code cell extraction for non-Python kernels', () => {
+    const notebook = JSON.stringify({
+      nbformat: 4,
+      metadata: { kernelspec: { language: 'r' } },
+      cells: [
+        { cell_type: 'code', source: 'x <- 1\n', metadata: {} },
+      ],
+    });
+    const result = extractFromSource('r_notebook.ipynb', notebook);
+    // No function/class nodes — R code is not parsed as Python
+    const codeNodes = result.nodes.filter((n) =>
+      n.kind === 'function' || n.kind === 'class'
+    );
+    expect(codeNodes).toHaveLength(0);
+  });
+});

--- a/src/extraction/grammars.ts
+++ b/src/extraction/grammars.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import { Parser, Language as WasmLanguage } from 'web-tree-sitter';
 import { Language } from '../types';
 
-export type GrammarLanguage = Exclude<Language, 'svelte' | 'vue' | 'liquid' | 'unknown'>;
+export type GrammarLanguage = Exclude<Language, 'svelte' | 'vue' | 'liquid' | 'jupyter' | 'unknown'>;
 
 /**
  * WASM filename map — maps each language to its .wasm grammar file
@@ -78,6 +78,7 @@ export const EXTENSION_MAP: Record<string, Language> = {
   '.fmx': 'pascal',
   '.scala': 'scala',
   '.sc': 'scala',
+  '.ipynb': 'jupyter',
 };
 
 /**
@@ -207,6 +208,7 @@ export function isLanguageSupported(language: Language): boolean {
   if (language === 'svelte') return true; // custom extractor (script block delegation)
   if (language === 'vue') return true; // custom extractor (script block delegation)
   if (language === 'liquid') return true; // custom regex extractor
+  if (language === 'jupyter') return true; // custom extractor (cell delegation to python)
   if (language === 'unknown') return false;
   return language in WASM_GRAMMAR_FILES;
 }
@@ -215,7 +217,7 @@ export function isLanguageSupported(language: Language): boolean {
  * Check if a grammar has been loaded and is ready for parsing.
  */
 export function isGrammarLoaded(language: Language): boolean {
-  if (language === 'svelte' || language === 'vue' || language === 'liquid') return true;
+  if (language === 'svelte' || language === 'vue' || language === 'liquid' || language === 'jupyter') return true;
   return languageCache.has(language);
 }
 
@@ -223,7 +225,7 @@ export function isGrammarLoaded(language: Language): boolean {
  * Get all supported languages (those with grammar definitions).
  */
 export function getSupportedLanguages(): Language[] {
-  return [...(Object.keys(WASM_GRAMMAR_FILES) as GrammarLanguage[]), 'svelte', 'vue', 'liquid'];
+  return [...(Object.keys(WASM_GRAMMAR_FILES) as GrammarLanguage[]), 'svelte', 'vue', 'liquid', 'jupyter'];
 }
 
 /**
@@ -291,6 +293,7 @@ export function getLanguageDisplayName(language: Language): string {
     liquid: 'Liquid',
     pascal: 'Pascal / Delphi',
     scala: 'Scala',
+    jupyter: 'Jupyter Notebook',
     unknown: 'Unknown',
   };
   return names[language] || language;

--- a/src/extraction/jupyter-extractor.ts
+++ b/src/extraction/jupyter-extractor.ts
@@ -1,0 +1,208 @@
+import { Node, Edge, ExtractionResult, ExtractionError, UnresolvedReference } from '../types';
+import { generateNodeId } from './tree-sitter-helpers';
+import { TreeSitterExtractor } from './tree-sitter';
+import { isLanguageSupported } from './grammars';
+
+/** IPython magic prefixes that are invalid Python syntax */
+const MAGIC_PREFIXES = ['%%', '%', '!', '?'];
+
+/**
+ * Replace IPython magic lines with blank lines so tree-sitter doesn't
+ * error on them. Blank lines preserve line-number offsets exactly.
+ * Cell magics (`%%...`) on the first line skip the entire remaining
+ * cell content — those are already single-statement cells, so
+ * blanking just the first line is sufficient.
+ */
+function stripMagics(source: string): string {
+  return source
+    .split('\n')
+    .map(line => {
+      const trimmed = line.trimStart();
+      if (MAGIC_PREFIXES.some(prefix => trimmed.startsWith(prefix))) {
+        return '';
+      }
+      return line;
+    })
+    .join('\n');
+}
+
+interface NotebookCell {
+  cell_type: string;
+  source: string | string[];
+  metadata?: Record<string, unknown>;
+}
+
+interface NotebookFormat {
+  nbformat?: number;
+  metadata?: {
+    kernelspec?: { language?: string };
+    language_info?: { name?: string };
+  };
+  cells?: NotebookCell[];
+}
+
+/**
+ * JupyterExtractor — indexes Python code cells in .ipynb notebooks.
+ *
+ * Each code cell is delegated to TreeSitterExtractor (python). Line numbers
+ * are reported as virtual offsets: cell 0 starts at line 1, each subsequent
+ * cell starts at (sum of lines in prior cells) + 1. This produces stable,
+ * self-consistent line numbers even though they don't correspond to JSON
+ * positions in the file.
+ */
+export class JupyterExtractor {
+  private filePath: string;
+  private source: string;
+  private nodes: Node[] = [];
+  private edges: Edge[] = [];
+  private unresolvedReferences: UnresolvedReference[] = [];
+  private errors: ExtractionError[] = [];
+
+  constructor(filePath: string, source: string) {
+    this.filePath = filePath;
+    this.source = source;
+  }
+
+  extract(): ExtractionResult {
+    const startTime = Date.now();
+
+    let notebook: NotebookFormat;
+    try {
+      notebook = JSON.parse(this.source) as NotebookFormat;
+    } catch (err) {
+      this.errors.push({
+        message: `Jupyter: failed to parse JSON — ${err instanceof Error ? err.message : String(err)}`,
+        filePath: this.filePath,
+        severity: 'error',
+        code: 'parse_error',
+      });
+      return this.result(startTime);
+    }
+
+    // Only index Python kernels
+    const kernelLang = (
+      notebook.metadata?.kernelspec?.language ||
+      notebook.metadata?.language_info?.name ||
+      'python'
+    ).toLowerCase();
+
+    if (!kernelLang.includes('python')) {
+      return this.result(startTime);
+    }
+
+    if (!isLanguageSupported('python')) {
+      this.errors.push({
+        message: 'Jupyter: Python grammar not available, cannot parse notebook cells',
+        filePath: this.filePath,
+        severity: 'warning',
+      });
+      return this.result(startTime);
+    }
+
+    // Module node representing the notebook file itself
+    const cells = notebook.cells ?? [];
+    const totalLines = cells.reduce((acc, cell) => {
+      if (cell.cell_type !== 'code') return acc;
+      const src = Array.isArray(cell.source) ? cell.source.join('') : cell.source;
+      return acc + src.split('\n').length;
+    }, 0);
+
+    const fileName = this.filePath.split(/[/\\]/).pop() ?? this.filePath;
+    const moduleName = fileName.replace(/\.ipynb$/, '');
+    const moduleId = generateNodeId(this.filePath, 'module', moduleName, 1);
+    const moduleNode: Node = {
+      id: moduleId,
+      kind: 'module',
+      name: moduleName,
+      qualifiedName: `${this.filePath}::${moduleName}`,
+      filePath: this.filePath,
+      language: 'jupyter',
+      startLine: 1,
+      endLine: Math.max(1, totalLines),
+      startColumn: 0,
+      endColumn: 0,
+      isExported: false,
+      updatedAt: Date.now(),
+    };
+    this.nodes.push(moduleNode);
+
+    // Process each code cell
+    let virtualLineOffset = 0; // 0-indexed; startLine = virtualLineOffset + 1
+
+    for (let cellIdx = 0; cellIdx < cells.length; cellIdx++) {
+      const cell = cells[cellIdx]!;
+      if (cell.cell_type !== 'code') continue;
+
+      const rawSource = Array.isArray(cell.source)
+        ? cell.source.join('')
+        : (cell.source ?? '');
+
+      if (!rawSource.trim()) {
+        // Still advance the offset for blank cells to keep numbering stable
+        virtualLineOffset += rawSource.split('\n').length;
+        continue;
+      }
+
+      const cleanedSource = stripMagics(rawSource);
+      this.processCell(cleanedSource, virtualLineOffset, moduleNode.id, cellIdx);
+
+      virtualLineOffset += rawSource.split('\n').length;
+    }
+
+    return this.result(startTime);
+  }
+
+  private processCell(
+    cellSource: string,
+    lineOffset: number,
+    moduleNodeId: string,
+    cellIdx: number,
+  ): void {
+    const extractor = new TreeSitterExtractor(this.filePath, cellSource, 'python');
+    const result = extractor.extract();
+
+    for (const node of result.nodes) {
+      node.startLine += lineOffset;
+      node.endLine += lineOffset;
+      node.language = 'jupyter';
+
+      // Qualify name with cell index to avoid collisions when the same
+      // variable name appears in multiple cells
+      node.qualifiedName = `${this.filePath}::cell${cellIdx}::${node.name}`;
+
+      this.nodes.push(node);
+      this.edges.push({ source: moduleNodeId, target: node.id, kind: 'contains' });
+    }
+
+    for (const edge of result.edges) {
+      if (edge.line !== undefined) {
+        edge.line += lineOffset;
+      }
+      this.edges.push(edge);
+    }
+
+    for (const ref of result.unresolvedReferences) {
+      ref.line += lineOffset;
+      ref.filePath = this.filePath;
+      ref.language = 'jupyter';
+      this.unresolvedReferences.push(ref);
+    }
+
+    for (const error of result.errors) {
+      if (error.line !== undefined) {
+        error.line += lineOffset;
+      }
+      this.errors.push(error);
+    }
+  }
+
+  private result(startTime: number): ExtractionResult {
+    return {
+      nodes: this.nodes,
+      edges: this.edges,
+      unresolvedReferences: this.unresolvedReferences,
+      errors: this.errors,
+      durationMs: Date.now() - startTime,
+    };
+  }
+}

--- a/src/extraction/tree-sitter.ts
+++ b/src/extraction/tree-sitter.ts
@@ -23,6 +23,7 @@ import { LiquidExtractor } from './liquid-extractor';
 import { SvelteExtractor } from './svelte-extractor';
 import { DfmExtractor } from './dfm-extractor';
 import { VueExtractor } from './vue-extractor';
+import { JupyterExtractor } from './jupyter-extractor';
 import {
   getAllFrameworkResolvers,
   getApplicableFrameworks,
@@ -2506,6 +2507,10 @@ export function extractFromSource(
   } else if (detectedLanguage === 'liquid') {
     // Use custom extractor for Liquid
     const extractor = new LiquidExtractor(filePath, source);
+    result = extractor.extract();
+  } else if (detectedLanguage === 'jupyter') {
+    // Use custom extractor for Jupyter notebooks (delegates cells to Python parser)
+    const extractor = new JupyterExtractor(filePath, source);
     result = extractor.extract();
   } else if (
     detectedLanguage === 'pascal' &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,7 @@ export const LANGUAGES = [
   'liquid',
   'pascal',
   'scala',
+  'jupyter',
   'unknown',
 ] as const;
 
@@ -545,6 +546,8 @@ export const DEFAULT_CONFIG: CodeGraphConfig = {
     // Scala
     '**/*.scala',
     '**/*.sc',
+    // Jupyter Notebooks
+    '**/*.ipynb',
   ],
   exclude: [
     // Version control


### PR DESCRIPTION
## Summary

- Adds a `JupyterExtractor` that parses `.ipynb` JSON files, iterates Python code cells, delegates each cell's source to `TreeSitterExtractor` (python), and applies line-number offsets so extracted symbols are addressable across the virtual cell stack.
- Adds `'jupyter'` to the `Language` union, maps `.ipynb → 'jupyter'` in `EXTENSION_MAP`, and adds `'**/*.ipynb'` to `DEFAULT_CONFIG.include`.
- Strips IPython magics (`%magic`, `!shell`, `?help`, `??source`) before parsing so tree-sitter never sees invalid Python syntax.
- Skips non-Python kernels gracefully (checks `metadata.kernelspec.language`).
- Wraps `JSON.parse` so malformed notebooks produce a recoverable `ExtractionError` instead of a thrown exception.

## Design notes

**Line numbers** are reported as virtual offsets: cell 0 starts at line 1, each subsequent code cell starts after the previous cell's line count. This is consistent and stable, even though it doesn't map back to JSON file positions (which are not useful for code navigation anyway).

**Language tag** on extracted nodes is `'jupyter'` (not `'python'`) so consumers can tell they came from a notebook. The Python WASM grammar is used internally for parsing but the surface language stays `jupyter`.

**No new WASM grammar** — delegates fully to the existing Python parser.

## Test plan

- [x] `detectLanguage('analysis.ipynb')` returns `'jupyter'`
- [x] `isLanguageSupported('jupyter')` returns `true`
- [x] `getSupportedLanguages()` includes `'jupyter'`
- [x] Function and class nodes are extracted from code cells
- [x] A `module` node is created for the notebook file itself
- [x] Markdown cells are ignored
- [x] IPython `%magic` and `!shell` lines are stripped without breaking parse
- [x] Line numbers are correctly offset across multiple cells
- [x] Malformed JSON produces a parse error, not a crash
- [x] Non-Python kernel notebooks produce no code nodes

All 12 new tests pass; full suite (619 existing tests) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)