### PR TITLE
fix(release): use RELEASE_PAT for git pushes so promote+sync land on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,19 @@ jobs:
           # Default checkout is detached at a SHA; we need an actual branch
           # so the CHANGELOG-promote commit knows where to push.
           ref: ${{ github.ref }}
+          # Authenticate as the maintainer (admin), not as github-actions[bot].
+          # The "Require PR approval for main branch" ruleset only lets the
+          # Admin repo role bypass — and GitHub blocks adding the GitHub
+          # Actions integration to bypass_actors on user-owned (non-org)
+          # repos with "Actor GitHub Actions integration must be part of
+          # the ruleset source or owner organization." So the auto-promote
+          # and auto-sync `git push origin HEAD:main` steps below both fail
+          # under the default GITHUB_TOKEN. Using a fine-grained PAT owned
+          # by the admin makes the push go through cleanly. Set the
+          # RELEASE_PAT secret with: contents:write on this repo, no other
+          # scopes. Rotate per your token policy; the workflow only runs
+          # on manual dispatch so the blast radius is small.
+          token: ${{ secrets.RELEASE_PAT }}
       - uses: actions/setup-node@v6
         with:
           node-version: 22


### PR DESCRIPTION
## Summary

The Release workflow's auto-promote and auto-sync steps push directly to `main` via the default `GITHUB_TOKEN` — that's now rejected by the "Require PR approval for main branch" ruleset (run [26484169143](https://github.com/colbymchenry/codegraph/actions/runs/26484169143) fails on the `Promote [Unreleased] → [<version>]` step). The obvious bypass (add the GitHub Actions integration to `bypass_actors`) is blocked on user-owned repos:

```
Validation Failed: Actor GitHub Actions integration must be part of the
ruleset source or owner organization.
```

So this PR authenticates `actions/checkout` with a fine-grained PAT owned by the admin instead. The PAT owner bypasses the ruleset, push lands, future releases auto-promote cleanly.

## Why this hit now and not on 0.9.5

- 0.9.5: CHANGELOG was hand-promoted before triggering Release. The workflow's promote step short-circuited on `git diff --quiet -- CHANGELOG.md` and never attempted the push.
- 0.9.5's lock-sync step had the same bug — manually patched after the fact in #440.
- 0.9.6: first release where `[Unreleased]` was the real source of truth at trigger time → first time the push actually fires → first observable failure.

## What you need to do before merging

1. Create a fine-grained PAT scoped to **`contents:write`** on `colbymchenry/codegraph` (no other scopes). [Token settings page](https://github.com/settings/personal-access-tokens/new).
2. Add it as a repo secret named **`RELEASE_PAT`** (Settings → Secrets → Actions → New repository secret).
3. Then merge this PR and re-run the Release workflow.

## Test plan

- [ ] PAT secret `RELEASE_PAT` added before merge
- [ ] Merge this PR
- [ ] Trigger Release workflow on `main` (still at 0.9.6)
- [ ] Confirm the `Promote [Unreleased] → [<version>]` step now commits + pushes `cc9cab7`-equivalent to main
- [ ] Confirm subsequent steps (build, GH release, npm publish, verify) all complete
- [ ] Confirm `v0.9.6` tag exists and `@colbymchenry/codegraph@0.9.6` is on the npm registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)