### PR TITLE
feat(installer): add Zed editor support to agent installer

### DIFF
--- a/src/installer/targets/registry.ts
+++ b/src/installer/targets/registry.ts
@@ -13,6 +13,7 @@ import { cursorTarget } from './cursor';
 import { codexTarget } from './codex';
 import { opencodeTarget } from './opencode';
 import { hermesTarget } from './hermes';
+import { zedTarget } from './zed';
 
 export const ALL_TARGETS: readonly AgentTarget[] = Object.freeze([
   claudeTarget,
@@ -20,6 +21,7 @@ export const ALL_TARGETS: readonly AgentTarget[] = Object.freeze([
   codexTarget,
   opencodeTarget,
   hermesTarget,
+  zedTarget,
 ]);
 
 export function getTarget(id: string): AgentTarget | undefined {

--- a/src/installer/targets/types.ts
+++ b/src/installer/targets/types.ts
@@ -19,7 +19,7 @@ export type Location = 'global' | 'local';
  * lookup. New targets add a value here when they're added to the
  * registry. Keep these short and lowercase.
  */
-export type TargetId = 'claude' | 'cursor' | 'codex' | 'opencode' | 'hermes';
+export type TargetId = 'claude' | 'cursor' | 'codex' | 'opencode' | 'hermes' | 'zed';
 
 /**
  * Result of `target.detect(location)`.

--- a/src/installer/targets/zed.ts
+++ b/src/installer/targets/zed.ts
@@ -1,0 +1,91 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  AgentTarget,
+  DetectionResult,
+  InstallOptions,
+  Location,
+  WriteResult,
+} from './types';
+import {
+  readJsonFile,
+  writeJsonFile,
+  getMcpServerConfig,
+} from './shared';
+
+function globalConfigDir(): string {
+  const xdg = process.env.XDG_CONFIG_HOME && process.env.XDG_CONFIG_HOME.trim().length > 0
+    ? process.env.XDG_CONFIG_HOME
+    : path.join(os.homedir(), '.config');
+  return path.join(xdg, 'zed');
+}
+
+function configPath(): string {
+  return path.join(globalConfigDir(), 'zed-settings.json');
+}
+
+class ZedTarget implements AgentTarget {
+  readonly id = 'zed' as const;
+  readonly displayName = 'Zed Editor';
+  readonly docsUrl = 'https://zed.dev/docs';
+
+  supportsLocation(loc: Location): boolean {
+    return loc === 'global';
+  }
+
+  detect(loc: Location): DetectionResult {
+    if (loc !== 'global') {
+      return { installed: false, alreadyConfigured: false };
+    }
+    const file = configPath();
+    const config = readJsonFile(file);
+    const installed = fs.existsSync(file);
+    const alreadyConfigured = !!config.mcpServers?.codegraph;
+    return { installed, alreadyConfigured, configPath: file };
+  }
+
+  install(loc: Location, _opts: InstallOptions): WriteResult {
+    if (loc !== 'global') {
+      return {
+        files: [],
+        notes: ['Zed only supports global config. Re-run with --location=global.'],
+      };
+    }
+    const file = configPath();
+    const config = readJsonFile(file);
+
+    if (!config.mcpServers) config.mcpServers = {};
+    config.mcpServers.codegraph = getMcpServerConfig();
+
+    writeJsonFile(file, config);
+
+    return {
+      files: [{ path: file, action: 'created' }],
+      notes: ['Restart Zed for MCP server changes to take effect.'],
+    };
+  }
+
+  uninstall(loc: Location): WriteResult {
+    if (loc !== 'global') return { files: [] };
+    const file = configPath();
+    const config = readJsonFile(file);
+    if (config.mcpServers?.codegraph) {
+      delete config.mcpServers.codegraph;
+      writeJsonFile(file, config);
+      return { files: [{ path: file, action: 'removed' }] };
+    }
+    return { files: [{ path: file, action: 'not-found' }] };
+  }
+
+  printConfig(_loc: Location): string {
+    const snippet = JSON.stringify({ mcpServers: { codegraph: getMcpServerConfig() } }, null, 2);
+    return `# Add to ${configPath()}\n\n${snippet}\n`;
+  }
+
+  describePaths(_loc: Location): string[] {
+    return [configPath()];
+  }
+}
+
+export const zedTarget = new ZedTarget();


### PR DESCRIPTION
## Add Zed Editor Support to Installer

**Summary:**
- Adds Zed editor (“zed”) as a supported agent in the multi-agent installer.
- Users with Zed can now run `codegraph install --target=zed` to inject MCP server config.
- Zed integration closely follows the pattern for other agents.

**Implementation:**
- New file: `src/installer/targets/zed.ts`
- Register new agent in `src/installer/targets/registry.ts`
- Add `"zed"` to `TargetId` in `src/installer/targets/types.ts`

**Verification:**
- Run `codegraph install --target=zed` to confirm config is written as expected for Zed.
- Run `codegraph uninstall --target=zed` to remove config cleanly.

---