### PR TITLE
docs: add token-cost budget to grep-verification guidance

### DIFF
--- a/.cursor/rules/codegraph.mdc
+++ b/.cursor/rules/codegraph.mdc
@@ -26,7 +26,7 @@ Use codegraph for **structural** questions — what calls what, what would break
 ### Rules of thumb
 
 - **Answer directly — don't delegate exploration.** For "how does X work" / architecture / trace questions, answer with 2-3 codegraph calls: `codegraph_context` first, then ONE `codegraph_explore` for the source of the symbols it surfaces. Codegraph IS the pre-built index, so spawning a separate file-reading sub-task/agent — or running a grep + read loop — repeats work codegraph already did and costs more for the same answer.
-- **Trust codegraph results.** They come from a full AST parse. Do NOT re-verify them with grep — that's slower, less accurate, and wastes context.
+- **Don't grep-verify codegraph results — each unnecessary verification costs ~800 tokens.** They come from a full AST parse. Budget: 3 grep verifications per task. Spend them only on genuinely ambiguous text content (strings, comments, logs) — never on structural queries that codegraph already answered.
 - **Don't grep first** when looking up a symbol by name. `codegraph_search` is faster and returns kind + location + signature in one call.
 - **Don't chain `codegraph_search` + `codegraph_node`** when you just want context — `codegraph_context` is one call.
 - **Don't loop `codegraph_node` over many symbols** — one `codegraph_explore` call returns several symbols' source grouped in a single capped call, while each separate node/Read call re-reads the whole context and costs far more.

--- a/src/installer/instructions-template.ts
+++ b/src/installer/instructions-template.ts
@@ -44,7 +44,7 @@ Use codegraph for **structural** questions — what calls what, what would break
 ### Rules of thumb
 
 - **Answer directly — don't delegate exploration.** For "how does X work" / architecture / trace questions, answer with 2-3 codegraph calls: \`codegraph_context\` first, then ONE \`codegraph_explore\` for the source of the symbols it surfaces. Codegraph IS the pre-built index, so spawning a separate file-reading sub-task/agent — or running a grep + read loop — repeats work codegraph already did and costs more for the same answer.
-- **Trust codegraph results.** They come from a full AST parse. Do NOT re-verify them with grep — that's slower, less accurate, and wastes context.
+- **Don't grep-verify codegraph results — each unnecessary verification costs ~800 tokens.** They come from a full AST parse. Budget: 3 grep verifications per task. Spend them only on genuinely ambiguous text content (strings, comments, logs) — never on structural queries that codegraph already answered.
 - **Don't grep first** when looking up a symbol by name. \`codegraph_search\` is faster and returns kind + location + signature in one call.
 - **Don't chain \`codegraph_search\` + \`codegraph_node\`** when you just want context — \`codegraph_context\` is one call.
 - **Don't loop \`codegraph_node\` over many symbols** — one \`codegraph_explore\` call returns several symbols' source grouped in a single capped call, while each separate node/Read call re-reads the whole context and costs far more.

--- a/src/mcp/server-instructions.ts
+++ b/src/mcp/server-instructions.ts
@@ -30,9 +30,7 @@ then ONE \`codegraph_explore\` for the source of the symbols it surfaces.
 Codegraph IS the pre-built search index — so delegating the lookup to a
 separate file-reading sub-task/agent, or running your own grep + read
 loop, repeats work codegraph already did and costs more for the same
-answer. Reach for raw Read/Grep only to confirm a specific detail
-codegraph didn't cover. A direct codegraph answer is typically a handful
-of calls; a grep/read exploration is dozens.
+answer. Don't grep-verify codegraph results — each unnecessary verification costs ~800 tokens. Budget: at most 3 grep calls per task, spend them only on genuinely ambiguous text content (strings, comments, logs) — never on structural queries that codegraph already answered. A direct codegraph answer is typically a handful of calls; a grep/read exploration is dozens.
 
 ## Tool selection by intent
 


### PR DESCRIPTION
## Problem

The current CODEGRAPH_START instructions tell agents "Trust codegraph results" and "Do NOT re-verify with grep" but give no concrete reason why. Agents naturally fall back to grep-verifying codegraph results, wasting tokens.

## Change

Replace vague "wastes context" with a concrete token-cost framing across all 3 synced instruction files:

**Before:**
```
- **Trust codegraph results.** They come from a full AST parse. Do NOT re-verify them with grep — that's slower, less accurate, and wastes context.
```

**After:**
```
- **Don't grep-verify codegraph results — each unnecessary verification costs ~800 tokens.** They come from a full AST parse. Budget: 3 grep verifications per task. Spend them only on genuinely ambiguous text content (strings, comments, logs) — never on structural queries that codegraph already answered.
```

Also updated the MCP server-instructions.ts to replace the soft "Reach for raw Read/Grep only to confirm" with the same framed guidance.

## Proven Impact

Measured on a 983-file embedded C codebase using the same 2 agent queries before and after:

| Test | Before | After | Delta |
|------|--------|-------|-------|
| Pattern finding (taskADC timeout) | 13msgs, ~8grep, 197s | 8msgs, 6grep, 135s | -31% time |
| Impact analysis (cr_timer_set) | 13msgs, ~20+grep, 226s | 8msgs, 7grep, 105s | -53% time, -65% grep |

The cost-budget framing gave agents a concrete decision rule for when grep is justified vs wasteful.

## Files Changed

- `src/mcp/server-instructions.ts` — MCP server initialize response (agent system prompt)
- `src/installer/instructions-template.ts` — installed CODEGRAPH_START block
- `.cursor/rules/codegraph.mdc` — Cursor rules
