### PR TITLE
chore: sync package-lock.json to 0.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@colbymchenry/codegraph",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@colbymchenry/codegraph",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.3.0",


### PR DESCRIPTION
The 0.9.5 release bumped `package.json` to 0.9.5 but `package-lock.json` stayed at 0.9.4 in both version fields (top-level + `packages[""]`). That's the exact EUSAGE-on-`npm ci` drift that #439's auto-sync workflow step now prevents going forward — but `main` is currently in the drifted state, which would break a fresh clone's `npm ci`.

## Why this isn't a release-yank situation

| | |
|---|---|
| Published `@colbymchenry/codegraph@0.9.5` tarball | Only contains `npm-shim.js`, `package.json`, `README.md`. No `package-lock.json` — npm never publishes lock files by default. |
| GitHub Release archives `codegraph-*.tar.gz` | Platform-bundled-Node tars from `build-bundle.sh`. No lock file either. |
| End-user `npm i -g @colbymchenry/codegraph@0.9.5` | Works as published. |
| Repo `npm ci` from main | ❌ EUSAGE error. This PR fixes that. |

So 0.9.5 stays released. This PR is just maintenance — sync `main`'s lock file to 0.9.5.

## Diff

Two lines: `package-lock.json`'s top-level `version` and `packages[""].version`, both `0.9.4` → `0.9.5`. No dependency upgrades, no other changes. Generated with `npm install --package-lock-only --ignore-scripts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)