### PR TITLE
fix(config): validate languages from shared registry

### DIFF
--- a/__tests__/foundation.test.ts
+++ b/__tests__/foundation.test.ts
@@ -9,8 +9,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { CodeGraph } from '../src';
-import { DEFAULT_CONFIG, Node, Edge } from '../src/types';
-import { loadConfig, saveConfig } from '../src/config';
+import { DEFAULT_CONFIG, LANGUAGES } from '../src/types';
+import { loadConfig, saveConfig, validateConfig } from '../src/config';
 import { isInitialized, getCodeGraphDir, validateDirectory } from '../src/directory';
 import { DatabaseConnection, getDatabasePath } from '../src/db';
 
@@ -190,6 +190,28 @@ describe('CodeGraph Foundation', () => {
       const config = loadConfig(tempDir);
       expect(config.version).toBe(DEFAULT_CONFIG.version);
       expect(config.rootDir).toBe(path.resolve(tempDir));
+    });
+
+    it('should validate every supported language from the shared registry', () => {
+      for (const language of LANGUAGES) {
+        expect(
+          validateConfig({
+            ...DEFAULT_CONFIG,
+            rootDir: tempDir,
+            languages: [language],
+          })
+        ).toBe(true);
+      }
+    });
+
+    it('should reject unknown languages', () => {
+      expect(
+        validateConfig({
+          ...DEFAULT_CONFIG,
+          rootDir: tempDir,
+          languages: ['not-a-language'],
+        })
+      ).toBe(false);
     });
 
     it('should update configuration', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import picomatch from 'picomatch';
-import { CodeGraphConfig, DEFAULT_CONFIG, Language, NodeKind } from './types';
+import { CodeGraphConfig, DEFAULT_CONFIG, LANGUAGES, Language, NodeKind } from './types';
 import { normalizePath } from './utils';
 
 /**
@@ -72,18 +72,7 @@ export function validateConfig(config: unknown): config is CodeGraphConfig {
   if (!c.include.every((p) => typeof p === 'string')) return false;
   if (!c.exclude.every((p) => typeof p === 'string')) return false;
 
-  // Validate languages
-  const validLanguages: Language[] = [
-    'typescript',
-    'javascript',
-    'python',
-    'go',
-    'rust',
-    'java',
-    'svelte',
-    'unknown',
-  ];
-  if (!c.languages.every((l) => validLanguages.includes(l as Language))) return false;
+  if (!c.languages.every((l) => LANGUAGES.includes(l as Language))) return false;
 
   // Validate frameworks
   for (const fw of c.frameworks) {


### PR DESCRIPTION
## Summary
- replace the stale hard-coded language allowlist in `validateConfig` with the shared `LANGUAGES` registry
- add regression coverage that every registered language validates and unknown languages are still rejected

## Why
`LANGUAGES` already includes languages such as `tsx`, `jsx`, `c`, `cpp`, `csharp`, `vue`, `liquid`, `pascal`, and `scala`, but `validateConfig` had a smaller local allowlist. A user config that explicitly listed one of those supported languages could be rejected as invalid.

## Test plan
- [x] `npm test -- --run __tests__/foundation.test.ts -t "supported language|unknown languages"`
- [x] `npm test -- --run __tests__/foundation.test.ts`
- [x] `npm run build`
- [x] `npm test`