### PR TITLE
feat: support antigravity target in installer

### DIFF
--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -1571,7 +1571,7 @@ program
  */
 program
   .command('install')
-  .description('Install codegraph MCP server into one or more agents (Claude Code, Cursor, Codex CLI, opencode, Hermes Agent)')
+  .description('Install codegraph MCP server into one or more agents (Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE)')
   .option('-t, --target <ids>', 'Target agent(s): comma-separated ids, or "auto"|"all"|"none". Default: prompt')
   .option('-l, --location <where>', 'Install location: "global" or "local". Default: prompt')
   .option('-y, --yes', 'Non-interactive: defaults to --location=global --target=auto, auto-allow on')


### PR DESCRIPTION


<img width="2558" height="670" alt="image" src="https://github.com/user-attachments/assets/ff2230a8-f161-4c8e-8cbd-8744967fc89e" />



This PR adds support for **antigravity IDE 2.0 / antigravity cli** (referred to as `antigravity`) as an installation target. 

> [!NOTE]
> This target configuration is supported starting from Antigravity version 5.20 (released around May 20th). It specifically targets **Antigravity 2.0**, **Antigravity IDE**, and **Antigravity Cli**. Older legacy versions of Antigravity do not support this configuration format. For more details, see [Antigravity Downloads](https://antigravity.google/download).

### Why this is needed
Modern versions of `antigravity` configure their MCP servers globally via `~/.gemini/config/mcp_config.json` and agent instructions via `~/.gemini/config/AGENTS.md`.

### MCP Config Specification
Unlike some other targets, `antigravity` expects its MCP server configuration in a specific JSON shape without a `"type"` property, but retaining an empty `"env"` block:
```json
{
  "mcpServers": {
    "codegraph": {
      "command": "codegraph",
      "args": [
        "serve",
        "--mcp"
      ],
      "env": {}
    }
  }
}