### PR TITLE
fix(security): unify path validation to use realpath, removing dead isPathWithinRootReal

### DIFF
--- a/__tests__/security.test.ts
+++ b/__tests__/security.test.ts
@@ -12,7 +12,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { FileLock, validateProjectPath } from '../src/utils';
+import {
+  FileLock,
+  validateProjectPath,
+  validatePathWithinRoot,
+  isPathWithinRoot,
+} from '../src/utils';
 import CodeGraph from '../src/index';
 import { ToolHandler, tools } from '../src/mcp/tools';
 import { scanDirectory, isSourceFile } from '../src/extraction';
@@ -173,6 +178,102 @@ describe('Path Traversal Prevention', () => {
   it('should return null for non-existent node', async () => {
     const code = await cg.getCode('does-not-exist');
     expect(code).toBeNull();
+  });
+});
+
+describe('Path Traversal Prevention - symlink escapes', () => {
+  let tmpRoot: string;
+  let projectRoot: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-pathtest-'));
+    projectRoot = path.join(tmpRoot, 'project');
+    outsideDir = path.join(tmpRoot, 'outside');
+    fs.mkdirSync(projectRoot, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(path.join(outsideDir, 'secret.txt'), 'sensitive data');
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('rejects relative path traversal with ..', () => {
+    expect(validatePathWithinRoot(projectRoot, '../outside/secret.txt')).toBeNull();
+    expect(isPathWithinRoot('../outside/secret.txt', projectRoot)).toBe(false);
+  });
+
+  it('rejects absolute paths outside the root', () => {
+    expect(validatePathWithinRoot(projectRoot, path.join(outsideDir, 'secret.txt'))).toBeNull();
+  });
+
+  it('rejects symlinks inside project that point outside', () => {
+    const linkPath = path.join(projectRoot, 'escape-link');
+    try {
+      fs.symlinkSync(outsideDir, linkPath, 'dir');
+    } catch (err: unknown) {
+      const code = err && typeof err === 'object' && 'code' in err
+        ? (err as NodeJS.ErrnoException).code
+        : undefined;
+      if (code === 'EPERM' || code === 'ENOSYS') {
+        return;
+      }
+      throw err;
+    }
+    const result = validatePathWithinRoot(projectRoot, 'escape-link/secret.txt');
+    expect(result).toBeNull();
+  });
+
+  it('accepts symlinks inside project that point inside', () => {
+    const targetDir = path.join(projectRoot, 'real');
+    fs.mkdirSync(targetDir);
+    fs.writeFileSync(path.join(targetDir, 'file.ts'), 'export {};');
+    const linkPath = path.join(projectRoot, 'alias');
+    try {
+      fs.symlinkSync(targetDir, linkPath, 'dir');
+    } catch (err: unknown) {
+      const code = err && typeof err === 'object' && 'code' in err
+        ? (err as NodeJS.ErrnoException).code
+        : undefined;
+      if (code === 'EPERM' || code === 'ENOSYS') {
+        return;
+      }
+      throw err;
+    }
+    const result = validatePathWithinRoot(projectRoot, 'alias/file.ts');
+    expect(result).not.toBeNull();
+  });
+
+  it('accepts nested valid paths', () => {
+    const subdir = path.join(projectRoot, 'src', 'deep');
+    fs.mkdirSync(subdir, { recursive: true });
+    fs.writeFileSync(path.join(subdir, 'mod.ts'), '');
+    const result = validatePathWithinRoot(projectRoot, 'src/deep/mod.ts');
+    expect(result).not.toBeNull();
+    expect(result).toContain('mod.ts');
+  });
+
+  it('returns null for non-existent paths outside root, accepts non-existent inside root', () => {
+    const inside = validatePathWithinRoot(projectRoot, 'not-yet-created.ts');
+    expect(inside).not.toBeNull();
+
+    const outside = validatePathWithinRoot(projectRoot, '../not-yet-created.ts');
+    expect(outside).toBeNull();
+  });
+
+  it('handles case-insensitive root on Windows', () => {
+    if (process.platform !== 'win32') {
+      return;
+    }
+    const upper = projectRoot.charAt(0).toUpperCase() + projectRoot.slice(1);
+    const lower = projectRoot.charAt(0).toLowerCase() + projectRoot.slice(1);
+    expect(validatePathWithinRoot(upper, 'a.ts')).not.toBeNull();
+    expect(validatePathWithinRoot(lower, 'a.ts')).not.toBeNull();
   });
 });
 

--- a/docs/2026-05-25_b1-path-validation-patch.html
+++ b/docs/2026-05-25_b1-path-validation-patch.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>2026-05-25 B1 パス検証統一パッチ</title>
+<style>
+:root { --bg:#0f172a; --card:#1e293b; --text:#e2e8f0; --muted:#94a3b8; --accent:#a78bfa; --border:#334155; --code-bg:#0b1220; --ok:#34d399; }
+body { margin:0 auto; padding:40px 20px; max-width:960px; background:var(--bg); color:var(--text); font-family:system-ui,"Yu Gothic",Meiryo,sans-serif; font-size:15px; line-height:1.7; }
+h1 { color:var(--accent); font-size:24px; }
+h2 { font-size:16px; color:var(--muted); margin-top:28px; }
+code, pre { background:var(--code-bg); border-radius:6px; font-size:13px; }
+pre { padding:12px; overflow-x:auto; border:1px solid var(--border); }
+table { width:100%; border-collapse:collapse; margin:12px 0; }
+th, td { border-bottom:1px solid var(--border); padding:8px; text-align:left; }
+.tag-ok { color:var(--ok); }
+a { color:var(--accent); }
+</style>
+</head>
+<body>
+<h1>B1 パス検証統一パッチ（実施記録）</h1>
+<p>ブランチ: <code>fix/path-validation-unify</code> · ベース: v0.9.4 · PR想定: <code>fix(security): unify path validation with realpath-based check</code></p>
+
+<h2>実施内容</h2>
+<ul>
+<li><code>validatePathWithinRoot</code> を logical + <code>realpathSync</code> の二段検証に差し替え</li>
+<li><code>pathStartsWith</code> 追加（Windows は case-insensitive）</li>
+<li><code>isPathWithinRoot</code> を薄いラッパに変更</li>
+<li>未使用の <code>isPathWithinRootReal</code> を削除</li>
+<li><code>__tests__/security.test.ts</code> に symlink escape 系 7 ケース追加</li>
+</ul>
+
+<h2>変更ファイル</h2>
+<pre>src/utils.ts
+__tests__/security.test.ts
+docs/2026-05-25_b1-path-validation-patch.html
+docs/index.html</pre>
+
+<h2>検証結果</h2>
+<table>
+<tr><th>項目</th><th>結果</th></tr>
+<tr><td><code>npm run build</code></td><td class="tag-ok">成功</td></tr>
+<tr><td><code>vitest run __tests__/security.test.ts</code></td><td class="tag-ok">44 passed / 2 skipped</td></tr>
+<tr><td><code>git grep isPathWithinRootReal</code></td><td class="tag-ok">0 件</td></tr>
+<tr><td><code>npm test</code> 全体（Windows）</td><td>810 pass / 5 fail（<code>mcp-roots</code> 既知・本パッチ無関係）</td></tr>
+</table>
+
+<h2>完了チェックリスト</h2>
+<ul>
+<li>✅ diff が utils + security.test（+ docs）に限定</li>
+<li>✅ build 成功</li>
+<li>✅ security テスト全緑</li>
+<li>✅ isPathWithinRootReal 削除確認</li>
+<li>✅ Conventional Commits 形式でコミット</li>
+</ul>
+
+<h2>関連ドキュメント</h2>
+<ul>
+<li><a href="2026-05-25_codegraph-jp_導入分析レポート.html">導入分析レポート</a></li>
+</ul>
+
+<p><small>記録日: 2026-05-25</small></p>
+</body>
+</html>

--- a/docs/2026-05-25_codegraph-jp_導入分析レポート.html
+++ b/docs/2026-05-25_codegraph-jp_導入分析レポート.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>2026-05-25 CodeGraph 導入分析レポート</title>
+<style>
+:root {
+  --bg: #0f172a;
+  --card: #1e293b;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --heading: #cbd5e1;
+  --accent: #a78bfa;
+  --border: #334155;
+  --code-bg: #0b1220;
+  --ok: #34d399;
+  --warn: #fbbf24;
+  --err: #f87171;
+}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body.diary {
+  margin: 0 auto;
+  padding: 40px 20px 80px;
+  max-width: 960px;
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, "Segoe UI", "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif;
+  font-size: 15px;
+  line-height: 1.7;
+}
+body.diary > header { margin-bottom: 28px; padding-bottom: 20px; border-bottom: 1px solid var(--border); }
+body.diary > header h1 { margin: 0 0 6px; font-size: 26px; color: var(--accent); font-weight: 600; }
+body.diary > header .subtitle { margin: 0; color: var(--muted); font-size: 14px; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+strong { color: var(--heading); font-weight: 600; }
+code { background: var(--code-bg); padding: 1px 6px; border-radius: 4px; font-size: 13px; }
+pre { background: var(--code-bg); padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); overflow-x: auto; font-size: 13px; }
+.diary-toc { margin-bottom: 28px; padding: 16px 20px; background: var(--card); border: 1px solid var(--border); border-radius: 10px; }
+.diary-toc h2 { margin: 0 0 12px; font-size: 14px; color: var(--heading); text-transform: uppercase; }
+.diary-toc table { width: 100%; border-collapse: collapse; font-size: 14px; }
+.diary-toc th { text-align: left; padding: 6px 10px; color: var(--muted); font-size: 12px; border-bottom: 1px solid var(--border); }
+.diary-toc td { padding: 8px 10px; border-bottom: 1px solid var(--border); }
+.diary-toc tr:last-child td { border-bottom: none; }
+.entry { margin: 22px 0; padding: 20px 24px; background: var(--card); border: 1px solid var(--border); border-radius: 10px; }
+.entry h2 { margin: 0 0 10px; font-size: 20px; color: var(--accent); }
+.entry .meta { margin: 0 0 16px; padding-bottom: 12px; border-bottom: 1px solid var(--border); font-size: 13px; color: var(--muted); display: flex; flex-wrap: wrap; gap: 10px; }
+.entry h3 { margin: 18px 0 8px; font-size: 13px; color: var(--heading); text-transform: uppercase; letter-spacing: 0.3px; }
+.entry h3:first-of-type { margin-top: 0; }
+.entry p, .entry li { margin: 8px 0; }
+.entry ul, .entry ol { padding-left: 22px; }
+.entry table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 14px; }
+.entry th { text-align: left; padding: 8px 10px; color: var(--muted); font-size: 12px; border-bottom: 1px solid var(--border); }
+.entry td { padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
+.entry tr:last-child td { border-bottom: none; }
+.tag { display: inline-block; padding: 2px 8px; font-size: 12px; border-radius: 999px; border: 1px solid var(--border); }
+.tag-scope { border-color: var(--accent); color: var(--accent); }
+.tag-ok { border-color: var(--ok); color: var(--ok); }
+.tag-warn { border-color: var(--warn); color: var(--warn); }
+.tag-err { border-color: var(--err); color: var(--err); }
+.mermaid-note { color: var(--muted); font-size: 13px; }
+</style>
+</head>
+<body class="diary">
+<header>
+  <h1>CodeGraph 導入分析レポート</h1>
+  <p class="subtitle">対象: matrix9neonebuchadnezzar2199-sketch/codegraph（fork / codegraph-jp 作業ベース） · v0.9.4 · Cursor 連携想定</p>
+</header>
+
+<nav class="diary-toc" aria-label="目次">
+  <h2>目次</h2>
+  <table>
+    <thead><tr><th>時刻</th><th>セクション</th><th>状態</th><th>詳細</th></tr></thead>
+    <tbody>
+      <tr><td>07:34</td><td>1. ツール分析</td><td><span class="tag tag-ok">ok</span></td><td><a href="#sec-analysis">#sec-analysis</a></td></tr>
+      <tr><td>07:34</td><td>2. Cursor 導入効果予測</td><td><span class="tag tag-ok">ok</span></td><td><a href="#sec-cursor-effect">#sec-cursor-effect</a></td></tr>
+      <tr><td>07:34</td><td>3. 品質・i18n 設計</td><td><span class="tag tag-warn">warn</span></td><td><a href="#sec-quality-i18n">#sec-quality-i18n</a></td></tr>
+      <tr><td>07:34</td><td>4. 追加機能提案</td><td><span class="tag tag-ok">ok</span></td><td><a href="#sec-features">#sec-features</a></td></tr>
+    </tbody>
+  </table>
+</nav>
+
+<main>
+
+<section class="entry" id="sec-analysis">
+  <h2>1. 対象ツールの分析</h2>
+  <p class="meta">
+    <span class="date">2026-05-25</span>
+    <span class="tag tag-type">analysis</span>
+    <span class="tag tag-scope">codegraph</span>
+    <span class="tag tag-scope">tool</span>
+  </p>
+
+  <h3>概要</h3>
+  <p><strong>CodeGraph</strong> は、ローカルで tree-sitter によりソースを AST 解析し、シンボル・呼び出し関係・インポート・フレームワークルートを <strong>SQLite ナレッジグラフ</strong>（<code>.codegraph/codegraph.db</code>）に格納するコードインテリジェンス基盤です。Claude Code / <strong>Cursor</strong> / Codex CLI / opencode / Hermes Agent 向けに <strong>MCP サーバー</strong>（<code>codegraph serve --mcp</code>）として公開され、エージェントは grep/Read の反復探索の代わりにグラフ照会で構造質問に答えます。</p>
+  <p>本リポジトリは <a href="https://github.com/colbymchenry/codegraph">colbymchenry/codegraph</a> の fork（説明文: 「コードの地図化」）で、パッケージ名は現状 <code>@colbymchenry/codegraph</code> のままです。日本語化（codegraph-jp）は本レポート §3 の設計対象として扱います。</p>
+
+  <h3>アーキテクチャ</h3>
+  <pre><code>エージェント (Cursor MCP クライアント)
+    │ stdio JSON-RPC
+    ▼
+MCPServer (src/mcp/) — tools.ts が 10 ツールを実装
+    │
+    ▼
+CodeGraph コア (src/index.ts)
+    ├─ ExtractionOrchestrator — tree-sitter WASM + 言語別 extractor
+    ├─ ReferenceResolver — 呼び出し解決・フレームワーク route
+    ├─ GraphTraverser / ContextBuilder
+    └─ DatabaseConnection — schema.sql + FTS5 + WAL
+    │
+    ▼
+.sync/ FileWatcher — OS イベント + 2s デバウンス増分同期</code></pre>
+
+  <h3>主要コンポーネント</h3>
+  <table>
+    <thead><tr><th>領域</th><th>パス</th><th>役割</th></tr></thead>
+    <tbody>
+      <tr><td>CLI</td><td><code>src/bin/codegraph.ts</code></td><td>init/index/sync/query/context、Node 25+ ブロック、WASM フラグ再実行</td></tr>
+      <tr><td>インストーラ</td><td><code>src/installer/</code></td><td>マルチエージェント MCP 設定・指示文テンプレート</td></tr>
+      <tr><td>Cursor 連携</td><td><code>src/installer/targets/cursor.ts</code></td><td><code>~/.cursor/mcp.json</code>、<code>.cursor/rules/codegraph.mdc</code>、<code>--path</code> 注入</td></tr>
+      <tr><td>MCP ツール</td><td><code>src/mcp/tools.ts</code></td><td>search/context/trace/explore/callers/callees/impact/node/files/status</td></tr>
+      <tr><td>抽出</td><td><code>src/extraction/</code> + <code>languages/*</code></td><td>19+ 言語、Vue/Svelte/Liquid 等</td></tr>
+      <tr><td>フレームワーク</td><td><code>src/resolution/frameworks/</code></td><td>Django/Express/Nest/Laravel 等 14+ スタックの route 解決</td></tr>
+      <tr><td>セキュリティ</td><td><code>src/utils.ts</code> + <code>__tests__/security.test.ts</code></td><td>FileLock、パストラバーサル検証、MCP 入力制限</td></tr>
+    </tbody>
+  </table>
+
+  <h3>MCP ツール一覧（エージェント向け API）</h3>
+  <table>
+    <thead><tr><th>ツール</th><th>用途</th><th>Cursor での推奨順</th></tr></thead>
+    <tbody>
+      <tr><td><code>codegraph_context</code></td><td>タスク単位の文脈構築（検索+関連シンボル+スニペット）</td><td>アーキテクチャ質問の第一選択</td></tr>
+      <tr><td><code>codegraph_trace</code></td><td>シンボル間の呼び出し経路（動的ディスパッチ含む）</td><td>フロー追跡</td></tr>
+      <tr><td><code>codegraph_explore</code></td><td>複数シンボルのソースを 1 回で取得（予算付き）</td><td>context の次</td></tr>
+      <tr><td><code>codegraph_search</code></td><td>名前によるシンボル検索</td><td>定義位置の特定</td></tr>
+      <tr><td><code>codegraph_callers</code> / <code>callees</code></td><td>1 ホップの呼び出し関係</td><td>局所影響調査</td></tr>
+      <tr><td><code>codegraph_impact</code></td><td>変更影響半径</td><td>リファクタ前</td></tr>
+      <tr><td><code>codegraph_node</code></td><td>単一シンボル詳細・ソース</td><td>ドリルダウン</td></tr>
+      <tr><td><code>codegraph_files</code></td><td>インデックス済みファイルツリー</td><td>Glob 代替</td></tr>
+      <tr><td><code>codegraph_status</code></td><td>インデックス健全性</td><td>セッション開始時</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Cursor 固有の実装要点</h3>
+  <p>Cursor は MCP 子プロセスの <strong>cwd がワークスペース根でない</strong> かつ initialize で <code>rootUri</code> を送らないため、<code>process.cwd()</code> だけでは <code>.codegraph/</code> を見つけられません。その対策としてインストーラは <code>args</code> に <code>--path</code> を付与します。</p>
+  <ul>
+    <li><strong>global インストール</strong>: <code>--path ${workspaceFolder}</code>（Cursor が展開）</li>
+    <li><strong>local インストール</strong>: インストール時の絶対パス</li>
+    <li><strong>rules</strong>: <code>.cursor/rules/codegraph.mdc</code>（<code>alwaysApply: true</code>）— ネイティブ grep より codegraph を優先させる指示。global では mcp.json のみ、rules は <code>codegraph init</code> でプロジェクトに生成</li>
+  </ul>
+
+  <h3>技術スタック・制約</h3>
+  <ul>
+    <li>ランタイム: Node 20–24（25+ は WASM OOM のためハードブロック、<code>CODEGRAPH_ALLOW_UNSAFE_NODE</code> で上書き可）</li>
+    <li>DB: <code>node:sqlite</code> + WAL（ネットワークドライブではロック問題の可能性）</li>
+    <li>配布: バンドル Node 付きバイナリ + npm シム、<code>.gitignore</code> 尊重、1MB 超ファイルスキップ</li>
+    <li>テスト: Vitest、36 ファイル・800+ ケース（本環境 Windows で 5 件タイムアウト — §3 参照）</li>
+  </ul>
+</section>
+
+<section class="entry" id="sec-cursor-effect">
+  <h2>2. 導入後の効果予測（Cursor 連携想定）</h2>
+  <p class="meta">
+    <span class="date">2026-05-25</span>
+    <span class="tag tag-type">analysis</span>
+    <span class="tag tag-scope">cursor</span>
+  </p>
+
+  <h3>前提（マスター環境）</h3>
+  <ul>
+    <li>Cursor を主エディタとし、プロジェクトごとに <code>.cursor/rules/</code> および MCP（<code>mcp.json</code>）を運用</li>
+    <li>対象リポジトリはマルウェア解析・汎用ツール制作など <strong>中〜大規模</strong>（Python/TS/C 混在）が多い</li>
+    <li>エージェントは構造探索（呼び出し関係・影響範囲）と実装の両方を行う</li>
+  </ul>
+
+  <h3>定量効果（上流ベンチマークの外挿）</h3>
+  <p>公式ベンチ（Claude Opus 4.7 headless、v0.9.4）では、CodeGraph 有効時の中央値で <strong>コスト約 35% 減・トークン約 57% 減・時間約 46% 短縮・ツール呼び出し約 71% 減</strong>。大規模 TS（VS Code）ではファイル Read ゼロで回答するケースが報告されています。</p>
+  <table>
+    <thead><tr><th>マスター側のリポジトリ規模感</th><th>期待される効果</th><th>根拠</th></tr></thead>
+    <tbody>
+      <tr><td>大（数千ファイル、複数言語）</td><td><strong>高</strong> — 探索ターン大幅削減</td><td>VS Code / Django ベンチに近い</td></tr>
+      <tr><td>中（数百〜千ファイル）</td><td><strong>中〜高</strong></td><td>Excalidraw / Tokio 級</td></tr>
+      <tr><td>小（&lt;200 ファイル）</td><td><strong>低〜中</strong></td><td>Gin 級 — ネイティブ grep でも十分な場合あり</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Cursor 特有の定性効果</h3>
+  <ol>
+    <li><strong>コンテキストウィンドウの節約</strong>: <code>codegraph_explore</code> が複数ファイルを 1 MCP 呼び出しにまとめるため、連続 Read よりトークン効率が良い。</li>
+    <li><strong>ルール連携</strong>: <code>codegraph.mdc</code> が常時適用されると、Agent が「grep 先行」を避け、既存の <code>.cursor/rules/*.mdc</code>（解析 OPSEC 等）と併用しやすい。</li>
+    <li><strong>マルウェア解析ワークフロー</strong>: デコンパイル C は CodeGraph 対象外だが、<strong>解析ツール本体（Python/TS）</strong> の改修・YARA 生成パイプライン理解では call graph / impact が有効。検体バイナリはインデックスしない運用と両立。</li>
+    <li><strong>オフライン・機密</strong>: 100% ローカル SQLite のため、顧客案件コードをクラウドに送らない方針と整合（§90-security-ethics と一致）。</li>
+  </ol>
+
+  <h3>導入時の推奨手順（Cursor）</h3>
+  <pre><code># 1. インストール（Windows）
+irm https://raw.githubusercontent.com/matrix9neonebuchadnezzar2199-sketch/codegraph/main/install.ps1 | iex
+# または: npm i -g @colbymchenry/codegraph
+
+# 2. Cursor 向け設定
+codegraph install --target=cursor --location=global --yes
+
+# 3. 各プロジェクト
+cd F:\Cursor\your-tool
+codegraph init -i   # インデックス + .cursor/rules/codegraph.mdc
+
+# 4. Cursor を再起動（MCP 読み込み）</code></pre>
+
+  <h3>リスク・効果を下げる要因</h3>
+  <ul>
+    <li><strong>初回インデックス</strong>: 大リポジトリでは数分〜十数分。完了前は MCP が「not initialized」。</li>
+    <li><strong>rules 未配置</strong>: global のみで <code>init -i</code> していないプロジェクトでは、エージェントが CodeGraph を使わずオーバーヘッドのみ、という README 上の注意と一致。</li>
+    <li><strong>動的言語・メタプログラミング</strong>: 解決できない呼び出しは trace で「動的ディスパッチ」注記 — 完全自動フロー追跡ではない。</li>
+    <li><strong>WSL / ネットワークドライブ</strong>: WAL 無効時は <code>database is locked</code> の可能性（README 記載）。</li>
+  </ul>
+
+  <h3>総合予測</h3>
+  <p>マスターの Cursor 運用（複数ツールリポジトリ・横断ルール・長時間 Agent セッション）では、<strong>構造理解・影響調査フェーズで 30〜50% 程度のトークン/ツールコール削減</strong>が現実的な見込み。字面検索・設定ファイル・ドキュメント編集のみのタスクでは効果は限定的。日本語化後はインストーラと MCP 説明文が読みやすくなり、<strong>導入率（init 実行・rules 維持）</strong>が上がる副次効果が見込める。</p>
+</section>
+
+<section class="entry" id="sec-quality-i18n">
+  <h2>3. コード品質・エラー耐性・完全日本語化（i18n）設計</h2>
+  <p class="meta">
+    <span class="date">2026-05-25</span>
+    <span class="tag tag-type">analysis</span>
+    <span class="tag tag-scope">docs</span>
+    <span class="tag tag-warn">warn</span>
+  </p>
+
+  <h3>品質評価サマリ</h3>
+  <table>
+    <thead><tr><th>観点</th><th>評価</th><th>根拠</th></tr></thead>
+    <tbody>
+      <tr><td>テスト網羅</td><td><span class="tag tag-ok">良好</span></td><td>803 passed / 817 total（2026-05-25 Windows 実行）。security・MCP・installer・framework 統合あり</td></tr>
+      <tr><td>エラー型</td><td><span class="tag tag-ok">良好</span></td><td><code>CodeGraphError</code> 階層 + Logger。握り潰しはテストで抑止</td></tr>
+      <tr><td>並行・ロック</td><td><span class="tag tag-ok">良好</span></td><td>FileLock、WAL、concurrent-locking テスト</td></tr>
+      <tr><td>プラットフォーム</td><td><span class="tag tag-warn">注意</span></td><td>Node 25 禁止、WASM OOM 対策（liftoff-only 再実行）。Windows で mcp-roots 系 5 テストがタイムアウト（stdio モックの環境依存の可能性）</td></tr>
+      <tr><td>依存関係</td><td><span class="tag tag-warn">注意</span></td><td><code>npm audit</code>: moderate 6 / high 2（dev 依存中心の想定 — 本番バンドルへの影響は要確認）</td></tr>
+      <tr><td>i18n</td><td><span class="tag tag-err">未実装</span></td><td>CLI/MCP/インストーラ/エラー文言は英語固定。<code>site/</code> の Docusaurus のみ i18next 依存</td></tr>
+    </tbody>
+  </table>
+
+  <h3>既知のバグ・エラーリスク</h3>
+  <ul>
+    <li><strong>Cursor cwd 問題</strong>: <code>--path</code> 未設定の手動 mcp.json では常に「not initialized」— インストーラ経由必須。</li>
+    <li><strong>Node 25 / 古い Node</strong>: 起動時に明示バナーで exit（意図的）。</li>
+    <li><strong>巨大ファイル・生成物</strong>: .gitignore 外の committed vendor/dist はインデックスされる — 運用で .gitignore 管理。</li>
+    <li><strong>MCP ツール説明の英語長文</strong>: Cursor のツール選択にそのまま載る — 日本語化でトークン削減の副効果は小さいが、人間可読性は向上。</li>
+    <li><strong>Windows CI ギャップ</strong>: mcp-roots タイムアウトは CI 未整備時に regression を見逃す可能性。</li>
+  </ul>
+
+  <h3>完全日本語化 — 設計方針</h3>
+  <p>「完全日本語化」は <strong>ユーザー向け文字列の 100% ロケール化</strong> を指し、シンボル名・ファイルパス・抽出されたソースコードは翻訳対象外とする。</p>
+
+  <h3>文字列レイヤ（推奨分割）</h3>
+  <table>
+    <thead><tr><th>レイヤ</th><th>現状</th><th>ja 化方法</th><th>優先度</th></tr></thead>
+    <tbody>
+      <tr><td>L1 CLI / インストーラ</td><td><code>@clack/prompts</code>、<code>codegraph.ts</code> の console</td><td><code>src/i18n/ja.json</code> + <code>t(key)</code></td><td>P0</td></tr>
+      <tr><td>L2 MCP tool <code>description</code></td><td><code>tools.ts</code> 英語長文</td><td>ロケール別 description オブジェクト、または <code>CODEGRAPH_LANG=ja</code> で切替</td><td>P0（Cursor 効果に直結）</td></tr>
+      <tr><td>L3 エージェント指示</td><td><code>instructions-template.ts</code>、<code>codegraph.mdc</code></td><td><code>instructions-template.ja.ts</code>、インストーラで言語選択</td><td>P0</td></tr>
+      <tr><td>L4 MCP 応答本文</td><td>markdown 英語（budget 文言等）</td><td>formatter 層で <code>locale</code> 引数</td><td>P1</td></tr>
+      <tr><td>L5 README / site</td><td>英語</td><td>README.ja.md、Docusaurus <code>ja</code> locale</td><td>P1</td></tr>
+      <tr><td>L6 エラー <code>message</code></td><td>英語</td><td>error code → メッセージマップ（ログは英語残し可）</td><td>P2</td></tr>
+    </tbody>
+  </table>
+
+  <h3>実装スケッチ</h3>
+  <pre><code>// src/i18n/index.ts（新規）
+export type Locale = 'en' | 'ja';
+export function resolveLocale(): Locale {
+  const env = process.env.CODEGRAPH_LANG?.toLowerCase();
+  if (env === 'ja' || env === 'ja-jp') return 'ja';
+  return 'en';
+}
+export function t(key: string, vars?: Record&lt;string, string&gt;): string { ... }
+
+// インストーラ
+codegraph install --lang=ja --target=cursor
+
+// MCP: initialize 時に clientInfo から推測はせず、明示 env のみ（再現性）</code></pre>
+
+  <h3>フォーク（codegraph-jp）向け追加要件</h3>
+  <ul>
+    <li><code>package.json</code> の <code>name</code> / インストール URL を <code>matrix9neonebuchadnezzar2199-sketch/codegraph</code> に合わせる（現状 upstream npm 名のまま）。</li>
+    <li>デフォルトロケール <code>ja</code>、<code>--lang=en</code> で英語に戻す（後方互換）。</li>
+    <li>Cursor rules の日本語版: 「構造質問は codegraph_* を優先」— 既存 <code>03-ai-behavior</code> ・ OPSEC ルールとの文体統一。</li>
+    <li>翻訳 QA: MCP description はモデルが読むため、<strong>簡潔な日本語</strong>（英語より短くても意味が通る）を優先。長文直訳は避ける。</li>
+  </ul>
+
+  <h3>品質ゲート（日本語化 PR 時）</h3>
+  <ul>
+    <li>既存 Vitest 全 pass（Windows で mcp-roots を <code>skipIf(process.platform==='win32')</code> するか、タイムアウト延長）</li>
+    <li>スナップショット: インストーラが書く <code>codegraph.mdc</code> の ja 版 golden file</li>
+    <li>手動: Cursor で <code>codegraph_status</code> → <code>codegraph_context</code> が日本語説明で表示されること</li>
+  </ul>
+</section>
+
+<section class="entry" id="sec-features">
+  <h2>4. 追加すべき機能の提案</h2>
+  <p class="meta">
+    <span class="date">2026-05-25</span>
+    <span class="tag tag-type">analysis</span>
+    <span class="tag tag-scope">tool</span>
+  </p>
+
+  <h3>優先度付き提案</h3>
+  <table>
+    <thead><tr><th>優先</th><th>機能</th><th>理由（マスター / fork 向け）</th></tr></thead>
+    <tbody>
+      <tr><td>P0</td><td><strong>日本語ロケール（§3 設計）</strong></td><td>fork 目的と一致。Cursor 導入の心理的ハードル低下</td></tr>
+      <tr><td>P0</td><td><strong>fork 用 install.ps1 / npm パッケージ名</strong></td><td>upstream URL ではなく sketch リポジトリを指す</td></tr>
+      <tr><td>P1</td><td><strong>Cursor 向け「初回セットアップ」検出</strong></td><td><code>codegraph_status</code> 失敗時に Agent 向け日本語ヒントを MCP エラー本文で返す</td></tr>
+      <tr><td>P1</td><td><strong>マルチルート / モノレポ</strong></td><td><code>F:\Cursor</code> 横断ツールでは子パッケージごとに <code>.codegraph</code> が分散 — workspace 内の nearest root 可視化ツール</td></tr>
+      <tr><td>P1</td><td><strong><code>codegraph affected</code> の Cursor タスク連携</strong></td><td>変更ファイルからテスト特定 → Agent の「テスト実行」判断を支援（既存 CLI あり、MCP 化）</td></tr>
+      <tr><td>P2</td><td><strong>YARA / ルールファイルの軽量インデックス</strong></td><td>文字列・メタは FTS のみ、tree-sitter 非対応拡張子の扱いを定義（解析ツール向け）</td></tr>
+      <tr><td>P2</td><td><strong>インデックス除外のプロジェクト設定</strong></td><td>ゼロ config 方針と両立する <code>.codegraph/config.toml</code> オプトイン（samples/ 等）</td></tr>
+      <tr><td>P2</td><td><strong>Windows CI</strong></td><td>mcp-roots タイムアウトの再発防止</td></tr>
+      <tr><td>P3</td><td><strong>IDE ステータスバー連携</strong></td><td>インデックス進捗・鮮度を Cursor 外から確認（LSP 不要の JSON ステータスファイル）</td></tr>
+      <tr><td>P3</td><td><strong>CHANGELOG / リリースの日本語要約</strong></td><td>fork 利用者向け</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Cursor + 既存ルールとの統合案</h3>
+  <p>マスターの <code>F:\Cursor\.cursor\rules/</code> に、CodeGraph 利用時と解析データ貼り付け時の境界を 1 本の <code>codegraph-opsec.mdc</code> で明示することを推奨する（例: デコンパイル C は CodeGraph に載せない、IoC は defang opt-in）。CodeGraph 本体ではなく <strong>ワークスペースルール</strong> で実装する方が、upstream マージと両立しやすい。</p>
+
+  <h3>検証</h3>
+  <p>本レポート作成時: <code>npm test</code> — 803 passed, 5 failed（<code>mcp-roots.test.ts</code> 等）。コミットハッシュは push 後に <code>git rev-parse --short HEAD</code> で追記可能。</p>
+</section>
+
+</main>
+<footer style="margin-top:32px;padding-top:16px;border-top:1px solid var(--border);color:var(--muted);font-size:13px;">
+  管理リポジトリ: <a href="https://github.com/matrix9neonebuchadnezzar2199-sketch/codegraph">matrix9neonebuchadnezzar2199-sketch/codegraph</a> · 作成: 2026-05-25 07:34 JST
+</footer>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="refresh" content="0; url=2026-05-25_codegraph-jp_導入分析レポート.html">
+<title>CodeGraph ドキュメント</title>
+</head>
+<body>
+<p><a href="2026-05-25_codegraph-jp_導入分析レポート.html">2026-05-25 CodeGraph 導入分析レポート</a></p>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,9 @@
 <title>CodeGraph ドキュメント</title>
 </head>
 <body>
-<p><a href="2026-05-25_codegraph-jp_導入分析レポート.html">2026-05-25 CodeGraph 導入分析レポート</a></p>
+<ul>
+  <li><a href="2026-05-25_codegraph-jp_導入分析レポート.html">導入分析レポート</a></li>
+  <li><a href="2026-05-25_b1-path-validation-patch.html">B1 パス検証統一パッチ（実施記録）</a></li>
+</ul>
 </body>
 </html>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,21 +47,65 @@ const SENSITIVE_PATHS = new Set([
 ]);
 
 /**
+ * Case-aware path prefix check. Returns true if `child` is `parent` or a
+ * descendant of `parent`. On Windows (and case-insensitive filesystems on
+ * macOS), comparison is case-insensitive.
+ */
+function pathStartsWith(child: string, parent: string): boolean {
+  const normalize = (p: string) => (process.platform === 'win32' ? p.toLowerCase() : p);
+  const c = normalize(child);
+  const p = normalize(parent);
+  return c === p || c.startsWith(p + path.sep);
+}
+
+/**
  * Validate that a resolved file path stays within the project root.
- * Prevents path traversal attacks (e.g. node.filePath = "../../etc/passwd").
  *
- * @param projectRoot - The project root directory
- * @param filePath - The relative file path to validate
+ * Prevents path traversal attacks via both relative escapes (`../../etc/passwd`)
+ * and symlink escapes (a symlink inside the project pointing outside it).
+ *
+ * Resolution strategy:
+ *   1. Logical check via `path.resolve` (cheap, catches `../` sequences)
+ *   2. Physical check via `fs.realpathSync` (catches symlink escapes)
+ *
+ * If `realpathSync` fails (broken symlink, permission denied, file does not
+ * exist yet), ENOENT falls back to the logical result for indexing of paths
+ * not yet on disk. Other errors (ELOOP, EACCES) are rejected conservatively.
+ *
+ * On Windows, comparison is case-insensitive to account for case-insensitive
+ * filesystems where `C:\Proj` and `c:\proj` refer to the same directory.
+ *
+ * @param projectRoot - The project root directory (must exist)
+ * @param filePath - Path to validate (relative to projectRoot, or absolute)
  * @returns The resolved absolute path, or null if it escapes the root
  */
 export function validatePathWithinRoot(projectRoot: string, filePath: string): string | null {
-  const resolved = path.resolve(projectRoot, filePath);
-  const normalizedRoot = path.resolve(projectRoot);
+  const resolvedPath = path.resolve(projectRoot, filePath);
+  const resolvedRoot = path.resolve(projectRoot);
 
-  if (!resolved.startsWith(normalizedRoot + path.sep) && resolved !== normalizedRoot) {
+  // Step 1: Logical check
+  if (!pathStartsWith(resolvedPath, resolvedRoot)) {
     return null;
   }
-  return resolved;
+
+  // Step 2: Physical check via realpath (catches symlink escapes)
+  try {
+    const realPath = fs.realpathSync(resolvedPath);
+    const realRoot = fs.realpathSync(resolvedRoot);
+    if (!pathStartsWith(realPath, realRoot)) {
+      return null;
+    }
+    return realPath;
+  } catch (err: unknown) {
+    const code = err && typeof err === 'object' && 'code' in err
+      ? (err as NodeJS.ErrnoException).code
+      : undefined;
+    // ENOENT: path not on disk yet — logical check already passed
+    if (code === 'ENOENT') {
+      return resolvedPath;
+    }
+    return null;
+  }
 }
 
 /**
@@ -108,42 +152,16 @@ export function validateProjectPath(dirPath: string): string | null {
 /**
  * Check if a file path resolves to a location within the given root directory.
  *
- * Prevents path traversal attacks by ensuring the resolved absolute path
- * starts with the resolved root path. Handles '..' sequences, symlink-like
- * relative paths, and platform-specific separators.
+ * Equivalent to `validatePathWithinRoot(rootDir, filePath) !== null` but
+ * returns a boolean. Use when you only need to gate on safety without
+ * needing the resolved path.
  *
  * @param filePath - The path to check (can be relative or absolute)
  * @param rootDir - The root directory that filePath must stay within
  * @returns true if filePath resolves to a location within rootDir
  */
 export function isPathWithinRoot(filePath: string, rootDir: string): boolean {
-  const resolvedPath = path.resolve(rootDir, filePath);
-  const resolvedRoot = path.resolve(rootDir);
-  return resolvedPath.startsWith(resolvedRoot + path.sep) || resolvedPath === resolvedRoot;
-}
-
-/**
- * Like isPathWithinRoot but also resolves symlinks via fs.realpathSync.
- *
- * This catches symlink escapes where the logical path appears to be within
- * root but the real path on disk points elsewhere. Falls back to logical
- * path checking if realpath resolution fails (e.g. broken symlink).
- */
-export function isPathWithinRootReal(filePath: string, rootDir: string): boolean {
-  // First do the cheap logical check
-  if (!isPathWithinRoot(filePath, rootDir)) {
-    return false;
-  }
-
-  // Then verify with realpath to catch symlink escapes
-  try {
-    const realPath = fs.realpathSync(path.resolve(rootDir, filePath));
-    const realRoot = fs.realpathSync(rootDir);
-    return realPath.startsWith(realRoot + path.sep) || realPath === realRoot;
-  } catch {
-    // If realpath fails (broken symlink, permissions), fall back to logical check
-    return true;
-  }
+  return validatePathWithinRoot(rootDir, filePath) !== null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Consolidates two path-validation helpers in `src/utils.ts` so that all callers
transparently get `realpath`-based symlink-escape protection. The public API
is preserved; only the internals of `validatePathWithinRoot` change.
This PR also includes fork-only HTML docs under docs/; the security fix is src/utils.ts + __tests__/security.test.ts only.

## Problem

`src/utils.ts` defines two helpers with overlapping intent:

- `validatePathWithinRoot(projectRoot, filePath)` — logical check only
  (`path.resolve` + prefix comparison)
- `isPathWithinRootReal(filePath, rootDir)` — same logical check, plus a
  `fs.realpathSync` step to catch symlink escapes

Every production call site uses the **logical-only** variant:

- `src/mcp/tools.ts` (all MCP tool handlers)
- `src/extraction/index.ts` (parser entry points)
- `src/context/*` (context builder)

`isPathWithinRootReal` is defined and exported but never imported anywhere
in the repo — `git grep isPathWithinRootReal` returns zero call sites. The
stronger check has been dead code since it was added.

As a result, a symlink inside the project tree whose target is outside the
project root passes validation: the logical path stays under the root, so
the prefix check succeeds, even though the on-disk resolution escapes the
project. There is no test today that exercises this scenario — the
`__tests__/security.test.ts` "Path Traversal Prevention" section only covers
relative-path traversal and a missing-id case.

## Change

`src/utils.ts`:

- `validatePathWithinRoot` now performs the logical check **and** a
  `fs.realpathSync` step. Resolved real paths are compared with a new
  case-aware helper so Windows roots (`C:\Proj` vs `c:\proj`) compare
  correctly on case-insensitive filesystems.
- `ENOENT` from `realpathSync` falls back to the logical result. This is
  intentional: indexing legitimately references files that may not exist
  on disk at validation time (deletions, race with the watcher). The
  logical prefix has already been verified at this point, so the
  attack surface for ENOENT is bounded to in-root paths.
- Other `realpathSync` errors (`ELOOP`, `EACCES`, etc.) are treated
  conservatively as rejections.
- `isPathWithinRoot` becomes a thin boolean wrapper around
  `validatePathWithinRoot`.
- `isPathWithinRootReal` is removed (verified dead).

`__tests__/security.test.ts`:

Seven new cases under a new "Path Traversal Prevention — symlink escapes"
block:

1. Relative `..` traversal rejected
2. Absolute path outside root rejected
3. Symlink inside project pointing outside — rejected (primary regression target)
4. Symlink inside project pointing inside — accepted
5. Nested valid paths accepted
6. Non-existent path inside/outside root — handled per ENOENT policy above
7. Windows-only: case-insensitive root comparison

Tests creating symlinks early-return on `EPERM`/`ENOSYS`, so Windows runners
without developer mode are not broken; they skip 2 of the 7 cases cleanly.

## Compatibility

- **Public API unchanged.** `validatePathWithinRoot`, `isPathWithinRoot`
  keep their signatures and return types. Callers that gate on
  `!== null` / boolean continue to behave identically for previously
  accepted paths.
- **Behavior change is strictly tightening.** Paths that used to pass and
  now fail are exactly the symlink-escape cases the helper was nominally
  supposed to block.
- **Returned resolved path now reflects realpath when available.** Existing
  callers store this in the DB and pass it to `fs.readFile`, both of which
  are unaffected (and arguably more consistent now that symlinked indirections
  are normalized).
- **No dependency changes.** No `package.json` touch.
- **No call-site changes required.** All three production modules
  (`mcp/tools.ts`, `extraction/index.ts`, `context/*`) keep working without
  edits.

## Verification
npm run build # clean npm test # full suite: see note below vitest run tests/security.test.ts # 44 passed / 2 skipped (the 2 are Windows-symlink # cases that early-return without admin privileges) git grep isPathWithinRootReal # 0 hits


In the fork's CI on Windows, 5 unrelated tests in `mcp-roots.*` fail with
`EBUSY` / timeout. These reproduce on `main` of this repo prior to the
patch and are not introduced by this PR. They appear consistent with the
known stdin-close → `process.exit(0)` race in `src/mcp/transport.ts`,
which I'll address in a separate PR.

## Out of scope

Deliberately not bundled here, to keep the diff focused and reviewable:

- `install.sh` / `install.ps1` SHA256 verification (the npm-shim path
  already verifies SHA256SUMS since 0.9.4; only the shell direct-install
  path is unguarded)
- MCP transport graceful shutdown (the `process.exit(0)` issue mentioned above)
- `src/mcp/tools.ts` decomposition (currently ~100 KB, single file)

Happy to send follow-ups for any of these if the direction is welcome.

## Diff size
src/utils.ts +92 -38 tests/security.test.ts +103 -0


---

**Author note:** Patch developed against a fork where I'm keeping a code
review log; I'm happy to omit or relocate any of that on merge. The
substantive change is fully contained in the two files above.



