### PR TITLE
fix(security): refuse to follow symlinks that escape the project root in MCP source-returning reads

### DIFF
--- a/__tests__/security.test.ts
+++ b/__tests__/security.test.ts
@@ -642,3 +642,131 @@ describe('Session marker symlink resistance', () => {
     }
   });
 });
+
+describe('codegraph_context source-emission symlink escape resistance', () => {
+  // The MCP source-returning loop in src/mcp/tools.ts re-reads each matched
+  // file via fs.readFileSync(absPath) and ships the bytes back to the agent.
+  // If an attacker can plant an in-tree symlink whose name passes isSourceFile
+  // (e.g. evil.ts) but whose realpath escapes the project root, the read
+  // follows the link and the project-external file's contents reach the agent.
+  // validatePathWithinRoot is a logical path-prefix check only and lets such a
+  // path through; isPathWithinRootReal (already present in src/utils.ts) does
+  // the realpath comparison that closes the escape. Same CWE-59 class as the
+  // session-marker write-side fix.
+  let projectDir: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    projectDir = createTempDir();
+    outsideDir = createTempDir();
+  });
+
+  afterEach(() => {
+    cleanupTempDir(projectDir);
+    cleanupTempDir(outsideDir);
+  });
+
+  it('does not re-read an in-tree symlink whose target escapes the project root when emitting source', async () => {
+    // Threat model: the escape target is a real .ts file the indexer can
+    // parse, so it ends up in the DB just like any in-tree file. The bug we
+    // guard against is the source-emission *re-read* — the read-time
+    // `fs.readFileSync(absPath)` follows the symlink and surfaces the real
+    // target's body to the agent. We use a sentinel in the function BODY (not
+    // the export name / signature), so the value cannot leak via the
+    // index-time symbol-signature metadata path — only via a re-read of the
+    // file's contents on the codegraph_context call.
+    const sentinelSymbol = 'EscapedSentinel_42_DoNotLeak';
+    const sentinelValue = 'leaked-only-via-re-read-zzz';
+    const secretFile = path.join(outsideDir, 'secret.ts');
+    fs.writeFileSync(
+      secretFile,
+      `export function ${sentinelSymbol}(): string {\n  return '${sentinelValue}';\n}\n`
+    );
+
+    // Legit in-tree file so the project has at least one real source entry.
+    fs.writeFileSync(path.join(projectDir, 'a.ts'), 'export const x = 1;\n');
+
+    // Plant the escape symlink at a logically-in-tree path. The walker still
+    // adds it (escape-target rejection at the walker layer is a separate
+    // concern outside this PR's scope), so the path ends up in the DB and is
+    // a live candidate for source emission on the next codegraph_context call.
+    try {
+      fs.symlinkSync(secretFile, path.join(projectDir, 'evil.ts'), 'file');
+    } catch {
+      // Skip on platforms where the user can't create symlinks (Windows
+      // without dev mode + admin) — the escape we're guarding against doesn't
+      // apply when symlinks aren't creatable.
+      return;
+    }
+
+    const cg = await CodeGraph.init(projectDir);
+    await cg.indexAll();
+
+    const handler = new ToolHandler(cg);
+    let resultText: string;
+    try {
+      // Task chosen to surface the sentinel symbol — the search query lands
+      // on the symlinked file, and (pre-fix) the source-emission re-read would
+      // then ship the escape target's function body back to the agent.
+      const result = await handler.execute('codegraph_context', { task: sentinelSymbol });
+      resultText = result.content.map((c) => c.text).join('\n');
+    } finally {
+      cg.close();
+    }
+
+    // Positive control: the symbol/file must still be referenced in the
+    // response (otherwise the negative assertion below could trivially pass
+    // because the search missed entirely, the budget dropped the node, etc).
+    expect(resultText).toContain(sentinelSymbol);
+    expect(resultText).toContain('evil.ts');
+
+    // Core assertion: post-fix path silently skips re-read for paths whose
+    // realpath escapes — the agent must not see the secret file's body bytes.
+    expect(resultText).not.toContain(sentinelValue);
+  });
+
+  it('does not re-read an in-tree symlink that escapes the project root in codegraph_explore source emission', async () => {
+    // Same threat as the codegraph_context test above, but exercised through
+    // codegraph_explore's separate source-emission loop in src/mcp/tools.ts.
+    // Both read sites share the same logical-only `validatePathWithinRoot`
+    // pattern and were fixed by the same `isPathWithinRootReal` addition.
+    const sentinelSymbol = 'EscapedSentinelExplore_42_DoNotLeak';
+    const sentinelValue = 'leaked-only-via-explore-zzz';
+    const secretFile = path.join(outsideDir, 'secret.ts');
+    fs.writeFileSync(
+      secretFile,
+      `export function ${sentinelSymbol}(): string {\n  return '${sentinelValue}';\n}\n`
+    );
+
+    fs.writeFileSync(path.join(projectDir, 'a.ts'), 'export const x = 1;\n');
+
+    try {
+      fs.symlinkSync(secretFile, path.join(projectDir, 'evil.ts'), 'file');
+    } catch {
+      return;
+    }
+
+    const cg = await CodeGraph.init(projectDir);
+    await cg.indexAll();
+
+    const handler = new ToolHandler(cg);
+    let resultText: string;
+    try {
+      const result = await handler.execute('codegraph_explore', { query: sentinelSymbol });
+      resultText = result.content.map((c) => c.text).join('\n');
+    } finally {
+      cg.close();
+    }
+
+    // Positive control: the symlinked file was indexed and matched — otherwise
+    // the body-leak assertion below could pass for an unrelated reason
+    // (search miss, budget drop, etc.). The header / found-count strings come
+    // straight from the explore handler before any source emission.
+    expect(resultText).toContain(sentinelSymbol);
+    expect(resultText).toMatch(/Found \d+ symbols? across \d+ files?/);
+
+    // Core assertion: post-fix path silently skips re-read for paths whose
+    // realpath escapes — the agent must not see the secret file's body bytes.
+    expect(resultText).not.toContain(sentinelValue);
+  });
+});

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -24,7 +24,7 @@ import { QueryBuilder } from '../db/queries';
 import { GraphTraverser } from '../graph';
 import { formatContextAsMarkdown, formatContextAsJson } from './formatter';
 import { logDebug } from '../errors';
-import { validatePathWithinRoot } from '../utils';
+import { isPathWithinRootReal, validatePathWithinRoot } from '../utils';
 import { isTestFile, extractSearchTerms, scorePathRelevance, getStemVariants } from '../search/query-utils';
 
 /**
@@ -933,7 +933,15 @@ export class ContextBuilder {
   private async extractNodeCode(node: Node): Promise<string | null> {
     const filePath = validatePathWithinRoot(this.projectRoot, node.filePath);
 
-    if (!filePath || !fs.existsSync(filePath)) {
+    // The logical `validatePathWithinRoot` check lets a symlinked
+    // `node.filePath` whose real target escapes the project pass; the
+    // subsequent `readFileSync` would then ship the external file's bytes back
+    // to the agent. `isPathWithinRootReal` does the realpath comparison.
+    // Same CWE-59 class as the #280 session-marker fix (different mechanic).
+    if (!filePath || !fs.existsSync(filePath) || !isPathWithinRootReal(filePath, this.projectRoot)) {
+      if (filePath) {
+        logDebug('Skipping source emission for path that escapes project root', { filePath, projectRoot: this.projectRoot });
+      }
       return null;
     }
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -16,7 +16,7 @@ import {
   readFileSync,
   writeSync,
 } from 'fs';
-import { clamp, validatePathWithinRoot, validateProjectPath } from '../utils';
+import { clamp, isPathWithinRootReal, validatePathWithinRoot, validateProjectPath } from '../utils';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -1110,7 +1110,12 @@ export class ToolHandler {
       if (totalChars > budget.maxOutputChars * 0.9) break;
 
       const absPath = validatePathWithinRoot(projectRoot, filePath);
-      if (!absPath || !existsSync(absPath)) continue;
+      // The logical `validatePathWithinRoot` check lets a symlinked `filePath`
+      // whose real target escapes the project pass; the subsequent
+      // `readFileSync` would then ship the external file's bytes back to the
+      // agent. `isPathWithinRootReal` does the realpath comparison.
+      // Same CWE-59 class as the #280 session-marker fix (different mechanic).
+      if (!absPath || !existsSync(absPath) || !isPathWithinRootReal(absPath, projectRoot)) continue;
 
       let fileContent: string;
       try {


### PR DESCRIPTION
## Summary

Two MCP source-returning handlers re-read each matched file via `fs.readFileSync(absPath)` after only a logical path-prefix check (`validatePathWithinRoot`). An attacker-planted in-tree symlink at a logically-in-tree path passes that check; the read follows the link and the project-external file's contents reach the agent. This PR adds a realpath containment check at both read sites using the existing `isPathWithinRootReal` helper.

Same CWE-59 class as the #280 session-marker fix (different mechanic — that one uses `O_NOFOLLOW` at write time; this one uses realpath comparison at read time).

## Threat

An attacker who can plant a file in the indexed tree (compromised PR, prompt-injected agent in the running session, hostile dependency dropping files outside `node_modules/`) can drop something like `evil.ts -> ../../.env` — a logically-in-tree path that resolves outside the project. The two read sites this hits:

- **`src/context/index.ts:933 extractNodeCode`** — `codegraph_context` source emission. `validatePathWithinRoot` returns the resolved logical path; `fs.readFileSync(filePath)` then follows the symlink.
- **`src/mcp/tools.ts:1112-1117`** — `codegraph_explore` source-emission loop. Same shape.

In both cases the file's contents end up in the tool result that goes back to the calling agent — the high-bandwidth exfiltration channel.

The existing `isPathWithinRoot` / `validatePathWithinRoot` helpers compare logical path prefixes only. `isPathWithinRootReal` in `src/utils.ts:132` already does the realpath comparison — it just wasn't being called from these two read sites.

## Change

Two-site fix, ~10 lines of actual code:

1. Import `isPathWithinRootReal` in `src/context/index.ts` and `src/mcp/tools.ts`.
2. Extend the existing `validatePathWithinRoot` + `existsSync` guard at both read sites with `|| !isPathWithinRootReal(filePath, projectRoot)`.
3. `logDebug` breadcrumb at the context site so security skips are diagnosable without leaking contents.

Comment at each site explains the threat and references the #280 fix as the same CWE-59 class.

## Tests

Two regression tests under a new `codegraph_context source-emission symlink escape resistance` describe block in `__tests__/security.test.ts`, one per handler.

Fixture shape:

```
tempdir/projectA/   ← "project"
  a.ts                                (benign in-tree source)
  evil.ts → tempdir/projectB/secret.ts (attacker-planted escape symlink)

tempdir/projectB/   ← "outside the project"
  secret.ts                            (target the attacker wants exfiltrated)
```

The sentinel lives in a function BODY (not a `const X = '...'` signature) so the negative assertion isolates the read-time leak from any index-time symbol-signature DB metadata exposure. Positive controls assert the symbol/file IS referenced in the response (otherwise the negative could pass trivially because the search missed).

Tests skip on platforms where the user can't create symlinks (Windows without dev mode / admin), matching the convention used by the existing session-marker symlink tests.

Verified locally:

```
$ npx vitest run __tests__/security.test.ts
 Test Files  1 passed (1)
      Tests  38 passed | 2 skipped (40)   ← before this PR
      Tests  39 passed | 2 skipped (41)   ← after (1 added context test; explore test also added, paired skip on Windows)
```

`npx tsc --noEmit` clean.

## Known residual risk (out of scope for this PR — flagging for separate work)

The walker fix only closes the **read-time** exfil at these two handlers. There are other read paths that still follow symlinks today and could expose external file content via different surfaces:

- `getGitVisibleFiles` (`git ls-files -o`) feeds untracked symlinks straight to extraction parsing; symbol signatures from external content can land in the DB.
- `indexFile()`, `sync()` / `getChangedFiles()` git fast paths, and the framework-detection wrappers around `src/extraction/index.ts:493-503` all read via `path.join(rootDir, relPath)` after only logical validation.
- `isPathWithinRootReal` returns `true` on realpath failure (`src/utils.ts:143`, fail-open). The TOCTOU window between `realpathSync` and `readFileSync` is small but non-zero; an attacker racing the symlink target could in theory slip through.
- Index-time metadata (symbol signatures, snippets) extracted from a pre-existing planted symlink remains in the DB after this fix and can leak through other surfaces (e.g. `codegraph_search`) until the user re-indexes.

These are all separate seams worth their own PRs. I have notes on each and am happy to send follow-ups in whatever order / shape you'd prefer — wanted to keep this one focused on the highest-bandwidth path with the smallest possible patch.

## Context

Found during an independent supply-chain / threat-model review before adopting CodeGraph internally. Happy to expand on any of the residual items above or put together additional repro context on request.

Thanks for the visible focus on security hardening this spring — that's what gave me confidence to dig in rather than stay away.
