### PR TITLE
fix(windows): suppress console popup on child_process calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,20 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   calls pay nothing. Most visible on the "deleted everything between
   sessions" case, where MCP now returns the correct empty index instead
   of stale rows. Validated end-to-end on a 10,640-file VS Code index.
+- **Windows: black console windows no longer flash on every file save / MCP
+  reconnect (#485, #510, #530).** v0.9.5 moved the MCP server to a detached
+  shared daemon (#411). Detached processes have no inherited console on
+  Windows, so any console-subsystem child they spawn (the daemon's `git`
+  invocations during auto-sync, the WASM-runtime `node` re-exec, the
+  installer's `npm` shell-out) is created with a fresh console window
+  visible to the user unless the spawn passes `windowsHide: true` (which
+  libuv translates to `STARTF_USESHOWWINDOW | SW_HIDE`, so the window is
+  created hidden and never flashes). All ten `spawnSync` / `execFileSync` /
+  `execSync` call sites across extraction, sync, installer, and the
+  WASM-flags relaunch now pass `windowsHide: true`. macOS/Linux ignore the
+  option, so this is a no-op elsewhere. The daemon launcher itself
+  (`src/mcp/index.ts`) already passed the flag — these children had been
+  missed.
 - **`codegraph index` / `init -i` summary now reports the true edge count.**
   The per-file counter in the orchestrator only saw extraction-phase edges,
   so resolution and synthesizer edges (often >50% of the graph on

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -191,7 +191,7 @@ export function buildDefaultIgnore(rootDir: string): Ignore {
  * (See issue #193.)
  */
 function collectGitFiles(repoDir: string, prefix: string, files: Set<string>): void {
-  const gitOpts = { cwd: repoDir, encoding: 'utf-8' as const, timeout: 30000, maxBuffer: 50 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] as ['pipe', 'pipe', 'pipe'] };
+  const gitOpts = { cwd: repoDir, encoding: 'utf-8' as const, timeout: 30000, maxBuffer: 50 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] as ['pipe', 'pipe', 'pipe'], windowsHide: true };
 
   // Tracked files. --recurse-submodules pulls in files from active submodules,
   // which the index would otherwise represent only as a commit pointer.
@@ -241,7 +241,7 @@ function getGitVisibleFiles(rootDir: string): Set<string> | null {
     const gitRoot = execFileSync(
       'git',
       ['rev-parse', '--show-toplevel'],
-      { cwd: rootDir, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }
+      { cwd: rootDir, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
     ).trim();
 
     if (path.resolve(gitRoot) !== path.resolve(rootDir)) {
@@ -250,7 +250,7 @@ function getGitVisibleFiles(rootDir: string): Set<string> | null {
         execFileSync(
           'git',
           ['check-ignore', '-q', path.resolve(rootDir)],
-          { cwd: rootDir, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }
+          { cwd: rootDir, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
         );
         // Directory is gitignored by parent repo — fall back to filesystem walk
         return null;
@@ -291,7 +291,7 @@ function getGitChangedFiles(rootDir: string): GitChanges | null {
     const output = execFileSync(
       'git',
       ['status', '--porcelain', '--no-renames'],
-      { cwd: rootDir, encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] }
+      { cwd: rootDir, encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
     );
 
     const modified: string[] = [];

--- a/src/extraction/wasm-runtime-flags.ts
+++ b/src/extraction/wasm-runtime-flags.ts
@@ -98,6 +98,7 @@ export function relaunchWithWasmRuntimeFlagsIfNeeded(scriptPath: string): void {
   const result = spawnSync(process.execPath, argv, {
     stdio: 'inherit',
     env: { ...process.env, [RELAUNCH_GUARD_ENV]: '1', [HOST_PPID_ENV]: String(process.ppid) },
+    windowsHide: true,
   });
 
   if (result.error) {

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -119,7 +119,7 @@ export async function runInstallerWithOptions(opts: RunInstallerOptions): Promis
       const s = clack.spinner();
       s.start('Installing codegraph CLI...');
       try {
-        execSync('npm install -g @colbymchenry/codegraph', { stdio: 'pipe' });
+        execSync('npm install -g @colbymchenry/codegraph', { stdio: 'pipe', windowsHide: true });
         s.stop('Installed codegraph CLI on PATH');
       } catch {
         s.stop('Could not install (permission denied)');

--- a/src/installer/targets/antigravity.ts
+++ b/src/installer/targets/antigravity.ts
@@ -124,6 +124,7 @@ function resolveCodegraphCommand(): string {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       shell: '/bin/bash',
+      windowsHide: true,
     }).trim();
     if (resolved && fs.existsSync(resolved)) return resolved;
   } catch {

--- a/src/mcp/engine.ts
+++ b/src/mcp/engine.ts
@@ -147,8 +147,7 @@ export class MCPEngine {
 
     const resolvedRoot = findNearestCodeGraphRoot(searchFrom);
     if (!resolvedRoot) {
-      // No .codegraph/ above searchFrom — that's not an error, sessions may
-      // still discover one later via roots/list.
+      // No .codegraph/ above searchFrom. Sessions may still discover one later via roots/list
       this.projectPath = searchFrom;
       return;
     }

--- a/src/sync/git-hooks.ts
+++ b/src/sync/git-hooks.ts
@@ -44,6 +44,7 @@ export function isGitRepo(projectRoot: string): boolean {
       cwd: projectRoot,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
     }).trim();
     return out === 'true';
   } catch {
@@ -61,6 +62,7 @@ function gitHooksDir(projectRoot: string): string | null {
       cwd: projectRoot,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
     }).trim();
     if (!out) return null;
     return path.isAbsolute(out) ? out : path.resolve(projectRoot, out);

--- a/src/sync/worktree.ts
+++ b/src/sync/worktree.ts
@@ -35,6 +35,7 @@ export function gitWorktreeRoot(dir: string): string | null {
       cwd: dir,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
     }).trim();
     return out ? realpath(out) : null;
   } catch {


### PR DESCRIPTION
Add windowsHide: true to all spawnSync/execFileSync/execSync calls across extraction, installer, sync, and mcp modules to prevent console window popup on Windows when CodeGraph spawns git/npm subprocesses.

Affected subprocess calls:
- WASM relaunch (spawnSync)
- git status/rev-parse calls (execFileSync × 4 in extraction)
- git worktree/hooks detection (execFileSync × 3 in sync)
- npm install detection (execSync × 2 in installer)