### PR TITLE
fix(extraction): index .mts and .cts files

### DIFF
--- a/__tests__/extraction.test.ts
+++ b/__tests__/extraction.test.ts
@@ -33,6 +33,8 @@ function cleanupTempDir(dir: string): void {
 describe('Language Detection', () => {
   it('should detect TypeScript files', () => {
     expect(detectLanguage('src/index.ts')).toBe('typescript');
+    expect(detectLanguage('src/server.mts')).toBe('typescript');
+    expect(detectLanguage('src/server.cts')).toBe('typescript');
     expect(detectLanguage('components/Button.tsx')).toBe('tsx');
   });
 
@@ -3168,6 +3170,27 @@ export function multiply(a: number, b: number): number {
     cg.close();
   });
 
+  it('should index TypeScript ESM files with .mts extension', async () => {
+    const srcDir = path.join(tempDir, 'src');
+    fs.mkdirSync(srcDir);
+
+    fs.writeFileSync(
+      path.join(srcDir, 'server.mts'),
+      `export function esmHandler() { return 1; }`
+    );
+
+    const cg = CodeGraph.initSync(tempDir);
+    const result = await cg.indexAll();
+
+    expect(result.success).toBe(true);
+    expect(result.filesIndexed).toBe(1);
+
+    const nodes = cg.getNodesInFile('src/server.mts');
+    expect(nodes.some((n) => n.name === 'esmHandler')).toBe(true);
+
+    cg.close();
+  });
+
   it('should track file hashes for incremental updates', async () => {
     // Create initial file
     const srcDir = path.join(tempDir, 'src');
@@ -3392,6 +3415,20 @@ describe('Directory Exclusion', () => {
     expect(files.length).toBe(1);
     expect(files[0]).toBe('src/components/Button.tsx');
     expect(files[0]).not.toContain('\\');
+  });
+
+  it('should include explicit TypeScript module extensions during scanning', () => {
+    const srcDir = path.join(tempDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(srcDir, 'server.mts'), 'export const server = true;');
+    fs.writeFileSync(path.join(srcDir, 'worker.cts'), 'export const worker = true;');
+
+    const files = scanDirectory(tempDir);
+
+    expect(files).toEqual(expect.arrayContaining([
+      'src/server.mts',
+      'src/worker.cts',
+    ]));
   });
 });
 

--- a/__tests__/frameworks.test.ts
+++ b/__tests__/frameworks.test.ts
@@ -245,6 +245,14 @@ describe('expressResolver.extract', () => {
     const { nodes, references } = expressResolver.extract!('routes.ts', src);
     expect(references[0].referenceName).toBe('list');
   });
+
+  it('extracts routes from .mts files as TypeScript', () => {
+    const src = `app.get('/users', listUsers);\n`;
+    const { nodes, references } = expressResolver.extract!('routes.mts', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].language).toBe('typescript');
+    expect(references[0].language).toBe('typescript');
+  });
 });
 
 import { nestjsResolver } from '../src/resolution/frameworks/nestjs';
@@ -326,6 +334,21 @@ export class BController {
 `;
     const { nodes } = nestjsResolver.extract!('multi.controller.ts', src);
     expect(nodes.map((n) => n.name)).toEqual(['GET /a/x', 'GET /b/y']);
+  });
+
+  it('extracts HTTP routes from .mts controllers as TypeScript', () => {
+    const src = `
+@Controller('users')
+export class UsersController {
+  @Get()
+  findAll() { return []; }
+}
+`;
+    const { nodes, references } = nestjsResolver.extract!('users.controller.mts', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe('GET /users');
+    expect(nodes[0].language).toBe('typescript');
+    expect(references[0].language).toBe('typescript');
   });
 });
 
@@ -451,6 +474,18 @@ describe('nestjsResolver.detect', () => {
       getAllFiles: () => ['src/users.controller.ts'],
       readFile: (p: string) =>
         p === 'src/users.controller.ts'
+          ? `@Controller('users')\nexport class UsersController {}`
+          : null,
+    };
+    expect(nestjsResolver.detect(context as any)).toBe(true);
+  });
+
+  it('detects @Controller in a *.controller.mts file when package.json is absent', () => {
+    const context = {
+      ...baseContext,
+      getAllFiles: () => ['src/users.controller.mts'],
+      readFile: (p: string) =>
+        p === 'src/users.controller.mts'
           ? `@Controller('users')\nexport class UsersController {}`
           : null,
     };

--- a/__tests__/resolution.test.ts
+++ b/__tests__/resolution.test.ts
@@ -315,6 +315,28 @@ describe('Resolution Module', () => {
       expect(result).toBe('src/helpers.ts');
     });
 
+    it('should resolve explicit TypeScript module extensions', () => {
+      const context: ResolutionContext = {
+        getNodesInFile: () => [],
+        getNodesByName: () => [],
+        getNodesByQualifiedName: () => [],
+        getNodesByKind: () => [],
+        fileExists: (p) => p === 'src/components/utils.mts' || p === 'src/components/utils/index.mts',
+        readFile: () => null,
+        getProjectRoot: () => '',
+        getAllFiles: () => ['src/components/utils.mts', 'src/components/utils/index.mts'],
+      };
+
+      const result = resolveImportPath(
+        './utils',
+        'src/components/Button.mts',
+        'typescript',
+        context
+      );
+
+      expect(result).toBe('src/components/utils.mts');
+    });
+
     it('should extract JS/TS import mappings', () => {
       const content = `
 import { foo } from './foo';

--- a/src/extraction/grammars.ts
+++ b/src/extraction/grammars.ts
@@ -45,6 +45,8 @@ const WASM_GRAMMAR_FILES: Record<GrammarLanguage, string> = {
  */
 export const EXTENSION_MAP: Record<string, Language> = {
   '.ts': 'typescript',
+  '.mts': 'typescript',
+  '.cts': 'typescript',
   '.tsx': 'tsx',
   '.js': 'javascript',
   '.mjs': 'javascript',

--- a/src/resolution/frameworks/express.ts
+++ b/src/resolution/frameworks/express.ts
@@ -132,7 +132,7 @@ export const expressResolver: FrameworkResolver = {
   },
 
   extract(filePath, content) {
-    if (!/\.(m?js|tsx?|cjs)$/.test(filePath)) return { nodes: [], references: [] };
+    if (!/\.(?:[mc]?js|[mc]?ts|tsx)$/.test(filePath)) return { nodes: [], references: [] };
     const nodes: Node[] = [];
     const references: UnresolvedRef[] = [];
     const now = Date.now();
@@ -329,7 +329,7 @@ function resolveServiceMethod(
  * Detect language from file extension
  */
 function detectLanguage(filePath: string): 'typescript' | 'javascript' {
-  if (filePath.endsWith('.ts') || filePath.endsWith('.tsx')) {
+  if (/\.(?:[mc]?ts|tsx)$/.test(filePath)) {
     return 'typescript';
   }
   return 'javascript';

--- a/src/resolution/frameworks/nestjs.ts
+++ b/src/resolution/frameworks/nestjs.ts
@@ -41,6 +41,7 @@ type JsLang = 'typescript' | 'javascript';
 
 const HTTP_METHODS = ['Get', 'Post', 'Put', 'Patch', 'Delete', 'Head', 'Options', 'All'];
 const GQL_OPS = ['Query', 'Mutation', 'Subscription'];
+const NEST_FILE_PATTERN = /\.(?:controller|module|resolver|gateway)\.(?:[mc]?js|[mc]?ts)$/;
 
 export const nestjsResolver: FrameworkResolver = {
   name: 'nestjs',
@@ -64,13 +65,7 @@ export const nestjsResolver: FrameworkResolver = {
     // Fallback: NestJS-specific decorators in conventionally named files.
     const allFiles = context.getAllFiles();
     for (const file of allFiles) {
-      if (
-        file.endsWith('.controller.ts') ||
-        file.endsWith('.controller.js') ||
-        file.endsWith('.module.ts') ||
-        file.endsWith('.resolver.ts') ||
-        file.endsWith('.gateway.ts')
-      ) {
+      if (NEST_FILE_PATTERN.test(file)) {
         const content = context.readFile(file);
         if (
           content &&
@@ -111,7 +106,7 @@ export const nestjsResolver: FrameworkResolver = {
   },
 
   extract(filePath, content) {
-    if (!/\.(m?js|tsx?|cjs)$/.test(filePath)) return { nodes: [], references: [] };
+    if (!/\.(?:[mc]?js|[mc]?ts|tsx)$/.test(filePath)) return { nodes: [], references: [] };
     const nodes: Node[] = [];
     const references: UnresolvedRef[] = [];
     const now = Date.now();
@@ -512,7 +507,7 @@ function lineAt(safe: string, index: number): number {
 }
 
 function detectLanguage(filePath: string): JsLang {
-  if (filePath.endsWith('.ts') || filePath.endsWith('.tsx')) return 'typescript';
+  if (/\.(?:[mc]?ts|tsx)$/.test(filePath)) return 'typescript';
   return 'javascript';
 }
 

--- a/src/resolution/import-resolver.ts
+++ b/src/resolution/import-resolver.ts
@@ -14,9 +14,9 @@ import { applyAliases } from './path-aliases';
  * Extension resolution order by language
  */
 const EXTENSION_RESOLUTION: Record<string, string[]> = {
-  typescript: ['.ts', '.tsx', '.d.ts', '.js', '.jsx', '/index.ts', '/index.tsx', '/index.js'],
+  typescript: ['.ts', '.mts', '.cts', '.tsx', '.d.ts', '.js', '.jsx', '/index.ts', '/index.mts', '/index.cts', '/index.tsx', '/index.js'],
   javascript: ['.js', '.jsx', '.mjs', '.cjs', '/index.js', '/index.jsx'],
-  tsx: ['.tsx', '.ts', '.d.ts', '.js', '.jsx', '/index.tsx', '/index.ts', '/index.js'],
+  tsx: ['.tsx', '.ts', '.mts', '.cts', '.d.ts', '.js', '.jsx', '/index.tsx', '/index.ts', '/index.mts', '/index.cts', '/index.js'],
   jsx: ['.jsx', '.js', '/index.jsx', '/index.js'],
   python: ['.py', '/__init__.py'],
   go: ['.go'],


### PR DESCRIPTION
## Summary

Fixes #366 by indexing explicit TypeScript module extensions (`.mts` and `.cts`) anywhere CodeGraph already treats `.ts` files as TypeScript source.

Note: `.mjs` / `.cjs` were already present in the JavaScript extension map before this PR; the missing coverage here was the TypeScript ESM/CJS pair.

## Changes

- add `.mts` and `.cts` to the scanner/language extension map as TypeScript
- include `.mts`, `.cts`, `index.mts`, and `index.cts` in TypeScript import resolution
- update Express and NestJS framework extractors so route files using `.mts` / `.cts` are not skipped
- extend NestJS convention detection for files like `*.controller.mts` and `*.module.cts`
- add regression coverage for language detection, scanning, full indexing, import resolution, Express extraction, and NestJS detection/extraction

## Validation

- `npm ci`
- `npm run build`
- `npm test -- __tests__/frameworks.test.ts __tests__/extraction.test.ts __tests__/resolution.test.ts -t "(explicit TypeScript module extensions|TypeScript ESM files with \.mts|include explicit TypeScript module extensions|routes from \.mts|HTTP routes from \.mts|controller\.mts)"`

The broader targeted run `npm test -- __tests__/frameworks.test.ts __tests__/extraction.test.ts __tests__/resolution.test.ts` currently passes 425/426 tests on my Windows machine and fails only in the existing C/C++ include end-to-end cleanup path with `EBUSY: resource busy or locked, unlink ...\\.codegraph\\codegraph.db`; the new `.mts` / `.cts` coverage above passes.