### PR TITLE
fix(hermes): preserve YAML list indentation (2-space flush style)

### DIFF
--- a/__tests__/installer-targets.test.ts
+++ b/__tests__/installer-targets.test.ts
@@ -341,8 +341,8 @@ describe('Installer targets — partial-state idempotency', () => {
     expect(body).toContain('model:\n  default: qwen-3.7');
     expect(body).toContain('mcp_servers:\n  other:\n    command: other');
     expect(body).toContain('  codegraph:\n    command: codegraph');
-    expect(body).toContain('    - hermes-cli');
-    expect(body).toContain('    - mcp-codegraph');
+    expect(body).toContain('  - hermes-cli');
+    expect(body).toContain('  - mcp-codegraph');
     expect(body).toContain('  discord:\n    - hermes-discord');
 
     const second = hermes.install('global', { autoAllow: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@colbymchenry/codegraph",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@colbymchenry/codegraph",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.3.0",
@@ -1431,7 +1431,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/installer/targets/hermes.ts
+++ b/src/installer/targets/hermes.ts
@@ -177,7 +177,15 @@ function childRange(lines: string[], parent: LineRange, child: string): LineRang
   for (let i = start + 1; i < parent.end; i++) {
     const line = lines[i] ?? '';
     if (line.trim() === '') continue;
-    if (/^  \S/.test(line)) {
+    // YAML allows both:
+    //   cli:
+    //   - file
+    // and:
+    //   cli:
+    //     - file
+    // A line beginning with "  -" is still part of the current child, not
+    // the next platform key. Only a sibling mapping key ends this child.
+    if (/^  [A-Za-z_][A-Za-z0-9_-]*:\s*(?:#.*)?$/.test(line)) {
       end = i;
       break;
     }
@@ -248,6 +256,14 @@ function removeCodeGraphMcpServer(content: string): string {
   return joinLines(lines);
 }
 
+function listItemIndent(lines: string[], range: LineRange, fallback: string): string {
+  for (const line of lines.slice(range.start + 1, range.end)) {
+    const match = /^(\s*)-\s+/.exec(line);
+    if (match) return match[1] ?? fallback;
+  }
+  return fallback;
+}
+
 function upsertCodeGraphToolset(content: string): string {
   const lines = splitLines(content);
   const parent = topLevelRange(lines, 'platform_toolsets');
@@ -261,7 +277,7 @@ function upsertCodeGraphToolset(content: string): string {
   }
 
   if (!cli) {
-    lines.splice(parent.end, 0, '  cli:', '    - hermes-cli', '    - mcp-codegraph');
+    lines.splice(parent.end, 0, '  cli:', '  - hermes-cli', '  - mcp-codegraph');
     return joinLines(lines);
   }
 
@@ -270,7 +286,8 @@ function upsertCodeGraphToolset(content: string): string {
     .some((line) => line.trim() === '- mcp-codegraph');
   if (hasEntry) return joinLines(lines);
 
-  lines.splice(cli.end, 0, '    - mcp-codegraph');
+  const indent = listItemIndent(lines, cli, '  ');
+  lines.splice(cli.end, 0, `${indent}- mcp-codegraph`);
   return joinLines(lines);
 }
 


### PR DESCRIPTION
## Summary

The Hermes installer target assumed list items were indented 4 spaces under their parent key, but YAML accepts both the 4-space style and the more common 2-space flush style:

\`\`\`yaml
# flush (2 spaces) — broke before this fix
platform_toolsets:
  cli:
  - hermes-cli
  - mcp-codegraph

# nested (4 spaces) — worked before, still works
platform_toolsets:
  cli:
    - hermes-cli
    - mcp-codegraph
\`\`\`

Two bugs surfaced on flush-style configs:

1. \`childRange()\` used \`/^  \S/\` to detect sibling keys, so a list item like \`  - mcp-codegraph\` was misread as the next child key — the range closed early and \`upsertCodeGraphToolset\` either failed to find the \`cli\` block or inserted into the wrong place.
2. When appending a new entry, the installer hardcoded 4-space indentation, mixing styles inside a single list.

## Fix

- Tighten the sibling-key regex in \`childRange()\` to require an actual mapping key (\`^  [A-Za-z_][\\w-]*:\`), so list lines no longer terminate the range.
- Add \`listItemIndent()\` to detect the indentation of existing list items and reuse it when appending \`- mcp-codegraph\`.
- Default the bootstrap insert (when no \`cli:\` block exists yet) to 2-space flush style, matching the in-repo Hermes config format.

## Test plan

- [x] Existing test suite updated to assert the flush-style output (\`  - hermes-cli\` instead of \`    - hermes-cli\`).
- [x] \`npm test -- __tests__/installer-targets.test.ts\` — 82/82 passing locally.
- [x] Reproduced the original break against a real Hermes config with flush-style lists; with this patch the installer is idempotent on both styles.