### PR TITLE
fix: center docs content on wide screens

### DIFF
--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -215,3 +215,12 @@ button[data-open-modal] {
 	color: var(--cg-ink);
 	text-underline-offset: 3px;
 }
+
+/* On wide screens Starlight right-aligns the content against the TOC
+   (margin-inline: auto 0), piling all the empty space on the left. Center the
+   content within its pane so it sits balanced between the sidebar and the TOC. */
+@media (min-width: 72rem) {
+	.main-pane {
+		--sl-content-margin-inline: auto;
+	}
+}


### PR DESCRIPTION
On wide screens Starlight sets the docs content's `margin-inline: auto 0` (for pages with a sidebar + TOC), right-aligning the body against the "On this page" rail and piling all the empty space on the left. This centers the content within its pane so the margins are balanced.

Touches `site/**`, so merging auto-deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)