### PR TITLE
Improve context lookup for code-like source strings

### DIFF
--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -202,6 +202,23 @@ export function env_var_for(provider: string): string {
 `
     );
 
+    // Create a Directus-style client file with cross-repo contract strings
+    // that are not symbols in the caller repo.
+    fs.writeFileSync(
+      path.join(srcDir, 'directus-client.ts'),
+      `export async function sendPayload(payload: unknown): Promise<Response> {
+  return fetch('/live-scoring/append-event', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function saveRecord(createItem: (collection: string) => Promise<unknown>): Promise<unknown> {
+  return createItem('game_matches');
+}
+`
+    );
+
     // Initialize CodeGraph
     cg = CodeGraph.initSync(testDir, {
       config: {
@@ -332,6 +349,22 @@ export function env_var_for(provider: string): string {
       expect(entryNames[0]).toBe('env_var_for');
       expect(entryNames).toContain('activeProviderHasEnvApiKey');
       expect(entryNames).toContain('providerEnvVars');
+    });
+
+    it('should route exact cross-repo contract strings to their enclosing caller functions', async () => {
+      const routeResult = await cg.findRelevantContext('/live-scoring/append-event', {
+        searchLimit: 3,
+        traversalDepth: 0,
+      });
+      const routeEntryNames = routeResult.roots.map((id) => routeResult.nodes.get(id)?.name);
+      expect(routeEntryNames).toContain('sendPayload');
+
+      const collectionResult = await cg.findRelevantContext('game_matches', {
+        searchLimit: 3,
+        traversalDepth: 0,
+      });
+      const collectionEntryNames = collectionResult.roots.map((id) => collectionResult.nodes.get(id)?.name);
+      expect(collectionEntryNames).toContain('saveRecord');
     });
   });
 

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -135,6 +135,27 @@ export function validateEmail(email: string): boolean {
 `
     );
 
+    // Create a provider config file with code-like string aliases that are not
+    // symbol names. Context search should still route these aliases to the
+    // enclosing implementation instead of returning no useful entry point.
+    fs.writeFileSync(
+      path.join(srcDir, 'provider-config.ts'),
+      `export function normalizeModelForProvider(model: string): string {
+  switch (model) {
+    case 'deepseek-r1':
+    case 'deepseek-reasoner':
+      return 'deepseek-ai/DeepSeek-V4-Pro';
+    default:
+      return model;
+  }
+}
+
+export function unrelatedProviderHelper(): string {
+  return 'not-this-one';
+}
+`
+    );
+
     // Initialize CodeGraph
     cg = CodeGraph.initSync(testDir, {
       config: {
@@ -209,6 +230,17 @@ export function validateEmail(email: string): boolean {
       });
 
       expect(result.nodes.size).toBeLessThanOrEqual(5);
+    });
+
+    it('should use code-like source text as a fallback entry point', async () => {
+      const result = await cg.findRelevantContext('deepseek-r1', {
+        searchLimit: 3,
+        traversalDepth: 0,
+      });
+
+      const nodeNames = Array.from(result.nodes.values()).map((n) => n.name);
+      expect(nodeNames).toContain('normalizeModelForProvider');
+      expect(nodeNames).not.toContain('unrelatedProviderHelper');
     });
   });
 

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -165,6 +165,10 @@ export function unrelatedProviderHelper(): string {
   return ['agent.trace-mode', 'billing.webhook.created'];
 }
 
+export function message(): string {
+  return 'generic helper';
+}
+
 export function resolveFeatureGate(key: string): boolean {
   if (key === 'agent.trace-mode') {
     return true;
@@ -179,6 +183,21 @@ export function lookupWebhookHandler(event: string): string {
     default:
       return 'ignoreWebhook';
   }
+}
+
+export function activeProviderHasEnvApiKey(provider: string): boolean {
+  return provider === 'siliconflow' && Boolean(process.env.SILICONFLOW_API_KEY);
+}
+
+export function providerEnvVars(): string[] {
+  return ['SILICONFLOW_API_KEY', 'DEEPSEEK_API_KEY'];
+}
+
+export function env_var_for(provider: string): string {
+  if (provider === 'siliconflow') {
+    return 'SILICONFLOW_API_KEY';
+  }
+  return 'DEEPSEEK_API_KEY';
 }
 `
     );
@@ -281,6 +300,17 @@ export function lookupWebhookHandler(event: string): string {
       expect(entryNames).toContain('genericAliasRegistry');
     });
 
+    it('should not over-boost generic lowercase word symbols over source-text matches', async () => {
+      const result = await cg.findRelevantContext('agent.trace-mode feature gate message history', {
+        searchLimit: 3,
+        traversalDepth: 0,
+      });
+
+      const entryNames = result.roots.map((id) => result.nodes.get(id)?.name);
+      expect(entryNames[0]).toBe('resolveFeatureGate');
+      expect(entryNames).toContain('message');
+    });
+
     it('should rank a webhook handler function above a generic alias registry', async () => {
       const result = await cg.findRelevantContext('billing.webhook.created webhook handler', {
         searchLimit: 3,
@@ -290,6 +320,18 @@ export function lookupWebhookHandler(event: string): string {
       const entryNames = result.roots.map((id) => result.nodes.get(id)?.name);
       expect(entryNames[0]).toBe('lookupWebhookHandler');
       expect(entryNames).toContain('genericAliasRegistry');
+    });
+
+    it('should rank an exact symbol match above broader source-text matches', async () => {
+      const result = await cg.findRelevantContext('env_var_for provider picker SILICONFLOW_API_KEY', {
+        searchLimit: 3,
+        traversalDepth: 0,
+      });
+
+      const entryNames = result.roots.map((id) => result.nodes.get(id)?.name);
+      expect(entryNames[0]).toBe('env_var_for');
+      expect(entryNames).toContain('activeProviderHasEnvApiKey');
+      expect(entryNames).toContain('providerEnvVars');
     });
   });
 

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -156,6 +156,33 @@ export function unrelatedProviderHelper(): string {
 `
     );
 
+    // Create a config-key fixture where code-like strings appear both in
+    // purpose-built functions and a generic alias registry. The purpose-built
+    // functions should rank first when the query provides semantic words.
+    fs.writeFileSync(
+      path.join(srcDir, 'runtime-config.ts'),
+      `export function genericAliasRegistry(): string[] {
+  return ['agent.trace-mode', 'billing.webhook.created'];
+}
+
+export function resolveFeatureGate(key: string): boolean {
+  if (key === 'agent.trace-mode') {
+    return true;
+  }
+  return false;
+}
+
+export function lookupWebhookHandler(event: string): string {
+  switch (event) {
+    case 'billing.webhook.created':
+      return 'handleBillingCreated';
+    default:
+      return 'ignoreWebhook';
+  }
+}
+`
+    );
+
     // Initialize CodeGraph
     cg = CodeGraph.initSync(testDir, {
       config: {
@@ -241,6 +268,28 @@ export function unrelatedProviderHelper(): string {
       const nodeNames = Array.from(result.nodes.values()).map((n) => n.name);
       expect(nodeNames).toContain('normalizeModelForProvider');
       expect(nodeNames).not.toContain('unrelatedProviderHelper');
+    });
+
+    it('should rank a feature flag function above a generic alias registry', async () => {
+      const result = await cg.findRelevantContext('agent.trace-mode feature gate', {
+        searchLimit: 3,
+        traversalDepth: 0,
+      });
+
+      const entryNames = result.roots.map((id) => result.nodes.get(id)?.name);
+      expect(entryNames[0]).toBe('resolveFeatureGate');
+      expect(entryNames).toContain('genericAliasRegistry');
+    });
+
+    it('should rank a webhook handler function above a generic alias registry', async () => {
+      const result = await cg.findRelevantContext('billing.webhook.created webhook handler', {
+        searchLimit: 3,
+        traversalDepth: 0,
+      });
+
+      const entryNames = result.roots.map((id) => result.nodes.get(id)?.name);
+      expect(entryNames[0]).toBe('lookupWebhookHandler');
+      expect(entryNames).toContain('genericAliasRegistry');
     });
   });
 

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -25,7 +25,7 @@ import { GraphTraverser } from '../graph';
 import { formatContextAsMarkdown, formatContextAsJson } from './formatter';
 import { logDebug } from '../errors';
 import { validatePathWithinRoot } from '../utils';
-import { isTestFile, extractSearchTerms, scorePathRelevance, getStemVariants } from '../search/query-utils';
+import { isTestFile, extractSearchTerms, scorePathRelevance, getStemVariants, kindBonus } from '../search/query-utils';
 
 /**
  * Extract likely symbol names from a natural language query
@@ -129,6 +129,54 @@ function extractSymbolsFromQuery(query: string): string[] {
   ]);
 
   return Array.from(symbols).filter(s => !commonWords.has(s.toLowerCase()));
+}
+
+const SOURCE_TEXT_MAX_FILE_SIZE = 1_000_000;
+const SOURCE_TEXT_MAX_TOKENS = 8;
+const SOURCE_TEXT_OCCURRENCES_PER_TOKEN = 3;
+const SOURCE_TEXT_BASE_SCORE = 160;
+const SOURCE_TEXT_TEST_PENALTY = 130;
+
+function extractCodeLikeSourceTokens(query: string): string[] {
+  const tokens = new Set<string>();
+  const tokenPattern = /[A-Za-z0-9][A-Za-z0-9_./:@-]{2,}/g;
+  let match: RegExpExecArray | null;
+  while ((match = tokenPattern.exec(query)) !== null) {
+    const token = match[0];
+    if (isCodeLikeSourceToken(token)) {
+      tokens.add(token);
+    }
+  }
+  return Array.from(tokens).slice(0, SOURCE_TEXT_MAX_TOKENS);
+}
+
+function isCodeLikeSourceToken(token: string): boolean {
+  const cleaned = token.trim();
+  if (cleaned.length < 3 || cleaned.length > 120) return false;
+  if (!/[A-Za-z0-9]/.test(cleaned)) return false;
+  if (!/[-_./:@]/.test(cleaned)) return false;
+  if (/^https?:\/\//i.test(cleaned)) return false;
+  return true;
+}
+
+function lineNumberAtIndex(content: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index; i++) {
+    if (content.charCodeAt(i) === 10) line++;
+  }
+  return line;
+}
+
+function isLikelyTestSourceNode(node: Node, lines: string[]): boolean {
+  const nameLower = node.name.toLowerCase();
+  if (/(^|_)(test|tests|spec|should|assert)(_|$)/.test(nameLower)) return true;
+
+  const beforeStart = Math.max(0, node.startLine - 4);
+  const leadingLines = lines
+    .slice(beforeStart, Math.max(0, node.startLine - 1))
+    .join('\n')
+    .toLowerCase();
+  return /#\[test\]|@test\b|\btest\s*\(|\bit\s*\(|\bdescribe\s*\(/.test(leadingLines);
 }
 
 /**
@@ -407,6 +455,9 @@ export class ContextBuilder {
       return { nodes, edges, roots };
     }
 
+    const queryLower = query.toLowerCase();
+    const isTestQuery = queryLower.includes('test') || queryLower.includes('spec');
+
     // === HYBRID SEARCH ===
 
     // Step 1: Extract potential symbol names from query
@@ -547,6 +598,20 @@ export class ContextBuilder {
       logDebug('Text search failed', { query, error: String(error) });
     }
 
+    // Step 3b: source-text fallback for code-like string literals and config keys.
+    // These often matter in provider aliases, feature flags, route names, and
+    // event channels, but they are not symbol names and therefore won't appear
+    // in node-name FTS. Search indexed source files only, then map each matching
+    // line back to the smallest enclosing indexed symbol so context still lands
+    // on implementation code rather than raw grep output.
+    let sourceTextResults: SearchResult[] = [];
+    try {
+      sourceTextResults = this.findSourceTextMatches(query, opts, isTestQuery);
+      logDebug('Source text fallback results', { count: sourceTextResults.length });
+    } catch (error) {
+      logDebug('Source text fallback failed', { query, error: String(error) });
+    }
+
     // Step 4: Merge results, taking the max score when duplicates appear
     // across search channels. Exact matches may have lower scores than FTS
     // results for the same node — use the best score from any channel.
@@ -575,8 +640,16 @@ export class ContextBuilder {
       }
     }
 
-    const queryLower = query.toLowerCase();
-    const isTestQuery = queryLower.includes('test') || queryLower.includes('spec');
+    // Add source-text matches, upgrading scores for duplicates.
+    for (const result of sourceTextResults) {
+      const existing = resultById.get(result.node.id);
+      if (existing) {
+        existing.score = Math.max(existing.score, result.score);
+      } else {
+        resultById.set(result.node.id, result);
+        searchResults.push(result);
+      }
+    }
 
     // Deprioritize test files early so they don't take multi-term boost slots
     if (!isTestQuery) {
@@ -1018,6 +1091,115 @@ export class ContextBuilder {
     }
 
     return { nodes: finalNodes, edges: finalEdges, roots };
+  }
+
+  private findSourceTextMatches(
+    query: string,
+    opts: Required<FindRelevantContextOptions>,
+    isTestQuery: boolean
+  ): SearchResult[] {
+    const tokens = extractCodeLikeSourceTokens(query);
+    if (tokens.length === 0) return [];
+
+    const queryTerms = extractSearchTerms(query, { stems: false });
+    const allowedKinds = opts.nodeKinds.length > 0 ? new Set(opts.nodeKinds) : null;
+    const byNode = new Map<string, { result: SearchResult; matchedTokens: Set<string> }>();
+
+    for (const file of this.queries.getAllFiles()) {
+      if (!isTestQuery && isTestFile(file.path)) continue;
+      if (file.size > SOURCE_TEXT_MAX_FILE_SIZE) continue;
+
+      const fullPath = validatePathWithinRoot(this.projectRoot, file.path);
+      if (!fullPath || !fs.existsSync(fullPath)) continue;
+
+      let content: string;
+      try {
+        content = fs.readFileSync(fullPath, 'utf-8');
+      } catch {
+        continue;
+      }
+
+      const contentLower = content.toLowerCase();
+      const matchedTokens = tokens.filter((token) => contentLower.includes(token.toLowerCase()));
+      if (matchedTokens.length === 0) continue;
+      const lines = content.split(/\r?\n/);
+
+      const fileNodes = this.queries.getNodesByFile(file.path);
+      if (fileNodes.length === 0) continue;
+
+      for (const token of matchedTokens) {
+        const tokenLower = token.toLowerCase();
+        let fromIndex = 0;
+        let occurrenceCount = 0;
+
+        while (occurrenceCount < SOURCE_TEXT_OCCURRENCES_PER_TOKEN) {
+          const index = contentLower.indexOf(tokenLower, fromIndex);
+          if (index === -1) break;
+
+          const line = lineNumberAtIndex(content, index);
+          const node = this.pickSourceTextMatchNode(fileNodes, line, allowedKinds);
+          if (node) {
+            const testPenalty = !isTestQuery && isLikelyTestSourceNode(node, lines) ? SOURCE_TEXT_TEST_PENALTY : 0;
+            const nodeText = lines
+              .slice(Math.max(0, node.startLine - 1), Math.max(0, node.endLine))
+              .join('\n')
+              .toLowerCase();
+            const termHitBonus =
+              queryTerms.filter((term) => nodeText.includes(term.toLowerCase())).length * 20;
+            const baseScore =
+              SOURCE_TEXT_BASE_SCORE +
+              kindBonus(node.kind) +
+              scorePathRelevance(node.filePath, query) +
+              termHitBonus +
+              Math.min(token.length, 40) / 4 -
+              testPenalty;
+            const existing = byNode.get(node.id);
+            if (existing) {
+              existing.matchedTokens.add(tokenLower);
+              existing.result.score = Math.max(existing.result.score, baseScore);
+            } else {
+              byNode.set(node.id, {
+                result: { node, score: baseScore },
+                matchedTokens: new Set([tokenLower]),
+              });
+            }
+          }
+
+          occurrenceCount++;
+          fromIndex = index + token.length;
+        }
+      }
+    }
+
+    return Array.from(byNode.values())
+      .map(({ result, matchedTokens }) => ({
+        ...result,
+        score: result.score + matchedTokens.size * 12,
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, opts.searchLimit * 2);
+  }
+
+  private pickSourceTextMatchNode(
+    nodes: Node[],
+    line: number,
+    allowedKinds: Set<NodeKind> | null
+  ): Node | null {
+    const candidates = nodes
+      .filter((node) => node.kind !== 'file')
+      .filter((node) => node.startLine <= line && line <= node.endLine)
+      .filter((node) => !allowedKinds || allowedKinds.has(node.kind))
+      .sort((a, b) => {
+        const aRange = a.endLine - a.startLine;
+        const bRange = b.endLine - b.startLine;
+        return aRange - bRange || a.startLine - b.startLine;
+      });
+
+    if (candidates.length > 0) return candidates[0]!;
+
+    const fileNode = nodes.find((node) => node.kind === 'file');
+    if (fileNode && (!allowedKinds || allowedKinds.has('file'))) return fileNode;
+    return null;
   }
 
   /**

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -136,6 +136,8 @@ const SOURCE_TEXT_MAX_TOKENS = 8;
 const SOURCE_TEXT_OCCURRENCES_PER_TOKEN = 3;
 const SOURCE_TEXT_BASE_SCORE = 160;
 const SOURCE_TEXT_TEST_PENALTY = 130;
+const SOURCE_TEXT_EXACT_NODE_NAME_BONUS = 700;
+const EXACT_SYMBOL_MATCH_BONUS = 700;
 
 function extractCodeLikeSourceTokens(query: string): string[] {
   const tokens = new Set<string>();
@@ -157,6 +159,12 @@ function isCodeLikeSourceToken(token: string): boolean {
   if (!/[-_./:@]/.test(cleaned)) return false;
   if (/^https?:\/\//i.test(cleaned)) return false;
   return true;
+}
+
+function isSpecificExactSymbol(symbol: string): boolean {
+  const cleaned = symbol.trim();
+  if (isCodeLikeSourceToken(cleaned)) return true;
+  return /[a-z][A-Z]/.test(cleaned) || /[A-Z][a-z]/.test(cleaned) || /^[A-Z0-9_]{2,}$/.test(cleaned);
 }
 
 function lineNumberAtIndex(content: string, index: number): number {
@@ -473,6 +481,14 @@ export class ContextBuilder {
           limit: Math.ceil(opts.searchLimit * 5),
           kinds: opts.nodeKinds && opts.nodeKinds.length > 0 ? opts.nodeKinds : undefined,
         });
+
+        const exactSymbolNames = new Set(
+          symbolsFromQuery.filter(isSpecificExactSymbol).map(s => s.toLowerCase())
+        );
+        exactMatches = exactMatches.map(r => exactSymbolNames.has(r.node.name.toLowerCase())
+          ? { ...r, score: r.score + EXACT_SYMBOL_MATCH_BONUS }
+          : r
+        );
 
         // Co-location boost: when multiple extracted symbols appear in the same file,
         // those results are much more likely to be what the user is looking for.
@@ -1146,11 +1162,14 @@ export class ContextBuilder {
               .toLowerCase();
             const termHitBonus =
               queryTerms.filter((term) => nodeText.includes(term.toLowerCase())).length * 20;
+            const exactNodeNameBonus =
+              tokenLower === node.name.toLowerCase() ? SOURCE_TEXT_EXACT_NODE_NAME_BONUS : 0;
             const baseScore =
               SOURCE_TEXT_BASE_SCORE +
               kindBonus(node.kind) +
               scorePathRelevance(node.filePath, query) +
               termHitBonus +
+              exactNodeNameBonus +
               Math.min(token.length, 40) / 4 -
               testPenalty;
             const existing = byNode.get(node.id);


### PR DESCRIPTION
## Summary

- add a source-text fallback inside context lookup for code-like string literals/config keys such as `deepseek-r1`
- map source-text hits back to the smallest enclosing indexed symbol so context still returns implementation nodes instead of raw grep output
- deprioritize likely test/spec nodes for non-test queries and add coverage for string-alias lookup
- preserve exact code-symbol intent: specific queried symbols such as `env_var_for` now outrank broader source-text matches, while generic lowercase words such as `message` are not over-boosted

## Why

`codegraph_context` could miss important implementation code when the user query named a code-like string that appears only inside function bodies, provider aliases, feature flags, event names, or route keys. In that case the existing node-name FTS path may return generic symbols or nothing useful, even though the indexed source contains an exact match.

This keeps the existing tool flow intact: agents still call `codegraph_context`, but the context builder can use exact code-like source text as an additional high-signal entry point.

## Validation

- `npx vitest run __tests__/context.test.ts` — 22 passed
- `npm run build` — passed
- DeepSeek-TUI real-source validation after rebuilding `dist/bin/codegraph.js`: 7 function-specific context queries all ranked the expected function first:
  - `normalize_model_for_provider` — `crates/config/src/lib.rs:1189`
  - `sanitize_thinking_mode_messages` — `crates/tui/src/client/chat.rs:1461`
  - `active_provider_has_env_api_key` — `crates/tui/src/config.rs:3464`
  - `env_for` — `crates/secrets/src/lib.rs:526`
  - `provider_env_vars` — `crates/cli/src/lib.rs:761`
  - `env_var_for` — `crates/tui/src/tui/provider_picker.rs:87`
  - `requires_reasoning_content` — `crates/tui/src/client/chat.rs:1591`
- Also attempted `npm test`; local Windows run was blocked outside this change by MCP process tests failing to remove temp directories with `EPERM` plus a worker OOM after most tests had already passed.