### PR TITLE
docs(changelog): move 0.9.5 features from [Unreleased] into [0.9.5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.5] - 2026-05-25
+
 ### Added
 - **Shared MCP daemon — running multiple AI agents in the same project no
   longer multiplies the file-watch, SQLite, and indexing cost.** Point more
@@ -196,10 +198,6 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   watch count drops from ~1,200 to ~14, even when the project has no
   `.gitignore`. (Stacks with the shared daemon from #411: one watcher across
   agents, and now that watcher is small.)
-
-## [0.9.5] - 2026-05-25
-
-### Fixed
 - **The index now stays in sync after `git pull`, branch switches, and edits made
   outside your editor.** Incremental sync detected changes via `git status`, which
   only sees *uncommitted* edits — so code pulled or checked out (which leaves a


### PR DESCRIPTION
The 0.9.5 release tag (`318cda1`) included all of:

- Shared MCP daemon (#411)
- Per-file staleness banner + tunable watcher debounce (#403)
- Worktree-borrow detection (#312)
- Watcher inotify-budget fix (#276)
- Objective-C indexing (#165)
- Mixed iOS / React Native / Expo cross-language bridging (#430)

But the `[0.9.5]` block in CHANGELOG.md only had two Fixed entries (the fs-based change detection and the default-ignore set), because the major feature entries were still under `[Unreleased]` when 0.9.5 was tagged. `release.yml` extracts notes from the matching version block, so the published v0.9.5 release notes are missing the bulk of what shipped.

This PR moves the orphaned `[Unreleased]` entries into `[0.9.5]` and resets `[Unreleased]` to empty. The on-disk CHANGELOG.md is the source of truth for the release.yml extractor; the GitHub Release notes for v0.9.5 are updated separately via `gh release edit` (since the release tag is already published, we can't re-run the workflow).

Diff is small: 2 inserted lines (the new `## [0.9.5]` header line being prepended to the moved content), 4 deleted (the old empty `[0.9.5]` block with just `### Fixed` heading + two entries that get re-included in the moved content's Fixed section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)