### PR TITLE
fix: count file-level tracked YAML/Twig files as indexed

### DIFF
--- a/__tests__/extraction.test.ts
+++ b/__tests__/extraction.test.ts
@@ -2974,6 +2974,38 @@ export function multiply(a: number, b: number): number {
 
     cg.close();
   });
+
+  it('should count file-level tracked YAML files as indexed', async () => {
+    fs.writeFileSync(path.join(tempDir, 'app.yaml'), 'name: test\n');
+    fs.writeFileSync(path.join(tempDir, 'routes.yml'), 'route: value\n');
+
+    const cg = CodeGraph.initSync(tempDir);
+    const result = await cg.indexAll();
+
+    expect(result.success).toBe(true);
+    expect(result.filesIndexed).toBe(2);
+    expect(result.filesSkipped).toBe(0);
+    expect(cg.getFiles().map((f) => f.path).sort()).toEqual(['app.yaml', 'routes.yml']);
+
+    cg.close();
+  });
+
+  it('should count file-level tracked YAML/Twig files as indexed in indexFiles()', async () => {
+    fs.writeFileSync(path.join(tempDir, 'app.yaml'), 'name: test\n');
+    fs.writeFileSync(path.join(tempDir, 'view.twig'), '{{ title }}\n');
+
+    const cg = CodeGraph.initSync(tempDir);
+    const result = await cg.indexFiles(['app.yaml', 'view.twig']);
+
+    expect(result.success).toBe(true);
+    expect(result.filesIndexed).toBe(2);
+    expect(result.filesSkipped).toBe(0);
+
+    const tracked = cg.getFiles().map((f) => `${f.path}:${f.language}`).sort();
+    expect(tracked).toEqual(['app.yaml:yaml', 'view.twig:twig']);
+
+    cg.close();
+  });
 });
 
 describe('Path Normalization', () => {

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -838,7 +838,15 @@ export class ExtractionOrchestrator {
         } else if (result.errors.some((e) => e.severity === 'error')) {
           filesErrored++;
         } else {
-          filesSkipped++;
+          // Files with no symbols but no errors (e.g. yaml, twig) are tracked
+          // at the file level — count them as indexed so the CLI doesn't
+          // misleadingly report "No files found to index".
+          const lang = detectLanguage(filePath, content);
+          if (lang === 'yaml' || lang === 'twig') {
+            filesIndexed++;
+          } else {
+            filesSkipped++;
+          }
         }
       }
     }
@@ -1004,7 +1012,12 @@ export class ExtractionOrchestrator {
       } else if (result.errors.some((e) => e.severity === 'error')) {
         filesErrored++;
       } else {
-        filesSkipped++;
+        const tracked = this.queries.getFileByPath(filePath);
+        if (tracked && (tracked.language === 'yaml' || tracked.language === 'twig')) {
+          filesIndexed++;
+        } else {
+          filesSkipped++;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- count file-level tracked `yaml` and `twig` files as indexed in `indexFiles()` too
- keep the existing file-level tracking behavior unchanged
- add regression coverage for `indexAll()` and `indexFiles()` with YAML/Twig-only inputs

## Why
For file-level tracked languages like YAML and Twig, storing the file without extracted symbols is expected behavior. Those files were already being written to the database, but some index paths still counted them as skipped, which could lead to misleading CLI output such as "No files found to index".

Closes #317

## Testing
- `npx vitest run __tests__/extraction.test.ts -t "file-level tracked YAML|indexFiles\(\)"`
- `npm run build`