### PR TITLE
fix(npm-shim): spawn bundled node directly to avoid Windows .cmd EINVAL

### DIFF
--- a/__tests__/npm-shim.test.ts
+++ b/__tests__/npm-shim.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression test for scripts/npm-shim.js.
+ *
+ * Background: Node's CVE-2024-27980 mitigation forbids spawning .cmd/.bat
+ * launchers without `shell: true`. The shim previously resolved the platform
+ * package's `bin/codegraph.cmd` and called spawnSync on it, which returned
+ * EINVAL on Windows before any CLI logic ran.
+ *
+ * This test stands up a minimal platform-package fixture (the bundled
+ * node binary + lib/dist/bin/codegraph.js + the legacy wrapper launcher)
+ * and verifies the shim launches it cleanly with arguments forwarded.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const SHIM = path.resolve(__dirname, '..', 'scripts', 'npm-shim.js');
+
+function makeFixture(): { tmp: string; shim: string } {
+  const target = `${process.platform}-${process.arch}`;
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-shim-'));
+  const pkgRoot = path.join(tmp, 'node_modules', '@colbymchenry', `codegraph-${target}`);
+  fs.mkdirSync(path.join(pkgRoot, 'lib', 'dist', 'bin'), { recursive: true });
+  fs.mkdirSync(path.join(pkgRoot, 'bin'), { recursive: true });
+
+  // Bundled Node binary — reuse the current process's node so the fixture is
+  // a real, executable binary at the expected path.
+  const nodeName = process.platform === 'win32' ? 'node.exe' : 'node';
+  fs.copyFileSync(process.execPath, path.join(pkgRoot, nodeName));
+  if (process.platform !== 'win32') {
+    fs.chmodSync(path.join(pkgRoot, nodeName), 0o755);
+  }
+
+  // The script the bundled node should run.
+  fs.writeFileSync(
+    path.join(pkgRoot, 'lib', 'dist', 'bin', 'codegraph.js'),
+    "process.stdout.write('SHIM_OK:' + JSON.stringify(process.argv.slice(2)));"
+  );
+
+  // Legacy wrappers — kept so the *unfixed* shim can still find them and
+  // exhibit the EINVAL regression rather than failing earlier at resolution.
+  if (process.platform === 'win32') {
+    fs.writeFileSync(
+      path.join(pkgRoot, 'bin', 'codegraph.cmd'),
+      '@"%~dp0..\\node.exe" "%~dp0..\\lib\\dist\\bin\\codegraph.js" %*\r\n'
+    );
+  } else {
+    const sh = path.join(pkgRoot, 'bin', 'codegraph');
+    fs.writeFileSync(sh, '#!/bin/sh\nexec "$(dirname "$0")/../node" "$(dirname "$0")/../lib/dist/bin/codegraph.js" "$@"\n');
+    fs.chmodSync(sh, 0o755);
+  }
+
+  fs.writeFileSync(
+    path.join(pkgRoot, 'package.json'),
+    JSON.stringify({ name: `@colbymchenry/codegraph-${target}`, version: '0.0.0' })
+  );
+
+  // Copy the shim into the fixture root so require.resolve walks the
+  // fixture's node_modules tree, finding our fake platform package.
+  const shim = path.join(tmp, 'npm-shim.js');
+  fs.copyFileSync(SHIM, shim);
+
+  return { tmp, shim };
+}
+
+describe('npm-shim launcher', () => {
+  it('launches the bundled node and forwards arguments without invoking the .cmd/.sh wrapper', () => {
+    const { tmp, shim } = makeFixture();
+    try {
+      const res = spawnSync(process.execPath, [shim, 'install', '--target=hermes', '--yes'], {
+        encoding: 'utf8',
+        cwd: tmp,
+      });
+
+      // The actual regression: on Windows, spawnSync on .cmd without
+      // shell:true returns EINVAL inside the shim. The shim catches it and
+      // exits 1 after printing the spawn error to stderr. A clean launch
+      // exits 0 with the inner script's stdout intact.
+      expect(res.stderr).not.toMatch(/EINVAL/);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toBe('SHIM_OK:["install","--target=hermes","--yes"]');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/npm-shim.js
+++ b/scripts/npm-shim.js
@@ -19,11 +19,20 @@ var childProcess = require('child_process');
 
 var target = process.platform + '-' + process.arch; // e.g. darwin-arm64, linux-x64
 var pkg = '@colbymchenry/codegraph-' + target;
-var launcher = process.platform === 'win32' ? 'bin/codegraph.cmd' : 'bin/codegraph';
 
-var binPath;
+// Invoke the bundled Node binary directly instead of the platform package's
+// bin/codegraph[.cmd] wrapper. Node's CVE-2024-27980 mitigation refuses to
+// spawn .cmd/.bat files without `shell: true`, so spawning the .cmd launcher
+// on Windows returned EINVAL before any CLI logic could run. The wrappers
+// themselves just exec `<pkg>/node[.exe] <pkg>/lib/dist/bin/codegraph.js`, so
+// we bypass them entirely.
+var nodeBin = process.platform === 'win32' ? 'node.exe' : 'node';
+var entryScript = 'lib/dist/bin/codegraph.js';
+
+var nodePath, scriptPath;
 try {
-  binPath = require.resolve(pkg + '/' + launcher);
+  nodePath = require.resolve(pkg + '/' + nodeBin);
+  scriptPath = require.resolve(pkg + '/' + entryScript);
 } catch (e) {
   process.stderr.write(
     'codegraph: no prebuilt bundle for ' + target + '.\n' +
@@ -35,7 +44,11 @@ try {
   process.exit(1);
 }
 
-var res = childProcess.spawnSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
+var res = childProcess.spawnSync(
+  nodePath,
+  [scriptPath].concat(process.argv.slice(2)),
+  { stdio: 'inherit' }
+);
 if (res.error) {
   process.stderr.write('codegraph: ' + res.error.message + '\n');
   process.exit(1);


### PR DESCRIPTION
## Summary

On Windows, `npx @colbymchenry/codegraph <anything>` (and any `codegraph` invocation from a globally-installed 0.9.x) fails with:

```
codegraph: spawnSync C:\Users\<u>\AppData\Roaming\npm\node_modules\@colbymchenry\codegraph\node_modules\@colbymchenry\codegraph-win32-x64\bin\codegraph.cmd EINVAL
```

before any CLI logic runs. Root cause is Node's CVE-2024-27980 mitigation, which refuses to spawn `.cmd`/`.bat` launchers without `shell: true`. `scripts/npm-shim.js` resolved the platform package's `bin/codegraph.cmd` and called `spawnSync` on it directly, so every Windows user on a current Node (≥ 18.20.2 / 20.12.2 / 21.7.3 / 22.x) hit `EINVAL` immediately.

The platform-package launchers are trivial wrappers:

- Windows `bin/codegraph.cmd` — `@"%~dp0..\node.exe" "%~dp0..\lib\dist\bin\codegraph.js" %*`
- Unix `bin/codegraph` — `exec "$DIR/node" "$DIR/lib/dist/bin/codegraph.js" "$@"`

So the shim can resolve and spawn the bundled `node[.exe]` binary directly with `lib/dist/bin/codegraph.js`, bypassing the wrapper entirely. Same end result on macOS/Linux, fixes Windows.

## Changes

- `scripts/npm-shim.js` — resolve `<pkg>/node[.exe]` + `<pkg>/lib/dist/bin/codegraph.js` and `spawnSync(node, [script, ...args])` instead of resolving the `.cmd`/`.sh` wrapper. Error message for the \"no prebuilt bundle\" case unchanged.
- `__tests__/npm-shim.test.ts` (new) — regression test that stands up a minimal platform-package fixture and invokes the shim.

## Verification

### Environment

- OS: Windows 11 Home 10.0.26200
- Node: v24.15.0
- Reproduced against published `@colbymchenry/codegraph@0.9.1` and on this branch's local source.

### 1. User-reported repro against published 0.9.1

```
> npx @colbymchenry/codegraph install --target=hermes --location=global --yes
codegraph: spawnSync C:\Users\tmdgu\AppData\Roaming\npm\node_modules\@colbymchenry\codegraph\node_modules\@colbymchenry\codegraph-win32-x64\bin\codegraph.cmd EINVAL
```

Exit code: 1. The shim's outer `spawnSync` returns `res.error` with `EINVAL`, the shim writes the error to stderr and exits 1, no CLI code runs.

### 2. Failing regression test BEFORE the fix

`__tests__/npm-shim.test.ts` creates a tmp fixture at `<tmp>/node_modules/@colbymchenry/codegraph-<platform>-<arch>/` containing:

- a real bundled `node[.exe]` (copy of `process.execPath`)
- `lib/dist/bin/codegraph.js` that prints `SHIM_OK:<args>`
- the legacy `bin/codegraph.cmd` (Windows) / `bin/codegraph` (Unix) wrapper so the *unfixed* shim resolves to it and exhibits the EINVAL rather than failing earlier

Then copies `scripts/npm-shim.js` into the fixture root and runs it. With the original shim:

\`\`\`
FAIL  __tests__/npm-shim.test.ts > npm-shim launcher > launches the bundled node and forwards arguments without invoking the .cmd/.sh wrapper
AssertionError: expected 'codegraph: spawnSync C:\Users\tmdgu\A…' not to match /EINVAL/

- Expected: /EINVAL/
+ Received: \"codegraph: spawnSync C:\\Users\\tmdgu\\AppData\\Local\\Temp\\codegraph-shim-GepP8j\\node_modules\\@colbymchenry\\codegraph-win32-x64\\bin\\codegraph.cmd EINVAL\n\"

Test Files  1 failed (1)
     Tests  1 failed (1)
\`\`\`

This reproduces the user-visible error at the test level — same EINVAL message, same path shape.

### 3. Same test PASSES after the fix

\`\`\`
✓ __tests__/npm-shim.test.ts (1 test) 1805ms
  ✓ npm-shim launcher > launches the bundled node and forwards arguments without invoking the .cmd/.sh wrapper 1805ms

Test Files  1 passed (1)
     Tests  1 passed (1)
\`\`\`

Inner script receives args verbatim — assertion checks `stdout === 'SHIM_OK:[\"install\",\"--target=hermes\",\"--yes\"]'`.

### 4. No regression in adjacent installer tests

\`\`\`
✓ __tests__/installer.test.ts          (8 tests)   22ms
✓ __tests__/installer-targets.test.ts  (74 tests)  187ms
✓ __tests__/npm-shim.test.ts           (1 test)    1734ms

Test Files  3 passed (3)
     Tests  83 passed (83)
\`\`\`

## Notes for reviewers

- The fix preserves the shim's invariant that the user's own Node only acts as a launcher — the real work still runs under the bundled Node 24 because we resolve and execute `<pkg>/node[.exe]`, not the user's interpreter.
- `require.resolve(pkg + '/node.exe')` and `require.resolve(pkg + '/node')` both work because the platform packages publish these files at the package root (verified by `npm pack @colbymchenry/codegraph-win32-x64@0.9.1` and `@colbymchenry/codegraph-linux-x64@0.9.1`).
- Test fixture also drops the legacy `.cmd`/`.sh` wrapper so the test asserts the new shim deliberately ignores it. If a future change re-introduces the wrapper codepath on Windows, this test will fail again.
- No changes to `package.json`, `optionalDependencies`, or the platform package layout. Drop-in shim replacement.