### PR TITLE
RHEL/Fedora development tools install with recent dnf version

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,8 @@ The `.codegraph/config.json` file controls indexing:
 
   # Linux (RHEL / Fedora)
   sudo yum groupinstall "Development Tools"
+  # with dnf5
+  sudo dnf group install "development-tools"
 
   # Then rebuild on any platform:
   npm rebuild better-sqlite3


### PR DESCRIPTION
Added instructions for installing development tools using dnf v5 (Fedora 44 for instance), as `yum groupinstall` is not available anymore.