### PR TITLE
fix(mcp): make session-marker symlink resistance work on Windows

### DIFF
--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -11,6 +11,7 @@ import {
   constants as fsConstants,
   closeSync,
   existsSync,
+  lstatSync,
   openSync,
   readFileSync,
   writeSync,
@@ -224,6 +225,16 @@ function markSessionConsulted(sessionId: string): void {
   try {
     const hash = createHash('md5').update(sessionId).digest('hex').slice(0, 16);
     const markerPath = join(tmpdir(), `codegraph-consulted-${hash}`);
+    // Refuse to follow a pre-planted symlink at the marker path (CWE-59).
+    // O_NOFOLLOW (below) is the atomic, TOCTOU-free guard on POSIX, but it is
+    // `undefined` on Windows (libuv ignores it), so the bitwise-OR silently
+    // drops it and openSync would follow the link. This lstat check closes that
+    // gap cross-platform; ENOENT (path is free) falls through to create it.
+    try {
+      if (lstatSync(markerPath).isSymbolicLink()) return;
+    } catch {
+      // No existing entry (or stat failed) — nothing to refuse; proceed.
+    }
     // O_NOFOLLOW makes openSync throw ELOOP if markerPath is already a symlink.
     // O_CREAT + O_TRUNC keep the original "create-or-overwrite" semantics, and
     // mode 0o600 prevents readback by other local users (the marker payload is


### PR DESCRIPTION
## What

`markSessionConsulted` (the `/tmp` session-consulted marker write) relied on `O_NOFOLLOW` to refuse a pre-planted symlink at the marker path — the CWE-59 protection added in #280. But `fs.constants.O_NOFOLLOW` is **`undefined` on Windows** (libuv ignores it), so `O_WRONLY | O_CREAT | O_TRUNC | undefined` silently drops the flag and `openSync` follows the symlink, overwriting the target.

## Fix

Add a cross-platform `lstatSync(markerPath).isSymbolicLink()` refuse-check before `openSync`. `O_NOFOLLOW` stays as the atomic, TOCTOU-free guard on POSIX; the lstat check covers Windows (small lstat→open TOCTOU window, acceptable for a benign marker).

## Validation

- macOS: full suite green (775 passed, 2 win-gated skips).
- **Real Windows 11 (ARM) VM**: `security.test.ts` now fully green (37 passed, 2 skipped). The `Session marker symlink resistance > does not follow a pre-planted symlink` test — which **failed on Windows before this change** — now passes.

Found while validating #327/#230 on a Windows VM. Refs #280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)