### PR TITLE
fix: include class instantiations in callers

### DIFF
--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -281,6 +281,19 @@ export { main };
       expect(Array.isArray(callers)).toBe(true);
     });
 
+    it('should get instantiating callers of a class', () => {
+      const nodes = cg.getNodesByKind('class');
+      const derivedClass = nodes.find((n) => n.name === 'DerivedClass');
+
+      if (!derivedClass) {
+        return;
+      }
+
+      const callers = cg.getCallers(derivedClass.id);
+
+      expect(callers.some((c) => c.node.name === 'main' && c.edge.kind === 'instantiates')).toBe(true);
+    });
+
     it('should get callees of a function', () => {
       const nodes = cg.getNodesByKind('function');
       const processValue = nodes.find((n) => n.name === 'processValue');

--- a/src/graph/traversal.ts
+++ b/src/graph/traversal.ts
@@ -248,7 +248,7 @@ export class GraphTraverser {
     }
     visited.add(nodeId);
 
-    const incomingEdges = this.queries.getIncomingEdges(nodeId, ['calls', 'references', 'imports']);
+    const incomingEdges = this.queries.getIncomingEdges(nodeId, ['calls', 'references', 'imports', 'instantiates']);
     if (incomingEdges.length === 0) return;
 
     // Batch-fetch all caller nodes in one round-trip instead of one


### PR DESCRIPTION
## Summary
- Include instantiates edges in caller traversal so class usages through construction/static class access are surfaced by getCallers, CLI callers, and MCP callers.
- Add a regression test that verifies a class instantiation is returned as a caller.

## Validation
- 
pm run build
- 
px vitest run __tests__/graph.test.ts --minWorkers=1 --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000 --no-file-parallelism
- 
ode dist\\bin\\codegraph.js callers CodeGraph --path . --json now includes 	ryInitializeDefault and etryInitIfNeeded class usage results.