### PR TITLE
fix(installer): tell Kiro IDE users to enable MCP in Settings

### DIFF
--- a/src/installer/targets/kiro.ts
+++ b/src/installer/targets/kiro.ts
@@ -79,7 +79,15 @@ class KiroTarget implements AgentTarget {
     files.push(writeSteeringEntry(loc));
     return {
       files,
-      notes: ['Restart Kiro for MCP changes to take effect.'],
+      // The IDE-only enable-MCP step is load-bearing: Kiro IDE ships
+      // with MCP support disabled by default, so even a valid
+      // `~/.kiro/settings/mcp.json` at the documented path is ignored
+      // until the user flips the toggle. Kiro CLI reads the same file
+      // without a gate, so we call out which audience this applies to.
+      notes: [
+        'Restart Kiro for MCP changes to take effect.',
+        'Kiro IDE: also enable MCP in Settings (search "MCP" → "Enabled"). Kiro CLI users can skip this step.',
+      ],
     };
   }
 


### PR DESCRIPTION
## Summary
PR #473 emitted only *"Restart Kiro for MCP changes to take effect."* on a successful Kiro install. That note is incomplete for **Kiro IDE** users: the IDE ships with MCP support disabled by default, so a freshly-written `~/.kiro/settings/mcp.json` is ignored until the user opens Settings (`Cmd+,`), searches "MCP", and flips the **"Kiro Agent: Configure MCP"** dropdown to **Enabled**. Before flipping it, the agent reports *"No MCP powers installed"* and falls back to grep/Read — which looks like an installer wiring bug but isn't (`~/.kiro/powers/installed.json` stays at `installedPowers: []`).

Kiro **CLI** doesn't gate on this flag — it reads the same file without any toggle — so the second note explicitly says which audience needs the extra step.

## Validated live
```
◆  Kiro: Updated ~/.kiro/settings/mcp.json
◆  Kiro: Unchanged ~/.kiro/steering/codegraph.md
●  Kiro: Restart Kiro for MCP changes to take effect.
●  Kiro: Kiro IDE: also enable MCP in Settings (search "MCP" → "Enabled"). Kiro CLI users can skip this step.
```

Discovered while validating that PR #473 actually worked end-to-end in Kiro IDE on a clean install — the install was correct, the IDE just needed a one-time toggle. Future users with no prior context will hit this on first install; calling it out in the installer's own output is the cheapest fix.

## Test plan
- [x] `npm run build` clean.
- [x] `npx vitest run __tests__/installer-targets.test.ts` — 132/132 pass (no test asserted on the `notes` content, so the existing contract still holds).
- [x] Live install on a real `~/.kiro/` prints both notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)