### PR TITLE
feat(cli): extend status JSON output for CI usage

### DIFF
--- a/__tests__/sync.test.ts
+++ b/__tests__/sync.test.ts
@@ -49,6 +49,14 @@ describe('Sync Module', () => {
     });
 
     describe('getChangedFiles()', () => {
+      it('should report the most recent indexed timestamp', () => {
+        const lastIndexed = cg.getLastIndexedAt();
+
+        expect(lastIndexed).toEqual(expect.any(Number));
+        expect(lastIndexed).toBeGreaterThan(0);
+        expect(new Date(lastIndexed!).toISOString()).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      });
+
       it('should detect added files', () => {
         // Add a new file
         fs.writeFileSync(

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -247,6 +247,39 @@ function createVerboseProgress(): (progress: { phase: string; current: number; t
   };
 }
 
+function toIsoTimestamp(timestamp: number | null | undefined): string | null {
+  if (timestamp == null) {
+    return null;
+  }
+  return new Date(timestamp).toISOString();
+}
+
+async function getConfiguredAgentCount(projectPath: string): Promise<number> {
+  const previousCwd = process.cwd();
+  try {
+    if (fs.existsSync(projectPath) && fs.statSync(projectPath).isDirectory()) {
+      process.chdir(projectPath);
+    }
+
+    const { detectAll } = await import('../installer/targets/registry');
+    const configuredTargets = new Set<string>();
+
+    for (const location of ['global', 'local'] as const) {
+      for (const { target, detection } of detectAll(location)) {
+        if (detection.alreadyConfigured) {
+          configuredTargets.add(target.id);
+        }
+      }
+    }
+
+    return configuredTargets.size;
+  } catch {
+    return 0;
+  } finally {
+    process.chdir(previousCwd);
+  }
+}
+
 /**
  * Print success message
  */
@@ -693,6 +726,8 @@ program
   .option('-j, --json', 'Output as JSON')
   .action(async (pathArg: string | undefined, options: { json?: boolean }) => {
     const projectPath = resolveProjectPath(pathArg);
+    const indexPath = getCodeGraphDir(projectPath);
+    const agentCount = options.json ? await getConfiguredAgentCount(projectPath) : 0;
     // The directory the user actually ran from, before walking up to the index
     // root. Used to detect when the resolved index lives in a different git
     // working tree (e.g. a nested worktree borrowing the main checkout's index).
@@ -702,7 +737,14 @@ program
     try {
       if (!isInitialized(projectPath)) {
         if (options.json) {
-          console.log(JSON.stringify({ initialized: false, projectPath }));
+          console.log(JSON.stringify({
+            initialized: false,
+            projectPath,
+            indexPath,
+            lastIndexed: null,
+            agentCount,
+            version: packageJson.version,
+          }));
           return;
         }
         console.log(chalk.bold('\nCodeGraph Status\n'));
@@ -718,12 +760,17 @@ program
       const changes = cg.getChangedFiles();
       const backend = cg.getBackend();
       const journalMode = cg.getJournalMode();
+      const lastIndexed = toIsoTimestamp(cg.getLastIndexedAt());
 
       // JSON output mode
       if (options.json) {
         console.log(JSON.stringify({
           initialized: true,
           projectPath,
+          indexPath,
+          lastIndexed,
+          agentCount,
+          version: packageJson.version,
           fileCount: stats.fileCount,
           nodeCount: stats.nodeCount,
           edgeCount: stats.edgeCount,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1193,6 +1193,16 @@ export class QueryBuilder {
   }
 
   /**
+   * Get the most recent index timestamp across all tracked files.
+   */
+  getLastIndexedAt(): number | null {
+    const row = this.db.prepare('SELECT MAX(indexed_at) AS last_indexed_at FROM files').get() as {
+      last_indexed_at: number | null;
+    } | undefined;
+    return row?.last_indexed_at ?? null;
+  }
+
+  /**
    * Get files that need re-indexing (hash changed)
    */
   getStaleFiles(currentHashes: Map<string, string>): FileRecord[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -690,6 +690,13 @@ export class CodeGraph {
     return this.queries.getAllFiles();
   }
 
+  /**
+   * Get the most recent index timestamp across all tracked files.
+   */
+  getLastIndexedAt(): number | null {
+    return this.queries.getLastIndexedAt();
+  }
+
   // ===========================================================================
   // Graph Query Methods
   // ===========================================================================


### PR DESCRIPTION
Closes #329

## Summary
- Extends the existing `codegraph status --json` output with `indexPath`, `lastIndexed`, `agentCount`, and `version`
- Preserves existing JSON fields so current consumers keep working
- Reports uninitialized projects with the same machine-readable CI fields
- Uses a database aggregate for `lastIndexed` instead of scanning file records in the CLI

## Test plan
- `npm run build`
- `node dist/bin/codegraph.js status /tmp/codegraph-status-json-smoke --json`
- `npx vitest run __tests__/sync.test.ts` attempted locally, but this machine is on Node v20.20.0 and the suite requires Node 22.5+ for `node:sqlite`; Git-backed cases also hit sandboxed `git` spawn EPERM here