### PR TITLE
docs: clarify zero-config + built-in default-ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,23 +421,25 @@ cg.close();
 
 ## Configuration
 
-There isn't any — CodeGraph is zero-config. It indexes every file whose
-extension maps to a [supported language](#supported-languages) and **respects
-your `.gitignore`**: in git repos via git itself, and in non-git projects by
-reading `.gitignore` files directly (root and nested, the same way git would).
+There isn't any — CodeGraph is zero-config, with **no config file** to write or
+keep in sync. Language support is automatic from the file extension; there's
+nothing to wire up per language.
 
-What that means in practice:
+What it skips out of the box:
 
-- Anything git ignores — `node_modules`, build output, secrets in `.env` — is
-  never indexed. **To keep something out of the graph, add it to `.gitignore`.**
-- There's no config file to write or keep in sync, and nothing to wire up per
-  language: support is automatic from the file extension.
-- Files larger than 1 MB are skipped (generated bundles, minified JS, vendored
-  blobs) — they cost parse budget for no useful symbols.
+- **Dependency, build, and cache directories** — `node_modules`, `vendor`,
+  `dist`, `build`, `target`, `.venv`, `Pods`, `.next`, and the like across every
+  [supported stack](#supported-languages) — so the graph is your code, not
+  third-party noise. This holds even with no `.gitignore`.
+- **Anything in your `.gitignore`** — honored in git repos via git, and in
+  non-git projects by reading `.gitignore` directly (root and nested).
+- **Files larger than 1 MB** — generated bundles, minified JS, vendored blobs.
 
-> Committed files that aren't gitignored *are* indexed, even under `vendor/` or a
-> committed `dist/`. If you commit a dependency or build directory you don't want
-> in the graph, add it to `.gitignore`.
+To keep something else out, add it to `.gitignore`. To pull a default-excluded
+directory back **in** (say you really do want a vendored dependency indexed),
+add a negation — `!vendor/`. The defaults apply uniformly, so committing a
+dependency or build directory doesn't force it into the graph; the `.gitignore`
+negation is the explicit opt-in.
 
 ## Supported Platforms
 
@@ -502,7 +504,7 @@ the MCP server and writing its instructions file:
 
 **MCP server not connecting** — Ensure the project is initialized/indexed, verify the path in your MCP config, and check that `codegraph serve --mcp` works from the command line.
 
-**Missing symbols** — The MCP server auto-syncs on save (wait a couple seconds). Run `codegraph sync` manually if needed. Check that the file's language is supported and isn't excluded by config patterns.
+**Missing symbols** — The MCP server auto-syncs on save (wait a couple seconds). Run `codegraph sync` manually if needed. Check that the file's language is supported and isn't inside a `.gitignore`d or default-excluded directory (e.g. `node_modules`, `dist`).
 
 ## Star History
 

--- a/site/src/content/docs/getting-started/configuration.md
+++ b/site/src/content/docs/getting-started/configuration.md
@@ -1,19 +1,21 @@
 ---
 title: Configuration
-description: CodeGraph is zero-config — here's what that means in practice.
+description: CodeGraph is zero-config — there are no config files.
 ---
 
-There isn't any — CodeGraph is **zero-config**. It indexes every file whose extension maps to a [supported language](/codegraph/reference/languages/) and **respects your `.gitignore`**: in git repos via git itself, and in non-git projects by reading `.gitignore` files directly (root and nested, the same way git would).
+There isn't any — CodeGraph is **zero-config**, with **no config file** to write or keep in sync. Language support is automatic from the file extension; there's nothing to wire up per language.
 
-## What that means in practice
+## What it skips out of the box
 
-- Anything git ignores — `node_modules`, build output, secrets in `.env` — is never indexed. **To keep something out of the graph, add it to `.gitignore`.**
-- There's no config file to write or keep in sync, and nothing to wire up per language: support is automatic from the file extension.
-- Files larger than 1 MB are skipped (generated bundles, minified JS, vendored blobs) — they cost parse budget for no useful symbols.
+- **Dependency, build, and cache directories** — `node_modules`, `vendor`, `dist`, `build`, `target`, `.venv`, `Pods`, `.next`, and the like across every [supported stack](/codegraph/reference/languages/) — so the graph is your code, not third-party noise. This holds even with no `.gitignore`.
+- **Anything in your `.gitignore`** — honored in git repos via git, and in non-git projects by reading `.gitignore` directly (root and nested).
+- **Files larger than 1 MB** — generated bundles, minified JS, vendored blobs.
 
-:::note
-Committed files that aren't gitignored *are* indexed, even under `vendor/` or a committed `dist/`. If you commit a dependency or build directory you don't want in the graph, add it to `.gitignore`.
-:::
+## Excluding or including more
+
+To keep something else out, add it to `.gitignore`. To pull a default-excluded directory back **in** (e.g. you really want a vendored dependency indexed), add a negation — `!vendor/`.
+
+The defaults apply uniformly, so committing a dependency or build directory doesn't force it into the graph — the `.gitignore` negation is the explicit opt-in.
 
 ## Where data lives
 

--- a/site/src/content/docs/guides/indexing.md
+++ b/site/src/content/docs/guides/indexing.md
@@ -36,4 +36,4 @@ Reports node/edge/file counts, the active SQLite backend, and the journal mode.
 
 ## What gets indexed
 
-Every file whose extension maps to a [supported language](/codegraph/reference/languages/), minus anything your `.gitignore` excludes and files over 1 MB. See [Configuration](/codegraph/getting-started/configuration/).
+Every file whose extension maps to a [supported language](/codegraph/reference/languages/), minus dependency/build directories excluded by default (`node_modules`, `vendor`, `dist`, …), anything your `.gitignore` excludes, and files over 1 MB. See [Configuration](/codegraph/getting-started/configuration/).


### PR DESCRIPTION
Follow-up to #417 (default-ignore dirs) and the #407 discussion.

A sweep of the README, docs site, and `docs/` confirmed there are **no references to a codegraph config file** anywhere (no `.codegraph/config.json` / `.codegraphrc` / `codegraph.config.*`; that surface was removed in #285, only the historical CHANGELOG entry mentions it). But the "Configuration" docs were stale post-#417, so this refreshes them:

- **README `## Configuration`** + **site `getting-started/configuration.md`** — state plainly there are no config files; describe the built-in default-ignores (`node_modules`, `vendor`, `dist`, …) and the `.gitignore`-negation opt-in (`!vendor/`); **remove the now-inaccurate note** that committed `vendor/`/`dist/` dirs are indexed (they're excluded by default now).
- **README troubleshooting** — drop the stray "excluded by config patterns" phrasing (there are no config patterns) → `.gitignore`d / default-excluded dir.
- **site `guides/indexing.md`** — note dependency/build dirs are excluded by default, not just `.gitignore`.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)