### PR TITLE
ci: bump checkout/setup-node to v6 (Node 24 runtime)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
The Release workflow emits a deprecation warning during runs:

> Node.js 20 actions are deprecated. … actions/checkout@v4, actions/setup-node@v4 … Node.js 24 will be forced by default starting June 2nd, 2026. Node.js 20 will be removed on September 16th, 2026.

Bumps both to `@v6`, which run on Node 24. No config change — `node-version: 22` and `registry-url` are supported in v6, and these are the only `@v4` action pins in the repo (release.yml only). Verified the v6 tags exist (checkout v6.0.2, setup-node v6.4.0).

Non-blocking — the 0.9.2 release succeeded; this just clears the warning and future-proofs CI before the June 2026 forced cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)