### PR TITLE
docs(claude): correct Node engines floor to match package.json (>=20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ npx vitest run __tests__/extraction.test.ts -t "TypeScript"
 
 `copy-assets` (called from `build`) copies `src/db/schema.sql` and all `src/extraction/wasm/*.wasm` files into `dist/`. **Any new SQL or grammar wasm must be copied or it won't ship.**
 
-Node engines: `>=18.0.0 <25.0.0`. There is a hard exit on Node 25.x (see `src/bin/node-version-check.ts`).
+Node engines: `>=20.0.0 <25.0.0`. There is a hard exit on Node 25.x (see `src/bin/node-version-check.ts`).
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

CLAUDE.md's Build/Test/Run section currently states:

> Node engines: `>=18.0.0 <25.0.0`

But the actual floor in `package.json` (`engines.node`) is `>=20.0.0 <25.0.0`, and `src/bin/node-version-check.ts` exports `MIN_NODE_MAJOR = 20` — which the CLI hard-blocks against on startup. A new contributor reading CLAUDE.md and trying to validate on Node 18 hits the unsupported-Node banner instead of the expected build/test flow.

One-line fix: bring the doc in line with the enforced floor.

## Test plan

- [x] `git diff` shows a single one-character change in CLAUDE.md
- [x] No code or build changes