### PR TITLE
Fix: Increase SQLite busy_timeout to 5 minutes to mitigate locking errors

### DIFF
--- a/src/db/__tests__/index.test.ts
+++ b/src/db/__tests__/index.test.ts
@@ -1,0 +1,185 @@
+
+import { DatabaseConnection, getDatabasePath, DATABASE_FILENAME } from '../index';
+import { createDatabase, SqliteDatabase, SqliteBackend } from '../sqlite-adapter';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Mock fs and path modules
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  readFileSync: jest.fn(),
+  statSync: jest.fn(),
+}));
+
+jest.mock('path', () => ({
+  dirname: jest.fn(),
+  join: jest.fn(),
+}));
+
+// Mock sqlite-adapter
+jest.mock('../sqlite-adapter', () => ({
+  createDatabase: jest.fn(),
+  WASM_FALLBACK_FIX_RECIPE: 'test-recipe',
+}));
+
+// Mock migrations
+jest.mock('../migrations', () => ({
+  runMigrations: jest.fn(),
+  getCurrentVersion: jest.fn(),
+  CURRENT_SCHEMA_VERSION: 1,
+}));
+
+describe('DatabaseConnection', () => {
+  let mockDb: SqliteDatabase;
+  let mockBackend: SqliteBackend;
+
+  beforeEach(() => {
+    mockDb = {
+      pragma: jest.fn(),
+      exec: jest.fn(),
+      prepare: jest.fn().mockReturnValue({ run: jest.fn(), get: jest.fn() }),
+      transaction: jest.fn((fn) => () => fn()),
+      close: jest.fn(),
+      open: true,
+    } as unknown as SqliteDatabase;
+
+    mockBackend = {
+      type: 'mock',
+    } as SqliteBackend;
+
+    (createDatabase as jest.Mock).mockReturnValue({ db: mockDb, backend: mockBackend });
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (path.dirname as jest.Mock).mockReturnValue('/tmp');
+    (path.join as jest.Mock).mockReturnValue('/tmp/test.db');
+    (fs.readFileSync as jest.Mock).mockReturnValue('SQL SCHEMA');
+    (fs.statSync as jest.Mock).mockReturnValue({ size: 1024 });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('initialize', () => {
+    it('should initialize a new database and set busy_timeout', () => {
+      const dbPath = '/tmp/test.db';
+      const conn = DatabaseConnection.initialize(dbPath);
+
+      expect(fs.existsSync).toHaveBeenCalledWith('/tmp');
+      expect(fs.mkdirSync).not.toHaveBeenCalled(); // Directory exists
+      expect(createDatabase).toHaveBeenCalledWith(dbPath);
+      expect(mockDb.pragma).toHaveBeenCalledWith('foreign_keys = ON');
+      expect(mockDb.pragma).toHaveBeenCalledWith('journal_mode = WAL');
+      expect(mockDb.pragma).toHaveBeenCalledWith('busy_timeout = 300000');
+      expect(mockDb.exec).toHaveBeenCalledWith('SQL SCHEMA');
+      expect(conn).toBeInstanceOf(DatabaseConnection);
+    });
+
+    it('should create directory if it does not exist', () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+      const dbPath = '/tmp/test.db';
+      DatabaseConnection.initialize(dbPath);
+      expect(fs.mkdirSync).toHaveBeenCalledWith('/tmp', { recursive: true });
+    });
+  });
+
+  describe('open', () => {
+    it('should open an existing database and set busy_timeout', () => {
+      const dbPath = '/tmp/test.db';
+      const conn = DatabaseConnection.open(dbPath);
+
+      expect(fs.existsSync).toHaveBeenCalledWith(dbPath);
+      expect(createDatabase).toHaveBeenCalledWith(dbPath);
+      expect(mockDb.pragma).toHaveBeenCalledWith('foreign_keys = ON');
+      expect(mockDb.pragma).toHaveBeenCalledWith('journal_mode = WAL');
+      expect(mockDb.pragma).toHaveBeenCalledWith('busy_timeout = 300000');
+      expect(conn).toBeInstanceOf(DatabaseConnection);
+    });
+
+    it('should throw error if database not found', () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+      const dbPath = '/tmp/nonexistent.db';
+      expect(() => DatabaseConnection.open(dbPath)).toThrowError(`Database not found: ${dbPath}`);
+    });
+  });
+
+  describe('getDb', () => {
+    it('should return the underlying database instance', () => {
+      const conn = DatabaseConnection.initialize('/tmp/test.db');
+      expect(conn.getDb()).toBe(mockDb);
+    });
+  });
+
+  describe('getBackend', () => {
+    it('should return the backend instance', () => {
+      const conn = DatabaseConnection.initialize('/tmp/test.db');
+      expect(conn.getBackend()).toBe(mockBackend);
+    });
+  });
+
+  describe('getPath', () => {
+    it('should return the database path', () => {
+      const dbPath = '/tmp/test.db';
+      const conn = DatabaseConnection.initialize(dbPath);
+      expect(conn.getPath()).toBe(dbPath);
+    });
+  });
+
+  describe('transaction', () => {
+    it('should execute a function within a transaction', () => {
+      const conn = DatabaseConnection.initialize('/tmp/test.db');
+      const mockFn = jest.fn(() => 'result');
+      const result = conn.transaction(mockFn);
+      expect(mockDb.transaction).toHaveBeenCalledWith(mockFn);
+      expect(result).toBe('result');
+    });
+  });
+
+  describe('getSize', () => {
+    it('should return the database file size', () => {
+      const conn = DatabaseConnection.initialize('/tmp/test.db');
+      expect(conn.getSize()).toBe(1024);
+      expect(fs.statSync).toHaveBeenCalledWith('/tmp/test.db');
+    });
+  });
+
+  describe('optimize', () => {
+    it('should execute VACUUM and ANALYZE', () => {
+      const conn = DatabaseConnection.initialize('/tmp/test.db');
+      conn.optimize();
+      expect(mockDb.exec).toHaveBeenCalledWith('VACUUM');
+      expect(mockDb.exec).toHaveBeenCalledWith('ANALYZE');
+    });
+  });
+
+  describe('close', () => {
+    it('should close the database connection', () => {
+      const conn = DatabaseConnection.initialize('/tmp/test.db');
+      conn.close();
+      expect(mockDb.close).toHaveBeenCalled();
+    });
+  });
+
+  describe('isOpen', () => {
+    it('should return true if database is open', () => {
+      const conn = DatabaseConnection.initialize('/tmp/test.db');
+      expect(conn.isOpen()).toBe(true);
+    });
+
+    it('should return false if database is closed', () => {
+      mockDb.open = false;
+      const conn = DatabaseConnection.initialize('/tmp/test.db');
+      expect(conn.isOpen()).toBe(false);
+    });
+  });
+
+  describe('getDatabasePath', () => {
+    it('should return the correct database path', () => {
+      (path.join as jest.Mock).mockReturnValue('/project/root/.codegraph/codegraph.db');
+      const projectRoot = '/project/root';
+      const result = getDatabasePath(projectRoot);
+      expect(path.join).toHaveBeenCalledWith(projectRoot, '.codegraph', DATABASE_FILENAME);
+      expect(result).toBe('/project/root/.codegraph/codegraph.db');
+    });
+  });
+});

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -42,9 +42,9 @@ export class DatabaseConnection {
     // Enable foreign keys and WAL mode for better performance
     db.pragma('foreign_keys = ON');
     db.pragma('journal_mode = WAL');
-    // Wait up to 2 minutes if database is locked by another process
+    // Wait up to 5 minutes if database is locked by another process
     // (indexing operations can hold locks for extended periods)
-    db.pragma('busy_timeout = 120000');
+    db.pragma('busy_timeout = 300000'); // Increased from 120000
     // Performance tuning
     db.pragma('synchronous = NORMAL');     // Safe with WAL mode
     db.pragma('cache_size = -64000');      // 64 MB page cache
@@ -80,17 +80,16 @@ export class DatabaseConnection {
     // Enable foreign keys and WAL mode
     db.pragma('foreign_keys = ON');
     db.pragma('journal_mode = WAL');
-    // Wait up to 2 minutes if database is locked by another process
+    // Wait up to 5 minutes if database is locked by another process
     // (indexing operations can hold locks for extended periods)
-    db.pragma('busy_timeout = 120000');
+    db.pragma('busy_timeout = 300000'); // Increased from 120000
     // Performance tuning
     db.pragma('synchronous = NORMAL');
     db.pragma('cache_size = -64000');
     db.pragma('temp_store = MEMORY');
     db.pragma('mmap_size = 268435456');
 
-    // Check and run migrations if needed
-    const conn = new DatabaseConnection(db, dbPath, backend);
+    // Check and run migrations if needed\n    const conn = new DatabaseConnection(db, dbPath, backend);
     const currentVersion = getCurrentVersion(db);
 
     if (currentVersion < CURRENT_SCHEMA_VERSION) {
@@ -109,8 +108,7 @@ export class DatabaseConnection {
 
   /**
    * Get the SQLite backend serving this connection. Per-instance so
-   * MCP cross-project queries report the right backend even when
-   * multiple project DBs are open in the same process.
+   * MCP cross-project queries report the right backend even when\n   * multiple project DBs are open in the same process.
    */
   getBackend(): SqliteBackend {
     return this.backend;


### PR DESCRIPTION
Fixes #238. Increased SQLite busy_timeout from 2 minutes (120000ms) to 5 minutes (300000ms) in src/db/index.ts to provide more buffer for concurrent read operations, especially when the WASM fallback is active and WAL mode is not available.

### Test Plan
- Unit tests have been added in `src/db/__tests__/index.test.ts`.
- The tests cover the `initialize` and `open` methods of `DatabaseConnection` to verify `busy_timeout` is set to 300000ms.
- Basic functionality of `DatabaseConnection` class such as `getDb`, `getPath`, `isOpen`, `close`, `transaction`, `getSize`, and `optimize` are also covered by unit tests.