### PR TITLE
Cap codegraph_context MCP output

### DIFF
--- a/__tests__/security.test.ts
+++ b/__tests__/security.test.ts
@@ -239,6 +239,20 @@ describe('MCP Input Validation', () => {
     expect(result.content[0].text).toContain('non-empty string');
   });
 
+  it('should truncate oversized codegraph_context output', async () => {
+    const oversizedContext = Array.from({ length: 400 }, (_, i) => `line-${i} ${'x'.repeat(80)}`).join('\n');
+    const fakeCg = {
+      buildContext: async () => oversizedContext,
+    };
+    const fakeHandler = new ToolHandler(fakeCg as unknown as CodeGraph);
+
+    const result = await fakeHandler.execute('codegraph_context', { task: 'find example' });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text.length).toBeLessThan(oversizedContext.length);
+    expect(result.content[0].text).toContain('... (output truncated)');
+  });
+
   it('should reject non-string symbol in codegraph_impact', async () => {
     const result = await handler.execute('codegraph_impact', { symbol: [] });
     expect(result.isError).toBe(true);

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -706,11 +706,11 @@ export class ToolHandler {
 
     // buildContext returns string when format is 'markdown'
     if (typeof context === 'string') {
-      return this.textResult(context + reminder);
+      return this.textResult(this.truncateOutput(context + reminder));
     }
 
     // If it returns TaskContext, format it
-    return this.textResult(this.formatTaskContext(context) + reminder);
+    return this.textResult(this.truncateOutput(this.formatTaskContext(context) + reminder));
   }
 
   /**


### PR DESCRIPTION
## Summary

I'm an AI agent helping triage MCP/Codex integration pain points. This is a small defensive fix related to #295.

`codegraph_context` was the only large MCP context path that returned its formatted payload without passing through `truncateOutput()`. Other tool paths such as search, callers/callees, impact, node, and files already apply the shared 15k-character cap.

This PR routes `codegraph_context` responses through that same cap for both markdown-string and structured-context fallback outputs. If Codex CLI is hanging while ingesting a large `codegraph_context` response during `/review`, this limits the blast radius on the server side. It may not be the whole Codex-side root cause, but it is a bounded guardrail.

## Tests

- `npm test -- --run __tests__/security.test.ts`
- `npm exec -- tsc --noEmit`
