### PR TITLE
fix: remove dead try/catch in insertNode and fix SENSITIVE_PATHS case sensitivity

### DIFF
--- a/__tests__/security.test.ts
+++ b/__tests__/security.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { FileLock } from '../src/utils';
+import { FileLock, validateProjectPath } from '../src/utils';
 import CodeGraph from '../src/index';
 import { ToolHandler, tools } from '../src/mcp/tools';
 import { scanDirectory, isSourceFile } from '../src/extraction';
@@ -174,6 +174,36 @@ describe('Path Traversal Prevention', () => {
     const code = await cg.getCode('does-not-exist');
     expect(code).toBeNull();
   });
+});
+
+describe('validateProjectPath — sensitive directory blocking', () => {
+  // POSIX-only: on Windows '/etc' resolves to C:\etc (non-existent), not a
+  // sensitive dir — the Windows case is covered by the win32-gated test below.
+  it.runIf(process.platform !== 'win32')('blocks POSIX system directories (exact match)', () => {
+    expect(validateProjectPath('/')).toMatch(/sensitive system directory/i);
+    expect(validateProjectPath('/etc')).toMatch(/sensitive system directory/i);
+  });
+
+  it('allows a normal, existing directory', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-validate-'));
+    try {
+      expect(validateProjectPath(dir)).toBeNull();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // SENSITIVE_PATHS stores the Windows entries lowercase and validateProjectPath
+  // matches via resolved.toLowerCase(), so 'C:\\Windows' and 'c:\\windows' are
+  // both blocked. path.resolve is platform-specific, so this only runs on Windows.
+  it.runIf(process.platform === 'win32')(
+    'blocks Windows system directories regardless of case',
+    () => {
+      expect(validateProjectPath('C:\\Windows')).toMatch(/sensitive system directory/i);
+      expect(validateProjectPath('c:\\windows')).toMatch(/sensitive system directory/i);
+      expect(validateProjectPath('C:\\WINDOWS\\System32')).toMatch(/sensitive system directory/i);
+    }
+  );
 });
 
 describe('MCP Input Validation', () => {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -230,32 +230,28 @@ export class QueryBuilder {
     // deleteNode below).
     this.nodeCache.delete(node.id);
 
-    try {
-      this.stmts.insertNode.run({
-        id: node.id,
-        kind: node.kind,
-        name: node.name,
-        qualifiedName: node.qualifiedName ?? node.name,
-        filePath: node.filePath,
-        language: node.language,
-        startLine: node.startLine ?? 0,
-        endLine: node.endLine ?? 0,
-        startColumn: node.startColumn ?? 0,
-        endColumn: node.endColumn ?? 0,
-        docstring: node.docstring ?? null,
-        signature: node.signature ?? null,
-        visibility: node.visibility ?? null,
-        isExported: node.isExported ? 1 : 0,
-        isAsync: node.isAsync ? 1 : 0,
-        isStatic: node.isStatic ? 1 : 0,
-        isAbstract: node.isAbstract ? 1 : 0,
-        decorators: node.decorators ? JSON.stringify(node.decorators) : null,
-        typeParameters: node.typeParameters ? JSON.stringify(node.typeParameters) : null,
-        updatedAt: node.updatedAt ?? Date.now(),
-      });
-    } catch (error) {
-      throw error;
-    }
+    this.stmts.insertNode.run({
+      id: node.id,
+      kind: node.kind,
+      name: node.name,
+      qualifiedName: node.qualifiedName ?? node.name,
+      filePath: node.filePath,
+      language: node.language,
+      startLine: node.startLine ?? 0,
+      endLine: node.endLine ?? 0,
+      startColumn: node.startColumn ?? 0,
+      endColumn: node.endColumn ?? 0,
+      docstring: node.docstring ?? null,
+      signature: node.signature ?? null,
+      visibility: node.visibility ?? null,
+      isExported: node.isExported ? 1 : 0,
+      isAsync: node.isAsync ? 1 : 0,
+      isStatic: node.isStatic ? 1 : 0,
+      isAbstract: node.isAbstract ? 1 : 0,
+      decorators: node.decorators ? JSON.stringify(node.decorators) : null,
+      typeParameters: node.typeParameters ? JSON.stringify(node.typeParameters) : null,
+      updatedAt: node.updatedAt ?? Date.now(),
+    });
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ import * as path from 'path';
 const SENSITIVE_PATHS = new Set([
   '/', '/etc', '/usr', '/bin', '/sbin', '/var', '/tmp', '/dev', '/proc', '/sys',
   '/root', '/boot', '/lib', '/lib64', '/opt',
-  'C:\\', 'C:\\Windows', 'C:\\Windows\\System32',
+  'c:\\', 'c:\\windows', 'c:\\windows\\system32',
 ]);
 
 /**


### PR DESCRIPTION
## Changes

Two small fixes:

### 1. Remove dead try/catch in `QueryBuilder.insertNode()`

`src/db/queries.ts` — The try/catch block around `this.stmts.insertNode.run()` only re-throws the error, adding no value. Removed it to reduce noise.

```diff
- try {
-   this.stmts.insertNode.run({...});
- } catch (error) {
-   throw error;
- }
+ this.stmts.insertNode.run({...});
```

### 2. Fix `SENSITIVE_PATHS` case-sensitivity bug on Windows

`src/utils.ts` — The `SENSITIVE_PATHS` Set contained PascalCase entries (`C:\Windows`) but the comparison used `resolved.toLowerCase()`, so Windows paths would **never match** the sensitive path check.

Normalized all entries to lowercase to fix the comparison.

Both fixes are minimal, low-risk code quality improvements.