### PR TITLE
docs: sync MCP tool listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ npm install -g @colbymchenry/codegraph
       "mcp__codegraph__codegraph_callees",
       "mcp__codegraph__codegraph_impact",
       "mcp__codegraph__codegraph_node",
+      "mcp__codegraph__codegraph_explore",
       "mcp__codegraph__codegraph_status",
       "mcp__codegraph__codegraph_files"
     ]
@@ -387,6 +388,7 @@ When running as an MCP server, CodeGraph exposes these tools to Claude Code:
 | `codegraph_callees` | Find what a function calls |
 | `codegraph_impact` | Analyze what code is affected by changing a symbol |
 | `codegraph_node` | Get details about a specific symbol (optionally with source code) |
+| `codegraph_explore` | Explore source for several related symbols in one capped call |
 | `codegraph_files` | Get indexed file structure (faster than filesystem scanning) |
 | `codegraph_status` | Check index health and statistics |
 

--- a/__tests__/tool-list-consistency.test.ts
+++ b/__tests__/tool-list-consistency.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '..');
+const MCP_TOOLS = [
+  'codegraph_search',
+  'codegraph_context',
+  'codegraph_callers',
+  'codegraph_callees',
+  'codegraph_impact',
+  'codegraph_node',
+  'codegraph_explore',
+  'codegraph_files',
+  'codegraph_status',
+];
+
+describe('MCP tool list docs stay in sync', () => {
+  it('serve help lists every MCP tool named in the README table', () => {
+    const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf-8');
+    const cli = fs.readFileSync(path.join(repoRoot, 'src/bin/codegraph.ts'), 'utf-8');
+
+    const table = readme.match(/## MCP Tools[\s\S]*?\| `codegraph_search`[\s\S]*?\| `codegraph_status`[^\n]*\n/);
+    expect(table).not.toBeNull();
+
+    const helpBlock = cli.match(/console\.error\('Available tools:'\);[\s\S]*?\n      \}/);
+    expect(helpBlock).not.toBeNull();
+
+    for (const tool of MCP_TOOLS) {
+      expect(table![0]).toContain(`\`${tool}\``);
+      expect(helpBlock![0]).toContain(`  ${tool}`);
+    }
+  });
+
+  it('Claude permission example covers every README-listed MCP tool', () => {
+    const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf-8');
+
+    const permissionBlock = readme.match(/"allow": \[[\s\S]*?\]/);
+    expect(permissionBlock).not.toBeNull();
+
+    const table = readme.match(/## MCP Tools[\s\S]*?\| `codegraph_search`[\s\S]*?\| `codegraph_status`[^\n]*\n/);
+    expect(table).not.toBeNull();
+
+    for (const tool of MCP_TOOLS) {
+      expect(table![0]).toContain(`\`${tool}\``);
+      expect(permissionBlock![0]).toContain(`mcp__codegraph__${tool}`);
+    }
+  });
+});

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -1159,6 +1159,7 @@ program
         console.error(chalk.cyan('  codegraph_callees') + '   - Find what a symbol calls');
         console.error(chalk.cyan('  codegraph_impact') + '    - Analyze impact of changes');
         console.error(chalk.cyan('  codegraph_node') + '      - Get symbol details');
+        console.error(chalk.cyan('  codegraph_explore') + '   - Explore related source');
         console.error(chalk.cyan('  codegraph_files') + '     - Get project file structure');
         console.error(chalk.cyan('  codegraph_status') + '    - Get index status');
       }


### PR DESCRIPTION
## Summary
- Add `codegraph_explore` to the README MCP tools table and Claude permission example.
- Include `codegraph_explore` in the non-MCP `codegraph serve` help output.
- Add a consistency test so README tool listings, the permission example, and CLI help stay aligned.

## Test plan
- `npm test -- __tests__/tool-list-consistency.test.ts`
- `npm run build`
- `npm test -- __tests__/mcp-initialize.test.ts __tests__/mcp-roots.test.ts __tests__/watcher.test.ts`
- `npm test` was attempted after build; the relevant tests passed, but the full suite hit a local Node 24 V8 WASM OOM and one watcher timeout during the all-files run.