### PR TITLE
feat: add Nix flake for native Nix/NixOS installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ test-languages/
 
 nul
 release/
+
+# Nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,12 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779414690,
-        "narHash": "sha256-gOTcX/9MZVMUE0Xvb4IEcv+0TQJkZFNEnL757ljU360=",
+        "lastModified": 1779536132,
+        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6dedf69f94d03cbe7bdde106f2d4c23ae2a853bf",
+        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
         "type": "github"
       },
       "original": {
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779414690,
+        "narHash": "sha256-gOTcX/9MZVMUE0Xvb4IEcv+0TQJkZFNEnL757ljU360=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6dedf69f94d03cbe7bdde106f2d4c23ae2a853bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,83 +3,101 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      nixpkgsFor = forAllSystems (system: nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
 
-        nodejs = pkgs.nodejs_24;
+          # Node 24 — matches build-bundle.sh pin (v24.16.0).
+          # Requires node:sqlite (>=22.5), blocks 25.x (V8 turboshaft OOM).
+          nodejs = pkgs.nodejs_24;
 
-        codegraph = pkgs.buildNpmPackage {
-          pname = "codegraph";
-          version =
-            (builtins.fromJSON (builtins.readFile ./package.json)).version;
+          codegraph = pkgs.buildNpmPackage {
+            pname = "codegraph";
+            version =
+              (builtins.fromJSON (builtins.readFile ./package.json)).version;
 
-          src = ./.;
-
-          npmDeps = pkgs.fetchNpmDeps {
             src = ./.;
-            hash = "sha256-GJfqzykgrgD/KCtf8LupRw31S2cCmwGCF/0PMpzaCrk=";
-          };
 
-          inherit nodejs;
+            npmDeps = pkgs.fetchNpmDeps {
+              src = ./.;
+              # Update after package-lock.json changes:
+              #   nix run nixpkgs#prefetch-npm-deps -- package-lock.json
+              hash = "sha256-GJfqzykgrgD/KCtf8LupRw31S2cCmwGCF/0PMpzaCrk=";
+            };
 
-          npmBuildScript = "build";
+            inherit nodejs;
 
-          # The build copies .wasm + schema.sql into dist/ via the
-          # `copy-assets` npm script (called from `build`).  Nothing
-          # extra to do here.
+            npmBuildScript = "build";
 
-          installPhase = ''
-            runHook preInstall
+            # The build copies .wasm + schema.sql into dist/ via the
+            # `copy-assets` npm script (called from `build`).  Nothing
+            # extra to do here.
 
-            # Application code
-            mkdir -p $out/lib/codegraph
-            cp -r dist $out/lib/codegraph/dist
-            cp package.json $out/lib/codegraph/
+            installPhase = ''
+              runHook preInstall
 
-            # Production node_modules — prune devDependencies that the
-            # build step pulled in so the closure stays lean.
-            npm prune --omit=dev
-            find node_modules -mindepth 1 -maxdepth 1 -type d -empty -delete
-            cp -r node_modules $out/lib/codegraph/node_modules
+              # Application code
+              mkdir -p $out/lib/codegraph
+              cp -r dist $out/lib/codegraph/dist
+              cp package.json $out/lib/codegraph/
 
-            # Launcher wrapper: injects --liftoff-only so tree-sitter's
-            # large WASM grammars stay on V8's Liftoff baseline compiler
-            # and never hit the turboshaft Zone OOM (issues #293/#298).
-            mkdir -p $out/bin
-            cat > $out/bin/codegraph <<'EOF'
+              # Production node_modules — prune devDependencies that the
+              # build step pulled in so the closure stays lean.
+              npm prune --omit=dev
+              find node_modules -mindepth 1 -maxdepth 1 -type d -empty -delete
+              cp -r node_modules $out/lib/codegraph/node_modules
+
+              # Launcher wrapper: injects --liftoff-only so tree-sitter's
+              # large WASM grammars stay on V8's Liftoff baseline compiler
+              # and never hit the turboshaft Zone OOM (issues #293/#298).
+              mkdir -p $out/bin
+              cat > $out/bin/codegraph <<'EOF'
 #!/bin/sh
 exec @node@ --liftoff-only @out@/lib/codegraph/dist/bin/codegraph.js "$@"
 EOF
-            substituteInPlace $out/bin/codegraph \
-              --replace-fail '@node@' '${nodejs}/bin/node' \
-              --replace-fail '@out@' "$out"
-            chmod +x $out/bin/codegraph
+              substituteInPlace $out/bin/codegraph \
+                --replace-fail '@node@' '${nodejs}/bin/node' \
+                --replace-fail '@out@' "$out"
+              chmod +x $out/bin/codegraph
 
-            runHook postInstall
-          '';
+              runHook postInstall
+            '';
 
-          meta = with pkgs.lib; {
-            description =
-              "Semantic code intelligence for AI agents — local-first knowledge graph over tree-sitter";
-            homepage = "https://github.com/colbymchenry/codegraph";
-            license = licenses.mit;
-            mainProgram = "codegraph";
-            platforms = platforms.unix;
+            meta = with pkgs.lib; {
+              description =
+                "Semantic code intelligence for AI agents — local-first knowledge graph over tree-sitter";
+              homepage = "https://github.com/colbymchenry/codegraph";
+              license = licenses.mit;
+              mainProgram = "codegraph";
+              platforms = platforms.unix;
+            };
           };
-        };
-      in {
-        packages = {
+        in
+        {
           default = codegraph;
           inherit codegraph;
-        };
+        });
 
-        devShells.default = pkgs.mkShell {
-          buildInputs = [ nodejs ];
-        };
-      });
+      devShells = forAllSystems (system:
+        let pkgs = nixpkgsFor.${system};
+        in {
+          default = pkgs.mkShell {
+            buildInputs = [ pkgs.nodejs_24 pkgs.prefetch-npm-deps ];
+          };
+        });
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,10 @@
             cp -r dist $out/lib/codegraph/dist
             cp package.json $out/lib/codegraph/
 
-            # Production node_modules (already populated by buildNpmPackage)
+            # Production node_modules — prune devDependencies that the
+            # build step pulled in so the closure stays lean.
+            npm prune --omit=dev
+            find node_modules -mindepth 1 -maxdepth 1 -type d -empty -delete
             cp -r node_modules $out/lib/codegraph/node_modules
 
             # Launcher wrapper: injects --liftoff-only so tree-sitter's
@@ -59,9 +62,6 @@ EOF
 
             runHook postInstall
           '';
-
-          # No native addons to build — pure JS + WASM.
-          dontNpmBuild = false;
 
           meta = with pkgs.lib; {
             description =

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,85 @@
+{
+  description = "CodeGraph – semantic code intelligence for AI agents";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        nodejs = pkgs.nodejs_24;
+
+        codegraph = pkgs.buildNpmPackage {
+          pname = "codegraph";
+          version =
+            (builtins.fromJSON (builtins.readFile ./package.json)).version;
+
+          src = ./.;
+
+          npmDeps = pkgs.fetchNpmDeps {
+            src = ./.;
+            hash = "sha256-GJfqzykgrgD/KCtf8LupRw31S2cCmwGCF/0PMpzaCrk=";
+          };
+
+          inherit nodejs;
+
+          npmBuildScript = "build";
+
+          # The build copies .wasm + schema.sql into dist/ via the
+          # `copy-assets` npm script (called from `build`).  Nothing
+          # extra to do here.
+
+          installPhase = ''
+            runHook preInstall
+
+            # Application code
+            mkdir -p $out/lib/codegraph
+            cp -r dist $out/lib/codegraph/dist
+            cp package.json $out/lib/codegraph/
+
+            # Production node_modules (already populated by buildNpmPackage)
+            cp -r node_modules $out/lib/codegraph/node_modules
+
+            # Launcher wrapper: injects --liftoff-only so tree-sitter's
+            # large WASM grammars stay on V8's Liftoff baseline compiler
+            # and never hit the turboshaft Zone OOM (issues #293/#298).
+            mkdir -p $out/bin
+            cat > $out/bin/codegraph <<'EOF'
+#!/bin/sh
+exec @node@ --liftoff-only @out@/lib/codegraph/dist/bin/codegraph.js "$@"
+EOF
+            substituteInPlace $out/bin/codegraph \
+              --replace-fail '@node@' '${nodejs}/bin/node' \
+              --replace-fail '@out@' "$out"
+            chmod +x $out/bin/codegraph
+
+            runHook postInstall
+          '';
+
+          # No native addons to build — pure JS + WASM.
+          dontNpmBuild = false;
+
+          meta = with pkgs.lib; {
+            description =
+              "Semantic code intelligence for AI agents — local-first knowledge graph over tree-sitter";
+            homepage = "https://github.com/colbymchenry/codegraph";
+            license = licenses.mit;
+            mainProgram = "codegraph";
+            platforms = platforms.unix;
+          };
+        };
+      in {
+        packages = {
+          default = codegraph;
+          inherit codegraph;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [ nodejs ];
+        };
+      });
+}


### PR DESCRIPTION
## Summary

Resolves #324 — the `curl|sh` install scripts don't work under Nix (FHS paths like `~/.local/bin` aren't on `$PATH`, and Nix's immutable store is incompatible with imperative installers).

This adds a `flake.nix` so Nix/NixOS users can install codegraph natively.

## Changes

| File | Description |
|---|---|
| `flake.nix` | Nix flake with `buildNpmPackage` derivation + dev shell |
| `flake.lock` | Auto-generated lock file (nixpkgs-unstable + flake-utils) |
| `.gitignore` | Added `result` (Nix build output symlink) |

## Details

- Uses **Node.js 24** (matching `build-bundle.sh`'s pinned `v24.16.0`)
- Wrapper injects `--liftoff-only` to prevent the V8 turboshaft WASM Zone OOM (issues #293/#298), matching the existing bundle launcher
- Supports **linux** and **darwin** on both **x86_64** and **aarch64**
- No native addons — pure JS + WASM, so builds on any platform without cross-compilation
- Includes a `devShells.default` for contributors

## Usage

```bash
# Run directly
nix run github:colbymchenry/codegraph

# Install to profile
nix profile install github:colbymchenry/codegraph

# Use in another flake / NixOS config
inputs.codegraph.url = "github:colbymchenry/codegraph";

# Development shell
nix develop github:colbymchenry/codegraph
```

## Verification

- [x] `nix build .#default` — builds successfully
- [x] `./result/bin/codegraph --version` → `0.9.3`
- [x] `./result/bin/codegraph --help` → full command list
- [x] `--liftoff-only` present in wrapper script
- [x] `nix flake check` — all systems evaluate cleanly

## Note for future releases

When `package-lock.json` changes, the `npmDepsHash` in `flake.nix` must be updated. Workflow: set hash to `""`, run `nix build`, copy the correct hash from the error.