### PR TITLE
feat(cli): add --max-file-size flag to index/sync/init (#369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New Features
 
+- **`codegraph index --max-file-size <size>` (also on `init` and `sync`) lets CI override the 1 MiB skip threshold (#369).** The previous compile-time `MAX_FILE_SIZE = 1 MiB` constant is now `DEFAULT_MAX_FILE_SIZE` and falls back unchanged when no override is given — so existing workflows behave identically. The flag accepts both raw byte counts (`1048576`) and human-readable sizes with binary multipliers (`500kb`, `2 MB`, `1.5GB`, `700KiB`); both decimal and IEC suffixes resolve to the binary base (×1024) to match what `du`/`ls -lh` report and the 1 MiB default the codebase has always used. Invalid values exit with a clear error (`Invalid --max-file-size value: …`) rather than silently coercing. Library consumers get the same control via `CodeGraph.indexAll({ maxFileSize })` / `sync({ maxFileSize })`. Closes #369.
+
 - `codegraph status --json` now also reports the running CLI `version`, the index directory (`indexPath`), and a `lastIndexed` timestamp (ISO-8601, or null when nothing's indexed yet), so CI and scripts can pin the CLI version and check index freshness from a single command. A matching `CodeGraph.getLastIndexedAt()` library method exposes the same freshness check without shelling out. Thanks @12122J and @eddieran. (#329)
 
 ### Fixes

--- a/__tests__/max-file-size.test.ts
+++ b/__tests__/max-file-size.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the configurable max-file-size limit (#369).
+ *
+ * Three layers under test:
+ *   1. `parseFileSize` — pure unit conversion of human-readable sizes.
+ *   2. `CodeGraph.indexAll({ maxFileSize })` — the library plumbing that
+ *      controls which files the orchestrator skips.
+ *   3. `codegraph index --max-file-size` — the CLI flag that surfaces it,
+ *      driven through the built binary end-to-end so the rejection path
+ *      (invalid suffix → exit 1) and the happy path both stay covered.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { CodeGraph } from '../src';
+import { parseFileSize } from '../src/utils';
+
+const BIN = path.resolve(__dirname, '../dist/bin/codegraph.js');
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-max-size-'));
+}
+
+describe('parseFileSize()', () => {
+  it('accepts plain byte counts', () => {
+    expect(parseFileSize('0')).toBe(0);
+    expect(parseFileSize('1024')).toBe(1024);
+    expect(parseFileSize('1048576')).toBe(1024 * 1024);
+  });
+
+  it('accepts kb/mb/gb suffixes (case-insensitive, with or without spaces)', () => {
+    expect(parseFileSize('1kb')).toBe(1024);
+    expect(parseFileSize('500KB')).toBe(500 * 1024);
+    expect(parseFileSize('2 mb')).toBe(2 * 1024 * 1024);
+    expect(parseFileSize('1.5GB')).toBe(Math.floor(1.5 * 1024 * 1024 * 1024));
+  });
+
+  it('accepts IEC binary suffixes (kib/mib/gib)', () => {
+    expect(parseFileSize('1kib')).toBe(1024);
+    expect(parseFileSize('1 MiB')).toBe(1024 * 1024);
+    expect(parseFileSize('2GiB')).toBe(2 * 1024 * 1024 * 1024);
+  });
+
+  it('returns null for malformed inputs', () => {
+    expect(parseFileSize('')).toBeNull();
+    expect(parseFileSize('   ')).toBeNull();
+    expect(parseFileSize('abc')).toBeNull();
+    expect(parseFileSize('-1mb')).toBeNull();
+    expect(parseFileSize('1.5xb')).toBeNull(); // unknown unit
+    expect(parseFileSize('1.2.3mb')).toBeNull();
+  });
+});
+
+describe('CodeGraph.indexAll({ maxFileSize })', () => {
+  let tempDir: string;
+
+  beforeEach(() => { tempDir = createTempDir(); });
+  afterEach(() => { fs.rmSync(tempDir, { recursive: true, force: true }); });
+
+  it('skips files larger than a tightened maxFileSize', async () => {
+    // A small file that any reasonable limit will accept...
+    fs.writeFileSync(path.join(tempDir, 'small.ts'), 'export const x = 1;\n');
+    // ...and a larger file we want the override to exclude. ~5 KiB of source
+    // is well below the 1 MiB default, so the only thing that can drop it is
+    // a custom maxFileSize.
+    const bigContent = `export const items = [\n${'  "x",\n'.repeat(700)}];\n`;
+    fs.writeFileSync(path.join(tempDir, 'big.ts'), bigContent);
+
+    const cg = CodeGraph.initSync(tempDir);
+    const result = await cg.indexAll({ maxFileSize: 1024 }); // 1 KiB
+
+    expect(result.success).toBe(true);
+    const sizeSkipped = result.errors.filter((e) => e.code === 'size_exceeded');
+    expect(sizeSkipped.map((e) => e.filePath)).toContain('big.ts');
+    expect(sizeSkipped.map((e) => e.filePath)).not.toContain('small.ts');
+
+    cg.close();
+  });
+
+  it('falls back to the 1 MiB default when no override is supplied', async () => {
+    // ~5 KiB — comfortably under the default. Both files must index.
+    fs.writeFileSync(path.join(tempDir, 'small.ts'), 'export const x = 1;\n');
+    const medium = `export const items = [\n${'  "x",\n'.repeat(700)}];\n`;
+    fs.writeFileSync(path.join(tempDir, 'medium.ts'), medium);
+
+    const cg = CodeGraph.initSync(tempDir);
+    const result = await cg.indexAll();
+
+    expect(result.errors.filter((e) => e.code === 'size_exceeded')).toEqual([]);
+    expect(result.filesIndexed).toBeGreaterThanOrEqual(2);
+
+    cg.close();
+  });
+});
+
+describe('codegraph index --max-file-size CLI flag', () => {
+  let tempDir: string;
+
+  beforeAll(() => {
+    if (!fs.existsSync(BIN)) {
+      throw new Error(`dist/ not built — run \`npm run build\` before this test. Missing: ${BIN}`);
+    }
+  });
+
+  beforeEach(() => { tempDir = createTempDir(); });
+  afterEach(() => { fs.rmSync(tempDir, { recursive: true, force: true }); });
+
+  it('rejects an invalid size string with a clear error and exit code 1', () => {
+    // Initialize so we're past the "not initialized" guard and the flag is
+    // exercised on its own merits.
+    const cg = CodeGraph.initSync(tempDir);
+    cg.close();
+
+    let stderr = '';
+    let exitCode = 0;
+    try {
+      execFileSync(process.execPath, [BIN, 'index', '--max-file-size', 'banana', '--quiet'], {
+        cwd: tempDir,
+        encoding: 'utf-8',
+        env: { ...process.env, CODEGRAPH_ALLOW_UNSAFE_NODE: '1' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (err: unknown) {
+      const e = err as { status?: number; stderr?: string };
+      exitCode = e.status ?? 0;
+      stderr = e.stderr ?? '';
+    }
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/Invalid --max-file-size value/);
+    expect(stderr).toContain('banana');
+  });
+
+  it('accepts a human-readable size and applies it', () => {
+    fs.writeFileSync(path.join(tempDir, 'small.ts'), 'export const x = 1;\n');
+    // ~5 KiB file, deliberately above our 1 KiB CLI override.
+    const big = `export const items = [\n${'  "x",\n'.repeat(700)}];\n`;
+    fs.writeFileSync(path.join(tempDir, 'big.ts'), big);
+
+    const cg = CodeGraph.initSync(tempDir);
+    cg.close();
+
+    execFileSync(process.execPath, [BIN, 'index', '--max-file-size', '1kb', '--quiet'], {
+      cwd: tempDir,
+      encoding: 'utf-8',
+      env: { ...process.env, CODEGRAPH_ALLOW_UNSAFE_NODE: '1' },
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+
+    // Re-open the now-built index and assert big.ts dropped while small.ts kept.
+    const reopened = CodeGraph.openSync(tempDir);
+    try {
+      const files = reopened.getFiles().map((f) => f.path);
+      expect(files).toContain('small.ts');
+      expect(files).not.toContain('big.ts');
+    } finally {
+      reopened.close();
+    }
+  });
+});

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -32,6 +32,7 @@ import { getGlyphs } from '../ui/glyphs';
 
 import { buildNode25BlockBanner, buildNodeTooOldBanner, MIN_NODE_MAJOR } from './node-version-check';
 import { relaunchWithWasmRuntimeFlagsIfNeeded } from '../extraction/wasm-runtime-flags';
+import { parseFileSize } from '../utils';
 
 // Lazy-load heavy modules (CodeGraph, runInstaller) to keep CLI startup fast.
 async function loadCodeGraph(): Promise<typeof import('../index')> {
@@ -407,6 +408,25 @@ function writeErrorLog(projectPath: string, errors: Array<{ message: string; fil
   fs.writeFileSync(logPath, lines.join('\n') + '\n');
 }
 
+/**
+ * Translate the `--max-file-size <size>` CLI option into a byte count for
+ * `IndexOptions.maxFileSize`. Empty / undefined returns `undefined` so the
+ * library default (1 MiB) applies. Invalid sizes exit the process with a
+ * clear error rather than silently coercing to the default.
+ */
+function resolveMaxFileSize(input: string | undefined): number | undefined {
+  if (input === undefined || input === '') return undefined;
+  const bytes = parseFileSize(input);
+  if (bytes === null) {
+    error(
+      `Invalid --max-file-size value: "${input}". ` +
+      `Use a non-negative number with an optional unit suffix (e.g. "500kb", "2mb", "1.5gb", "1048576").`,
+    );
+    process.exit(1);
+  }
+  return bytes;
+}
+
 // =============================================================================
 // Commands
 // =============================================================================
@@ -419,7 +439,8 @@ program
   .description('Initialize CodeGraph in a project directory and build the initial index')
   .option('-i, --index', 'Deprecated: indexing now runs by default; flag accepted for backward compatibility')
   .option('-v, --verbose', 'Show detailed worker lifecycle and memory info')
-  .action(async (pathArg: string | undefined, options: { index?: boolean; verbose?: boolean }) => {
+  .option('--max-file-size <size>', 'Skip files larger than this (e.g. "500kb", "2mb", "1.5gb", or bytes). Default: 1mb')
+  .action(async (pathArg: string | undefined, options: { index?: boolean; verbose?: boolean; maxFileSize?: string }) => {
     const projectPath = path.resolve(pathArg || process.cwd());
     const clack = await importESM('@clack/prompts');
 
@@ -445,16 +466,20 @@ program
       // accepted (so existing muscle memory and scripts don't break) but is a
       // no-op — initializing always builds the initial index.
       let result: IndexResult;
+      const maxFileSize = resolveMaxFileSize(options.maxFileSize);
+
       if (options.verbose) {
         result = await cg.indexAll({
           onProgress: createVerboseProgress(),
           verbose: true,
+          maxFileSize,
         });
       } else {
         process.stdout.write(`${colors.dim}${getGlyphs().rail}${colors.reset}\n`);
         const progress = createShimmerProgress();
         result = await cg.indexAll({
           onProgress: progress.onProgress,
+          maxFileSize,
         });
         await progress.stop();
       }
@@ -536,7 +561,8 @@ program
   .option('-f, --force', 'Force full re-index even if already indexed')
   .option('-q, --quiet', 'Suppress progress output')
   .option('-v, --verbose', 'Show detailed worker lifecycle and memory info')
-  .action(async (pathArg: string | undefined, options: { force?: boolean; quiet?: boolean; verbose?: boolean }) => {
+  .option('--max-file-size <size>', 'Skip files larger than this (e.g. "500kb", "2mb", "1.5gb", or bytes). Default: 1mb')
+  .action(async (pathArg: string | undefined, options: { force?: boolean; quiet?: boolean; verbose?: boolean; maxFileSize?: string }) => {
     const projectPath = resolveProjectPath(pathArg);
 
     try {
@@ -548,11 +574,12 @@ program
 
       const { default: CodeGraph } = await loadCodeGraph();
       const cg = await CodeGraph.open(projectPath);
+      const maxFileSize = resolveMaxFileSize(options.maxFileSize);
 
       if (options.quiet) {
         // Quiet mode: no UI, just run
         if (options.force) cg.clear();
-        const result = await cg.indexAll();
+        const result = await cg.indexAll({ maxFileSize });
         if (!result.success) process.exit(1);
         cg.destroy();
         return;
@@ -572,12 +599,14 @@ program
         result = await cg.indexAll({
           onProgress: createVerboseProgress(),
           verbose: true,
+          maxFileSize,
         });
       } else {
         process.stdout.write(`${colors.dim}${getGlyphs().rail}${colors.reset}\n`);
         const progress = createShimmerProgress();
         result = await cg.indexAll({
           onProgress: progress.onProgress,
+          maxFileSize,
         });
         await progress.stop();
       }
@@ -603,7 +632,8 @@ program
   .command('sync [path]')
   .description('Sync changes since last index')
   .option('-q, --quiet', 'Suppress output (for git hooks)')
-  .action(async (pathArg: string | undefined, options: { quiet?: boolean }) => {
+  .option('--max-file-size <size>', 'Skip files larger than this (e.g. "500kb", "2mb", "1.5gb", or bytes). Default: 1mb')
+  .action(async (pathArg: string | undefined, options: { quiet?: boolean; maxFileSize?: string }) => {
     const projectPath = resolveProjectPath(pathArg);
 
     try {
@@ -616,9 +646,10 @@ program
 
       const { default: CodeGraph } = await loadCodeGraph();
       const cg = await CodeGraph.open(projectPath);
+      const maxFileSize = resolveMaxFileSize(options.maxFileSize);
 
       if (options.quiet) {
-        await cg.sync();
+        await cg.sync({ maxFileSize });
         cg.destroy();
         return;
       }
@@ -631,6 +662,7 @@ program
 
       const result = await cg.sync({
         onProgress: progress.onProgress,
+        maxFileSize,
       });
 
       await progress.stop();

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -93,11 +93,14 @@ export function hashContent(content: string): string {
 }
 
 /**
- * Skip files larger than this (bytes). Generated bundles, minified JS, and
- * vendored blobs blow the WASM heap and the worker-recycle budget for no useful
- * symbols. 1 MB covers essentially all hand-written source.
+ * Default file-size ceiling (bytes). Files above this are skipped at index
+ * time with a `size_exceeded` warning, because generated bundles, minified
+ * JS, and vendored blobs blow the WASM heap and the worker-recycle budget
+ * for no useful symbols, and 1 MiB covers essentially all hand-written
+ * source. Overridable per call via `IndexOptions.maxFileSize` (and the
+ * `codegraph index --max-file-size` CLI flag) — see issue #369.
  */
-const MAX_FILE_SIZE = 1024 * 1024;
+export const DEFAULT_MAX_FILE_SIZE = 1024 * 1024;
 
 /**
  * Directory names that are dependency, build, cache, or tooling output across the
@@ -595,7 +598,8 @@ export class ExtractionOrchestrator {
   async indexAll(
     onProgress?: (progress: IndexProgress) => void,
     signal?: AbortSignal,
-    verbose?: boolean
+    verbose?: boolean,
+    maxFileSize: number = DEFAULT_MAX_FILE_SIZE
   ): Promise<IndexResult> {
     await initGrammars();
     const startTime = Date.now();
@@ -885,16 +889,16 @@ export class ExtractionOrchestrator {
           continue;
         }
 
-        // Honour MAX_FILE_SIZE. Without this check, vendored generated
-        // headers, minified bundles, and other multi-MB files get indexed,
-        // wasting WASM heap and the worker recycle budget on inputs with no
-        // useful symbols. The single-file extractFile path already enforces
-        // this; the bulk path used to silently skip the check.
-        if (stats.size > MAX_FILE_SIZE) {
+        // Honour the configured max-file-size. Without this check, vendored
+        // generated headers, minified bundles, and other multi-MB files get
+        // indexed, wasting WASM heap and the worker recycle budget on inputs
+        // with no useful symbols. The single-file extractFile path already
+        // enforces this; the bulk path used to silently skip the check.
+        if (stats.size > maxFileSize) {
           processed++;
           filesSkipped++;
           errors.push({
-            message: `File exceeds max size (${stats.size} > ${MAX_FILE_SIZE})`,
+            message: `File exceeds max size (${stats.size} > ${maxFileSize})`,
             filePath,
             severity: 'warning',
             code: 'size_exceeded',
@@ -1140,7 +1144,10 @@ export class ExtractionOrchestrator {
   /**
    * Index a single file
    */
-  async indexFile(relativePath: string): Promise<ExtractionResult> {
+  async indexFile(
+    relativePath: string,
+    maxFileSize: number = DEFAULT_MAX_FILE_SIZE
+  ): Promise<ExtractionResult> {
     const fullPath = validatePathWithinRoot(this.rootDir, relativePath);
 
     if (!fullPath) {
@@ -1176,7 +1183,7 @@ export class ExtractionOrchestrator {
       };
     }
 
-    return this.indexFileWithContent(relativePath, content, stats);
+    return this.indexFileWithContent(relativePath, content, stats, maxFileSize);
   }
 
   /**
@@ -1186,7 +1193,8 @@ export class ExtractionOrchestrator {
   async indexFileWithContent(
     relativePath: string,
     content: string,
-    stats: fs.Stats
+    stats: fs.Stats,
+    maxFileSize: number = DEFAULT_MAX_FILE_SIZE
   ): Promise<ExtractionResult> {
     // Prevent path traversal
     const fullPath = validatePathWithinRoot(this.rootDir, relativePath);
@@ -1202,14 +1210,14 @@ export class ExtractionOrchestrator {
     }
 
     // Check file size
-    if (stats.size > MAX_FILE_SIZE) {
+    if (stats.size > maxFileSize) {
       return {
         nodes: [],
         edges: [],
         unresolvedReferences: [],
         errors: [
           {
-            message: `File exceeds max size (${stats.size} > ${MAX_FILE_SIZE})`,
+            message: `File exceeds max size (${stats.size} > ${maxFileSize})`,
             filePath: relativePath,
             severity: 'warning',
             code: 'size_exceeded',
@@ -1326,7 +1334,10 @@ export class ExtractionOrchestrator {
    * changes. This works in non-git projects and catches committed changes from
    * `git pull`/`checkout`/`merge`/`rebase` that `git status` cannot see.
    */
-  async sync(onProgress?: (progress: IndexProgress) => void): Promise<SyncResult> {
+  async sync(
+    onProgress?: (progress: IndexProgress) => void,
+    maxFileSize: number = DEFAULT_MAX_FILE_SIZE
+  ): Promise<SyncResult> {
     await initGrammars(); // Initialize WASM runtime (grammars loaded lazily below)
     const startTime = Date.now();
     let filesChecked = 0;
@@ -1436,7 +1447,7 @@ export class ExtractionOrchestrator {
         currentFile: filePath,
       });
 
-      const result = await this.indexFile(filePath);
+      const result = await this.indexFile(filePath, maxFileSize);
       nodesUpdated += result.nodes.length;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,13 @@ export interface IndexOptions {
 
   /** Enable verbose logging (worker lifecycle, memory, timeouts) */
   verbose?: boolean;
+
+  /**
+   * Maximum file size in bytes; files larger than this are skipped with a
+   * `size_exceeded` warning. Defaults to 1 MiB (`DEFAULT_MAX_FILE_SIZE`) —
+   * see issue #369. Surface via `codegraph index --max-file-size <size>`.
+   */
+  maxFileSize?: number;
 }
 
 /**
@@ -331,7 +338,7 @@ export class CodeGraph {
       }
       try {
         const before = this.queries.getNodeAndEdgeCount();
-        const result = await this.orchestrator.indexAll(options.onProgress, options.signal, options.verbose);
+        const result = await this.orchestrator.indexAll(options.onProgress, options.signal, options.verbose, options.maxFileSize);
 
         // Re-detect frameworks now that the index is populated. The resolver
         // is constructed with createResolver() before any files exist, so
@@ -422,7 +429,7 @@ export class CodeGraph {
         return { filesChecked: 0, filesAdded: 0, filesModified: 0, filesRemoved: 0, nodesUpdated: 0, durationMs: 0 };
       }
       try {
-        const result = await this.orchestrator.sync(options.onProgress);
+        const result = await this.orchestrator.sync(options.onProgress, options.maxFileSize);
 
         // Cross-file finalization (e.g. NestJS RouterModule prefixes). Run on
         // every sync that touched files so edits to `app.module.ts` propagate

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -175,6 +175,53 @@ export function normalizePath(filePath: string): string {
 }
 
 /**
+ * Parse a human-readable file-size string into a byte count.
+ *
+ * Accepts a non-negative number (`"1048576"` → 1 048 576) or a number with a
+ * unit suffix (`"500kb"`, `"2 MB"`, `"1.5gb"`, `"700 KiB"`). Whitespace is
+ * tolerated and the suffix is case-insensitive. Both decimal (KB/MB/GB) and
+ * binary (KiB/MiB/GiB) units are supported; we use the binary base (×1024)
+ * for both since that matches the existing 1 MiB default and is what filesystem
+ * tools (`du`, `ls -lh`) typically report.
+ *
+ * Returns `null` for any input that doesn't parse as a non-negative size
+ * (empty, NaN, negative, unknown unit) — callers should report a user-friendly
+ * error so the CLI fails fast instead of silently coercing.
+ *
+ * Used by `codegraph index --max-file-size <size>` — see issue #369.
+ */
+export function parseFileSize(input: string): number | null {
+  if (typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  if (trimmed === '') return null;
+
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*([a-z]*)$/i);
+  if (!match) return null;
+
+  const value = parseFloat(match[1]!);
+  if (!Number.isFinite(value) || value < 0) return null;
+
+  const unit = match[2]!.toLowerCase();
+  const multipliers: Record<string, number> = {
+    '': 1,            // plain bytes
+    'b': 1,
+    'k': 1024,
+    'kb': 1024,
+    'kib': 1024,
+    'm': 1024 * 1024,
+    'mb': 1024 * 1024,
+    'mib': 1024 * 1024,
+    'g': 1024 * 1024 * 1024,
+    'gb': 1024 * 1024 * 1024,
+    'gib': 1024 * 1024 * 1024,
+  };
+  const multiplier = multipliers[unit];
+  if (multiplier === undefined) return null;
+
+  return Math.floor(value * multiplier);
+}
+
+/**
  * Cross-process file lock using a lock file with PID tracking.
  *
  * Prevents multiple processes (e.g., git hooks, CLI, MCP server) from


### PR DESCRIPTION
## Summary

Closes #369.

CI pipelines that only want source-code symbols (and would rather skip multi-MB media/vendor blobs) currently have to patch the codebase: the 1 MiB threshold lives as a compile-time constant in `src/extraction/index.ts`. This PR makes that threshold configurable per invocation, with the same default so existing workflows are unaffected.

## New surface

**CLI** — three commands grow an identical `--max-file-size <size>` flag:

```bash
codegraph init -i --max-file-size 500kb
codegraph index --max-file-size 2mb
codegraph sync --max-file-size 1.5gb
```

`<size>` accepts:

| Input | Bytes |
|---|---|
| `1048576` | 1 048 576 (raw bytes) |
| `500kb` / `500 KB` | 512 000 |
| `2mb` / `2 MB` | 2 097 152 |
| `1.5gb` | 1 610 612 736 |
| `700KiB` / `1MiB` | IEC suffixes also supported |

Both decimal and IEC suffixes resolve to the binary base (×1024). That matches what `du -h` / `ls -lh` report and keeps the 1 MiB default the codebase has always used. Invalid values fail fast:

```
$ codegraph index --max-file-size banana
✗ Invalid --max-file-size value: "banana". Use a non-negative number with an optional unit suffix (e.g. "500kb", "2mb", "1.5gb", "1048576").
```

**Library** — `IndexOptions.maxFileSize?: number` is added to both `CodeGraph.indexAll(opts)` and `CodeGraph.sync(opts)`. Omitting it keeps the existing 1 MiB default. `DEFAULT_MAX_FILE_SIZE` (the renamed `MAX_FILE_SIZE`) is also exported from `src/extraction/index.ts` for consumers that want to clamp or report against it.

## Implementation notes

- The orchestrator's `indexAll`, `sync`, `indexFile`, and `indexFileWithContent` methods now take an optional `maxFileSize` argument with the default constant as fallback — additive, non-breaking on the existing positional-arg shape.
- `parseFileSize()` lives in `src/utils.ts` (it's small and pure, and may be useful elsewhere in the future). Returns `null` on bad input so the CLI can format a clean error and exit 1 — silently coercing to the default would have been worse than failing fast for a CI use case.
- No persistence: each invocation provides its own value, the watcher/auto-sync keeps using the default. This matched the issue's "CI pipelines indexing only source code" framing more naturally than a per-project config setting; happy to layer in a config-file knob in a follow-up if there's demand.

## Test plan

New `__tests__/max-file-size.test.ts` (8 tests) covers:

- **`parseFileSize`** — plain bytes, kb/mb/gb (with and without spaces, case-insensitive), IEC kib/mib/gib, and explicit `null` for malformed inputs (empty, negative, unknown suffix, repeated dots).
- **`CodeGraph.indexAll({ maxFileSize })`** — tightened limit drops a ~5 KiB file with `code: 'size_exceeded'` while keeping the small one; default keeps both.
- **CLI flag end-to-end** — invalid size string → exit 1 + clear stderr message; `--max-file-size 1kb --quiet` against the built binary drops the larger file from the index while keeping the smaller one.

Full suite green:

```
Test Files  50 passed (50)
     Tests  1040 passed | 2 skipped (1042)
```

(+8 new tests over `main`; no regressions.)