### PR TITLE
fix: resolve install.sh latest version without the GitHub API (#325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `CODEGRAPH_DOWNLOAD_BASE=<url>` to point it at your own mirror of the release
   archives; the standalone `install.sh` remains the no-Node alternative. Resolves
   [#303](https://github.com/colbymchenry/codegraph/issues/303).
+- **`install.sh` failing with `403` / "could not resolve latest version" on
+  shared or cloud hosts.** The standalone installer resolved the latest release
+  through the GitHub API, whose unauthenticated limit is 60 requests/hour per IP
+  — routinely exhausted on cloud devboxes and CI where many users share an
+  address, returning `403` (issue #325). It now resolves the version from the
+  `releases/latest` web redirect, which isn't rate-limited (and still falls back
+  to the API). `CODEGRAPH_VERSION` also accepts a bare `0.9.4` in addition to
+  `v0.9.4`. Resolves
+  [#325](https://github.com/colbymchenry/codegraph/issues/325).
 
 ## [0.9.3] - 2026-05-22
 

--- a/install.sh
+++ b/install.sh
@@ -44,12 +44,24 @@ esac
 target="${os}-${arch}"
 
 # 2. Resolve the version (latest release unless pinned).
+#
+# Resolve "latest" from the releases/latest *web* redirect, not the GitHub API:
+# the unauthenticated API is rate-limited to 60 requests/hour per IP and returns
+# 403 once exhausted — routine on shared/cloud hosts and CI (issue #325). The
+# redirect (github.com/<repo>/releases/latest -> .../releases/tag/vX.Y.Z) has no
+# such limit. Fall back to the API if the redirect can't be read.
 version="${CODEGRAPH_VERSION:-}"
+if [ -z "$version" ]; then
+  version="$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/$REPO/releases/latest" \
+    | sed -n 's#.*/releases/tag/##p')"
+fi
 if [ -z "$version" ]; then
   version="$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
     | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)"
 fi
-[ -n "$version" ] || { echo "codegraph: could not resolve latest version; set CODEGRAPH_VERSION." >&2; exit 1; }
+[ -n "$version" ] || { echo "codegraph: could not resolve latest version; set CODEGRAPH_VERSION (e.g. CODEGRAPH_VERSION=v0.9.4)." >&2; exit 1; }
+# Release tags are vX.Y.Z; accept a bare X.Y.Z in CODEGRAPH_VERSION too.
+case "$version" in v*) ;; *) version="v$version" ;; esac
 
 # 3. Download + extract the bundle.
 url="https://github.com/$REPO/releases/download/$version/codegraph-${target}.tar.gz"


### PR DESCRIPTION
## Problem

On shared/cloud hosts (the reporter is on `root@devbox`), `install.sh` fails with `curl: (22) 403` → `could not resolve latest version` (#325). It resolved the latest release through `api.github.com`, and GitHub's **unauthenticated API is rate-limited to 60 requests/hour per IP** — easily exhausted where many users share an address — returning 403.

(The `no prebuilt bundle for linux-x64` in the same screenshot is #303, already fixed in #335; this PR covers the `install.sh` half.)

## Fix

- Resolve "latest" from the `releases/latest` **web redirect** (`github.com/<repo>/releases/latest` → `Location: .../tag/vX.Y.Z`) instead of the API — no token, no rate limit. Falls back to the API if the redirect can't be read.
- Normalize `CODEGRAPH_VERSION` so a bare `0.9.4` works as well as `v0.9.4` (the release-tag form). The reporter's `CODEGRAPH_VERSION=0.9.3` wouldn't have matched the `v0.9.3` tag even if it had been passed through.

## Validation

End-to-end on darwin-arm64 into temp dirs (`CODEGRAPH_INSTALL_DIR`/`CODEGRAPH_BIN_DIR`):
- No `CODEGRAPH_VERSION` → redirect resolves `v0.9.3` → installs → `codegraph --version` = `0.9.3`.
- `CODEGRAPH_VERSION=0.9.3` (bare) → normalized to `v0.9.3` → installs → works.
- `sh -n install.sh` passes.

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
