### PR TITLE
ci: add GitHub Actions build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x, 24.x]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Audit critical vulnerabilities
+        run: npm audit --audit-level=critical


### PR DESCRIPTION
## Summary
- add a CI workflow for pull requests and pushes to `main`
- run `npm ci`, `npm run build`, and `npm test` on Node 20.x, 22.x, and 24.x, matching the package engine range
- include a critical-level audit gate without failing on the current moderate/high advisory baseline

## Why
The repository has a strong local test suite, but no checked-in GitHub Actions workflow. This gives maintainers and contributors a repeatable PR gate across supported Node versions.

## Test plan
- [x] `git diff --check`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm audit --audit-level=critical`