### PR TITLE
release: roll WASM Zone OOM fix into 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,6 @@ a [GitHub Release](https://github.com/colbymchenry/codegraph/releases) tagged
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.4] - 2026-05-22
-
-### Fixed
-- **`Fatal process out of memory: Zone` crash while indexing large projects.**
-  On Node.js 22 and 24 — including CodeGraph's own bundled runtime — running
-  `codegraph index` / `codegraph init` on a large multi-language repo could
-  abort the entire process partway through parsing with
-  `Fatal process out of memory: Zone`, even with tens of GB of RAM free (the
-  failure is in a V8-internal compilation arena, not the JS heap). The cause is
-  V8's "turboshaft" optimizing WASM compiler exhausting its Zone budget while
-  compiling tree-sitter's large WebAssembly grammars on a background thread.
-  CodeGraph now runs with V8's `--liftoff-only`, which keeps grammar compilation
-  on the baseline compiler and never reaches the optimizing tier, eliminating
-  the crash; indexing output is otherwise unchanged. The bundled launcher passes
-  the flag directly, and any other launch path (from source, `npx`, a globally
-  linked dev build) re-execs once with it automatically. Resolves
-  [#298](https://github.com/colbymchenry/codegraph/issues/298) and
-  [#293](https://github.com/colbymchenry/codegraph/issues/293). (Node 25 stays
-  blocked — its variant of this V8 bug is not resolved by `--liftoff-only`.)
-
 ## [0.9.3] - 2026-05-22
 
 ### Added
@@ -45,6 +25,22 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   MCP server that no longer existed.
 
 ### Fixed
+- **`Fatal process out of memory: Zone` crash while indexing large projects.**
+  On Node.js 22 and 24 — including CodeGraph's own bundled runtime — running
+  `codegraph index` / `codegraph init` on a large multi-language repo could
+  abort the entire process partway through parsing with
+  `Fatal process out of memory: Zone`, even with tens of GB of RAM free (the
+  failure is in a V8-internal compilation arena, not the JS heap). The cause is
+  V8's "turboshaft" optimizing WASM compiler exhausting its Zone budget while
+  compiling tree-sitter's large WebAssembly grammars on a background thread.
+  CodeGraph now runs with V8's `--liftoff-only`, which keeps grammar compilation
+  on the baseline compiler and never reaches the optimizing tier, eliminating
+  the crash; indexing output is otherwise unchanged. The bundled launcher passes
+  the flag directly, and any other launch path (from source, `npx`, a globally
+  linked dev build) re-execs once with it automatically. Resolves
+  [#298](https://github.com/colbymchenry/codegraph/issues/298) and
+  [#293](https://github.com/colbymchenry/codegraph/issues/293). (Node 25 stays
+  blocked — its variant of this V8 bug is not resolved by `--liftoff-only`.)
 - **Cursor uninstall left an orphaned `.cursor/rules/codegraph.mdc`.** It
   stripped the rule body but left the file and its `description: CodeGraph …`
   frontmatter behind. The dedicated rules file is now deleted outright on
@@ -136,7 +132,6 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   find its bundle. The release pipeline now verifies every package reached the
   registry (and is idempotent), so a release can't pass green-but-broken again.
 
-[0.9.4]: https://github.com/colbymchenry/codegraph/releases/tag/v0.9.4
 [0.9.3]: https://github.com/colbymchenry/codegraph/releases/tag/v0.9.3
 [0.9.2]: https://github.com/colbymchenry/codegraph/releases/tag/v0.9.2
 [0.9.1]: https://github.com/colbymchenry/codegraph/releases/tag/v0.9.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@colbymchenry/codegraph",
-  "version": "0.9.4",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@colbymchenry/codegraph",
-      "version": "0.9.4",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colbymchenry/codegraph",
-  "version": "0.9.4",
+  "version": "0.9.3",
   "description": "Supercharge Claude Code with semantic code intelligence. 94% fewer tool calls • 77% faster exploration • 100% local.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
0.9.3 was committed to the repo but never released (latest published is 0.9.2), so this fix ships as part of **0.9.3** rather than a separate 0.9.4. Folds the `Fatal process out of memory: Zone` fix (from #322) into the existing `[0.9.3]` changelog entry and reverts the version to `0.9.3` in `package.json` / lockfile.

No code changes — the fix from #322 is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)