### PR TITLE
fix: add shell: true to spawnSync on Windows for .cmd launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,13 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   exports are gone. Existing `.codegraph/config.json` files are simply ignored.
   The `.codegraphignore` marker is no longer supported — use `.gitignore`.
 
+### Fixed
+- **Windows `EINVAL` via npm/npx.** The thin-installer shim used `spawnSync` to
+  launch the bundled `codegraph.cmd` on Windows, which throws `EINVAL` when
+  `shell: true` is omitted (Node.js requires a shell to execute `.cmd` batch
+  files). Windows installs via `npm i -g` or `npx` now work. Resolves
+  [#289](https://github.com/colbymchenry/codegraph/issues/289).
+
 ## [0.9.1] - 2026-05-21
 
 ### Fixed

--- a/scripts/npm-shim.js
+++ b/scripts/npm-shim.js
@@ -35,7 +35,7 @@ try {
   process.exit(1);
 }
 
-var res = childProcess.spawnSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
+var res = childProcess.spawnSync(binPath, process.argv.slice(2), { stdio: 'inherit', shell: process.platform === 'win32' });
 if (res.error) {
   process.stderr.write('codegraph: ' + res.error.message + '\n');
   process.exit(1);


### PR DESCRIPTION
Node.js `spawnSync` requires `shell: true` when executing `.cmd` batch files on Windows; without it the npm thin-installer shim throws `EINVAL` when running `codegraph -v` (or any command) via `npm i -g` or `npx`.

Fixes #289