### PR TITLE
fix: include anonymous callback and file-read dependents

### DIFF
--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -281,6 +281,36 @@ export { main };
       expect(Array.isArray(callers)).toBe(true);
     });
 
+    it('should include top-level anonymous callback bodies as file callers', async () => {
+      const callbacksPath = path.join(testDir, 'src', 'callbacks.ts');
+      fs.writeFileSync(
+        callbacksPath,
+        `
+import { formatValue } from './utils';
+
+Deno.serve(async (request) => {
+  return formatValue(1);
+});
+
+it('formats a value', async () => {
+  expect(formatValue(2)).toBe('2.00');
+});
+`
+      );
+
+      await cg.sync();
+      cg.resolveReferences();
+
+      const nodes = cg.getNodesByKind('function');
+      const formatValue = nodes.find((n) => n.name === 'formatValue');
+      expect(formatValue).toBeDefined();
+
+      const callers = cg.getCallers(formatValue!.id);
+      expect(callers.some(
+        (c) => c.node.kind === 'file' && c.node.filePath === 'src/callbacks.ts'
+      )).toBe(true);
+    });
+
     it('should get callees of a function', () => {
       const nodes = cg.getNodesByKind('function');
       const processValue = nodes.find((n) => n.name === 'processValue');
@@ -385,6 +415,26 @@ export { main };
       const dependents = cg.getFileDependents('src/utils.ts');
 
       expect(Array.isArray(dependents)).toBe(true);
+    });
+
+    it('should treat static file-read string paths as file dependents', async () => {
+      fs.writeFileSync(
+        path.join(testDir, 'src', 'source-contract.test.ts'),
+        `
+import { readFileSync } from 'fs';
+
+test('source contract', () => {
+  const source = readFileSync("src/utils.ts", "utf8");
+  expect(source).toContain('formatValue');
+});
+`
+      );
+
+      await cg.sync();
+      cg.resolveReferences();
+
+      const dependents = cg.getFileDependents('src/utils.ts');
+      expect(dependents).toContain('src/source-contract.test.ts');
     });
   });
 

--- a/__tests__/mcp-initialize.test.ts
+++ b/__tests__/mcp-initialize.test.ts
@@ -99,6 +99,20 @@ function waitFor<T>(
   });
 }
 
+function stopServer(child: ChildProcessWithoutNullStreams | null): Promise<void> {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, 5000);
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    child.kill('SIGKILL');
+  });
+}
+
 describe('MCP initialize handshake (issue #172)', () => {
   let tempDir: string;
   let child: ChildProcessWithoutNullStreams | null = null;
@@ -107,12 +121,10 @@ describe('MCP initialize handshake (issue #172)', () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-mcp-init-'));
   });
 
-  afterEach(() => {
-    if (child && !child.killed) {
-      child.kill('SIGKILL');
-      child = null;
-    }
-    fs.rmSync(tempDir, { recursive: true, force: true });
+  afterEach(async () => {
+    await stopServer(child);
+    child = null;
+    fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
   });
 
   it('responds to initialize quickly when no .codegraph exists in cwd', async () => {

--- a/__tests__/mcp-roots.test.ts
+++ b/__tests__/mcp-roots.test.ts
@@ -72,6 +72,20 @@ function send(child: ChildProcessWithoutNullStreams, msg: object): void {
   child.stdin.write(JSON.stringify(msg) + '\n');
 }
 
+function stopServer(child: ChildProcessWithoutNullStreams | null): Promise<void> {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, 5000);
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    child.kill('SIGKILL');
+  });
+}
+
 const CLIENT_INFO = { name: 'test', version: '0.0.0' };
 
 describe('MCP project resolution via roots/list (issue #196)', () => {
@@ -84,13 +98,11 @@ describe('MCP project resolution via roots/list (issue #196)', () => {
     projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-mcp-proj-'));
   });
 
-  afterEach(() => {
-    if (child && !child.killed) {
-      child.kill('SIGKILL');
-      child = null;
-    }
-    fs.rmSync(cwdDir, { recursive: true, force: true });
-    fs.rmSync(projectDir, { recursive: true, force: true });
+  afterEach(async () => {
+    await stopServer(child);
+    child = null;
+    fs.rmSync(cwdDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    fs.rmSync(projectDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
   });
 
   it('resolves the project from the client roots/list when no rootUri is sent', async () => {

--- a/__tests__/pr19-improvements.test.ts
+++ b/__tests__/pr19-improvements.test.ts
@@ -164,6 +164,52 @@ export const useAuth = () => {
     expect(callNames).toContain('generateToken');
   });
 
+  it('should extract unresolved references from anonymous callback bodies', () => {
+    const code = `
+Deno.serve(async (request) => {
+  const result = await confirmPayment(request);
+  return json(result);
+});
+
+it('runs crawler', async () => {
+  await runCrawl();
+});
+`;
+    const result = extractFromSource('callbacks.ts', code);
+
+    const anonymousFunctions = result.nodes.filter(
+      (n) => n.kind === 'function' && n.name === '<anonymous>'
+    );
+    expect(anonymousFunctions).toHaveLength(0);
+
+    const calls = result.unresolvedReferences.filter((r) => r.referenceKind === 'calls');
+    const callNames = calls.map((c) => c.referenceName);
+    expect(callNames).toContain('confirmPayment');
+    expect(callNames).toContain('json');
+    expect(callNames).toContain('runCrawl');
+  });
+
+  it('should extract project file references from file read calls', () => {
+    const code = `
+import { readFileSync } from 'fs';
+
+test('checks source contract', () => {
+  const source = readFileSync("supabase/functions/_shared/payment.ts", "utf8");
+  const page = Deno.readTextFileSync('app/app/page.tsx');
+  const dynamic = readFileSync(\`src/\${name}.ts\`, "utf8");
+  const remote = readFileSync("https://example.com/file.ts", "utf8");
+});
+`;
+    const result = extractFromSource('payment.test.ts', code);
+
+    const fileRefs = result.unresolvedReferences.filter((r) => r.referenceKind === 'imports');
+    const refNames = fileRefs.map((r) => r.referenceName);
+    expect(refNames).toContain('supabase/functions/_shared/payment.ts');
+    expect(refNames).toContain('app/app/page.tsx');
+    expect(refNames).not.toContain('https://example.com/file.ts');
+    expect(refNames.some((name) => name.includes('${'))).toBe(false);
+  });
+
   it('should extract unresolved references from function expression bodies', () => {
     const code = `
 export const processData = function(input: string): string {

--- a/src/extraction/tree-sitter.ts
+++ b/src/extraction/tree-sitter.ts
@@ -122,6 +122,15 @@ const INSTANTIATION_KINDS: ReadonlySet<string> = new Set([
   'instance_creation_expression',    // some grammars
 ]);
 
+const FILE_READ_CALL_NAMES: ReadonlySet<string> = new Set([
+  'readFileSync',
+  'readFile',
+  'readTextFile',
+  'readTextFileSync',
+]);
+
+const PROJECT_FILE_EXT_RE = /\.(?:[cm]?[jt]sx?|json|ya?ml|sql|md|css|scss|html)$/i;
+
 /**
  * TreeSitterExtractor - Main extraction class
  */
@@ -562,7 +571,18 @@ export class TreeSitterExtractor {
         }
       }
     }
-    if (name === '<anonymous>') return; // Skip anonymous functions
+    if (name === '<anonymous>') {
+      // Anonymous callbacks still contain real calls. Do not create a
+      // synthetic symbol, but do walk the body under the current scope so
+      // top-level wrappers like `Deno.serve(async () => handler())` and
+      // test callbacks like `it(..., async () => run())` preserve call edges.
+      const body = this.extractor.resolveBody?.(node, this.extractor.bodyField)
+        ?? getChildByField(node, this.extractor.bodyField);
+      if (body) {
+        this.visitFunctionBody(body, '');
+      }
+      return;
+    }
 
     // Check for misparse artifacts (e.g. C++ macros causing "namespace detail" functions)
     // Skip the node but still visit the body for calls and structural nodes
@@ -1517,7 +1537,52 @@ export class TreeSitterExtractor {
         line: node.startPosition.row + 1,
         column: node.startPosition.column,
       });
+      this.extractFilePathArgumentReferences(node, callerId, calleeName);
     }
+  }
+
+  private extractFilePathArgumentReferences(node: SyntaxNode, callerId: string, calleeName: string): void {
+    const callName = calleeName.split(/[.:]/).pop() ?? calleeName;
+    if (!FILE_READ_CALL_NAMES.has(callName)) return;
+
+    const args = getChildByField(node, 'arguments');
+    if (!args) return;
+
+    for (let i = 0; i < args.namedChildCount; i++) {
+      const arg = args.namedChild(i);
+      if (!arg) continue;
+      const filePath = this.getStaticStringLiteral(arg);
+      if (!filePath || !this.looksLikeProjectFilePath(filePath)) continue;
+
+      this.unresolvedReferences.push({
+        fromNodeId: callerId,
+        referenceName: filePath.replace(/\\/g, '/').replace(/^\.\//, ''),
+        referenceKind: 'imports',
+        line: arg.startPosition.row + 1,
+        column: arg.startPosition.column,
+      });
+    }
+  }
+
+  private getStaticStringLiteral(node: SyntaxNode): string | null {
+    const text = getNodeText(node, this.source).trim();
+    if (
+      (text.startsWith('"') && text.endsWith('"')) ||
+      (text.startsWith("'") && text.endsWith("'"))
+    ) {
+      return text.slice(1, -1);
+    }
+    if (text.startsWith('`') && text.endsWith('`') && !text.includes('${')) {
+      return text.slice(1, -1);
+    }
+    return null;
+  }
+
+  private looksLikeProjectFilePath(value: string): boolean {
+    if (!value || value.includes('\0')) return false;
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return false;
+    if (!PROJECT_FILE_EXT_RE.test(value)) return false;
+    return value.includes('/') || value.includes('\\') || value.startsWith('.');
   }
 
   /**


### PR DESCRIPTION
## Summary

- walk anonymous function and arrow callback bodies without creating synthetic anonymous symbols, preserving call edges from wrappers such as `Deno.serve(async () => handler())` and test callbacks like `it(..., async () => run())`
- treat static project file paths passed to file-read APIs such as `readFileSync()` and `Deno.readTextFileSync()` as file dependencies so `affected` can find source-contract tests
- make MCP subprocess tests wait for child process exit and retry temp directory removal on Windows to avoid `EBUSY` cleanup failures

## Validation

- `npx vitest run __tests__/pr19-improvements.test.ts __tests__/graph.test.ts __tests__/mcp-initialize.test.ts __tests__/mcp-roots.test.ts --minWorkers=1 --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000 --no-file-parallelism`
- `npm run build`
- `npx vitest run --minWorkers=1 --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000 --no-file-parallelism` — 35 passed, 2 skipped; 820 tests passed, 9 skipped
- smoke-tested against a real TS/Deno project: `callers runCrawl`, `callers confirmPayment`, and `affected supabase/functions/_shared/payment.ts` now return the expected caller/test files