### PR TITLE
test(vitest): unblock subprocess MCP tests on Node >= 25 dev machines (#478)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,20 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['__tests__/**/*.test.ts'],
+    /**
+     * Several MCP integration tests (mcp-daemon, mcp-initialize, mcp-ppid-watchdog,
+     * mcp-roots) spawn `dist/bin/codegraph.js serve --mcp` with `process.execPath`
+     * and rely on the child inheriting `process.env`. On a Node >= 25 dev machine
+     * the CLI's hard-block (src/bin/codegraph.ts) would otherwise exit the child
+     * before it ever responds, so every spawn-based test times out — see #478.
+     *
+     * Setting the override here keeps the CLI's runtime guard intact for end
+     * users (it's still enforced when `codegraph` is invoked directly) while
+     * letting the test suite run on whatever Node the contributor happens to
+     * have installed. CI on Node 22/23 is unaffected — the guard doesn't fire
+     * there, so the variable is a no-op.
+     */
+    env: { CODEGRAPH_ALLOW_UNSAFE_NODE: '1' },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

Closes #478.

On a developer machine running Node.js 25+, `npm test` against `main` reports **13 failures across 4 files** (mcp-daemon, mcp-initialize, mcp-ppid-watchdog, mcp-roots). Every failure is a subprocess test: each one spawns `dist/bin/codegraph.js serve --mcp` with `process.execPath` and waits for a JSON-RPC response. On Node ≥25 the spawned child hits the CLI's hard-block (`src/bin/codegraph.ts:65`) and exits before responding, so `waitForMessage` times out.

The CLI's block exists to keep end users off Node 25's V8 turboshaft WASM JIT Zone bug (#81). Test scenarios don't actually exercise that path — they spin up short-lived servers, exchange a few JSON-RPC frames, and tear down — so the right thing is to opt the **test runner's spawned children** out of the block, while leaving the runtime guard intact for everyone else.

## Change

One added field in `vitest.config.ts`:

```ts
env: { CODEGRAPH_ALLOW_UNSAFE_NODE: '1' },
```

Vitest puts this into `process.env` for the test process. Every affected test either (a) spawns without `env` (default = inherit `process.env`) or (b) spawns with `env: { ...process.env, ... }`, so the variable flows into the child unchanged. No test file or production source is modified.

## Validation

On Node 26.0.0 (this dev box), before:

```
Test Files  4 failed | 44 passed (48)
     Tests  13 failed | 1019 passed | 2 skipped (1034)
```

After:

```
Test Files  48 passed (48)
     Tests  1032 passed | 2 skipped (1034)
```

The runtime guard is still enforced when `codegraph` is invoked directly — `node dist/bin/codegraph.js status` on Node 26 still prints the banner and exits with code 1.

## Notes for review

- CI on Node 22/23 is unaffected — the guard doesn't fire there, so the variable is a no-op.
- The `node-version-check.test.ts` unit tests (which assert the banner content) are unrelated and continue to pass — they call the banner builders directly, not via spawn.
- `CLAUDE.md`'s "Known pre-existing Windows failures" note explains the *Windows* failure mode for `mcp-initialize.test.ts` / `mcp-roots.test.ts` (EPERM in afterEach). The macOS/Linux Node ≥25 failure mode is different (timeouts on the parent side, child exits 1 on startup), and is now addressed by this PR — happy to add a follow-up doc tweak to CLAUDE.md if useful.

## Test plan

- [x] `npm test` green on Node 26.0.0
- [x] `node dist/bin/codegraph.js status` still prints the unsupported-version banner and exits 1 on Node 26.0.0 (guard intact for end users)
- [ ] CI green on Node 22/23 (no behavior change expected)