### PR TITLE
docs: link to the website & docs site from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **~35% cheaper · ~70% fewer tool calls · 100% local**
 
+### [Documentation & Website →](https://colbymchenry.github.io/codegraph/)
+
 [![npm version](https://img.shields.io/npm/v/@colbymchenry/codegraph.svg)](https://www.npmjs.com/package/@colbymchenry/codegraph)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Self-contained](https://img.shields.io/badge/Node.js-bundled%20%C2%B7%20none%20required-brightgreen.svg)](https://nodejs.org/)


### PR DESCRIPTION
Adds a prominent link to the new site (**https://colbymchenry.github.io/codegraph/**) at the top of the README, under the tagline, so visitors who land on the repo can reach the landing page and docs.

Docs-only change — does not touch `site/`, so it won't trigger a site redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)