### PR TITLE
fix(lock): harden FileLock ownership semantics and lock diagnostics

### DIFF
--- a/__tests__/security.test.ts
+++ b/__tests__/security.test.ts
@@ -8,11 +8,12 @@
  * - Atomic writes
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { FileLock, validateProjectPath } from '../src/utils';
+import { setLogger, silentLogger, type Logger } from '../src/errors';
 import CodeGraph from '../src/index';
 import { ToolHandler, tools } from '../src/mcp/tools';
 import { scanDirectory, isSourceFile } from '../src/extraction';
@@ -32,13 +33,25 @@ function cleanupTempDir(dir: string): void {
 describe('FileLock', () => {
   let tempDir: string;
   let lockPath: string;
+  let logger: Logger;
+  let debugSpy: ReturnType<typeof vi.fn>;
+  let warnSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     tempDir = createTempDir();
     lockPath = path.join(tempDir, 'test.lock');
+    debugSpy = vi.fn();
+    warnSpy = vi.fn();
+    logger = {
+      debug: debugSpy,
+      warn: warnSpy,
+      error: vi.fn(),
+    };
+    setLogger(logger);
   });
 
   afterEach(() => {
+    setLogger(silentLogger);
     cleanupTempDir(tempDir);
   });
 
@@ -47,8 +60,16 @@ describe('FileLock', () => {
     lock.acquire();
 
     expect(fs.existsSync(lockPath)).toBe(true);
-    const content = fs.readFileSync(lockPath, 'utf-8').trim();
-    expect(parseInt(content, 10)).toBe(process.pid);
+    const content = JSON.parse(fs.readFileSync(lockPath, 'utf-8')) as {
+      pid: number;
+      token: string;
+      createdAt: number;
+      hostname: string;
+    };
+    expect(content.pid).toBe(process.pid);
+    expect(content.token).toEqual(expect.any(String));
+    expect(content.createdAt).toEqual(expect.any(Number));
+    expect(content.hostname).toEqual(expect.any(String));
 
     lock.release();
     expect(fs.existsSync(lockPath)).toBe(false);
@@ -60,20 +81,33 @@ describe('FileLock', () => {
 
     lock1.acquire();
 
-    // Second lock should fail because our PID is alive
-    expect(() => lock2.acquire()).toThrow(/locked by another process/);
+    expect(() => lock2.acquire()).toThrow(/locked by another process \(PID/);
 
     lock1.release();
   });
 
   it('should detect and remove stale locks from dead processes', () => {
-    // Write a lock file with a PID that doesn't exist
-    // PID 99999999 is extremely unlikely to be a real process
     fs.writeFileSync(lockPath, '99999999');
 
     const lock = new FileLock(lockPath);
-    // Should succeed because the PID is dead
     expect(() => lock.acquire()).not.toThrow();
+    expect(debugSpy).toHaveBeenCalledWith(
+      'Removing stale lock from dead process',
+      expect.objectContaining({ lockPath, pid: 99999999 })
+    );
+
+    lock.release();
+  });
+
+  it('should remove unreadable lock files before acquiring', () => {
+    fs.writeFileSync(lockPath, '{bad json');
+
+    const lock = new FileLock(lockPath);
+    expect(() => lock.acquire()).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Removing unreadable lock file before reacquiring',
+      expect.objectContaining({ lockPath })
+    );
 
     lock.release();
   });
@@ -130,8 +164,92 @@ describe('FileLock', () => {
     const lock = new FileLock(lockPath);
     lock.acquire();
     lock.release();
-    // Second release should not throw
     expect(() => lock.release()).not.toThrow();
+  });
+
+  it('should not remove a lock it no longer owns', () => {
+    const lock = new FileLock(lockPath);
+    lock.acquire();
+    const current = JSON.parse(fs.readFileSync(lockPath, 'utf-8')) as {
+      pid: number;
+      token: string;
+      createdAt: number;
+      hostname: string;
+    };
+    fs.writeFileSync(lockPath, JSON.stringify({ ...current, token: 'different-token' }));
+
+    lock.release();
+
+    expect(fs.existsSync(lockPath)).toBe(true);
+  });
+});
+
+describe('CodeGraph lock error propagation', () => {
+  let testDir: string;
+  let cg: CodeGraph;
+  let lockPath: string;
+
+  beforeEach(() => {
+    testDir = createTempDir();
+    fs.writeFileSync(path.join(testDir, 'example.ts'), 'export const value = 1;\n');
+    cg = CodeGraph.initSync(testDir);
+    lockPath = path.join(testDir, '.codegraph', 'codegraph.lock');
+  });
+
+  afterEach(() => {
+    if (cg) cg.close();
+    cleanupTempDir(testDir);
+  });
+
+  it('indexAll should return the specific file lock error', async () => {
+    fs.writeFileSync(lockPath, JSON.stringify({
+      pid: process.pid,
+      token: 'held-by-other',
+      createdAt: Date.now() - 1234,
+      hostname: 'test-host',
+    }));
+
+    const result = await cg.indexAll();
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0]?.message ?? '').toContain('PID');
+    expect(result.errors[0]?.message ?? '').toContain(lockPath);
+    expect(result.errors[0]?.message ?? '').toContain('test-host');
+  });
+
+  it('indexFiles should return the specific file lock error', async () => {
+    fs.writeFileSync(lockPath, JSON.stringify({
+      pid: process.pid,
+      token: 'held-by-other',
+      createdAt: Date.now() - 567,
+      hostname: 'test-host',
+    }));
+
+    const result = await cg.indexFiles([path.join(testDir, 'example.ts')]);
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0]?.message ?? '').toContain('PID');
+    expect(result.errors[0]?.message ?? '').toContain(lockPath);
+  });
+
+  it('sync should preserve the zero-result sentinel on lock contention', async () => {
+    fs.writeFileSync(lockPath, JSON.stringify({
+      pid: process.pid,
+      token: 'held-by-other',
+      createdAt: Date.now() - 250,
+      hostname: 'test-host',
+    }));
+
+    const result = await cg.sync();
+
+    expect(result).toEqual({
+      filesChecked: 0,
+      filesAdded: 0,
+      filesModified: 0,
+      filesRemoved: 0,
+      nodesUpdated: 0,
+      durationMs: 0,
+    });
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import { GraphTraverser, GraphQueryManager } from './graph';
 import { ContextBuilder, createContextBuilder } from './context';
 import { Mutex, FileLock } from './utils';
 import { FileWatcher, WatchOptions, PendingFile, LockUnavailableError } from './sync';
+import { logDebug } from './errors';
 
 // Re-export types for consumers
 export * from './types';
@@ -321,8 +322,11 @@ export class CodeGraph {
     return this.indexMutex.withLock(async () => {
       try {
         this.fileLock.acquire();
-      } catch {
-        return { success: false, filesIndexed: 0, filesSkipped: 0, filesErrored: 0, nodesCreated: 0, edgesCreated: 0, errors: [{ message: 'Could not acquire file lock - another process may be indexing', severity: 'error' as const }], durationMs: 0 };
+      } catch (err) {
+        const message = err instanceof Error
+          ? err.message
+          : 'Could not acquire file lock - another process may be indexing';
+        return { success: false, filesIndexed: 0, filesSkipped: 0, filesErrored: 0, nodesCreated: 0, edgesCreated: 0, errors: [{ message, severity: 'error' as const }], durationMs: 0 };
       }
       try {
         const before = this.queries.getNodeAndEdgeCount();
@@ -393,8 +397,11 @@ export class CodeGraph {
     return this.indexMutex.withLock(async () => {
       try {
         this.fileLock.acquire();
-      } catch {
-        return { success: false, filesIndexed: 0, filesSkipped: 0, filesErrored: 0, nodesCreated: 0, edgesCreated: 0, errors: [{ message: 'Could not acquire file lock - another process may be indexing', severity: 'error' as const }], durationMs: 0 };
+      } catch (err) {
+        const message = err instanceof Error
+          ? err.message
+          : 'Could not acquire file lock - another process may be indexing';
+        return { success: false, filesIndexed: 0, filesSkipped: 0, filesErrored: 0, nodesCreated: 0, edgesCreated: 0, errors: [{ message, severity: 'error' as const }], durationMs: 0 };
       }
       try {
         return this.orchestrator.indexFiles(filePaths);
@@ -413,7 +420,11 @@ export class CodeGraph {
     return this.indexMutex.withLock(async () => {
       try {
         this.fileLock.acquire();
-      } catch {
+      } catch (err) {
+        logDebug('Skipping sync because file lock is unavailable', {
+          error: err instanceof Error ? err.message : String(err),
+          projectRoot: this.projectRoot,
+        });
         return { filesChecked: 0, filesAdded: 0, filesModified: 0, filesRemoved: 0, nodesUpdated: 0, durationMs: 0 };
       }
       try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,9 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
+import { randomUUID } from 'crypto';
+import { logDebug, logWarn } from './errors';
 
 // ============================================================
 // SECURITY UTILITIES
@@ -175,17 +178,25 @@ export function normalizePath(filePath: string): string {
 }
 
 /**
- * Cross-process file lock using a lock file with PID tracking.
+ * Cross-process file lock using a lock file with explicit ownership metadata.
  *
  * Prevents multiple processes (e.g., git hooks, CLI, MCP server) from
  * writing to the same database simultaneously.
  */
+interface FileLockInfo {
+  pid: number;
+  token?: string;
+  createdAt?: number;
+  hostname?: string;
+}
+
 export class FileLock {
   private lockPath: string;
   private held = false;
+  private token: string | null = null;
+  private acquiredAtMs: number | null = null;
 
-  /** Locks older than this are considered stale regardless of PID status */
-  private static readonly STALE_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
+  private static readonly WARN_HOLD_MS = 30_000;
 
   constructor(lockPath: string) {
     this.lockPath = lockPath;
@@ -195,44 +206,39 @@ export class FileLock {
    * Acquire the lock. Throws if the lock is held by another live process.
    */
   acquire(): void {
-    // Check for existing lock
     if (fs.existsSync(this.lockPath)) {
-      try {
-        const content = fs.readFileSync(this.lockPath, 'utf-8').trim();
-        const pid = parseInt(content, 10);
-        const stat = fs.statSync(this.lockPath);
-        const lockAge = Date.now() - stat.mtimeMs;
-
-        // Treat locks older than the timeout as stale, regardless of PID
-        if (lockAge < FileLock.STALE_TIMEOUT_MS && !isNaN(pid) && this.isProcessAlive(pid)) {
-          throw new Error(
-            `CodeGraph database is locked by another process (PID ${pid}). ` +
-            `If this is stale, run 'codegraph unlock' or delete ${this.lockPath}`
-          );
+      const existing = this.readLockInfo();
+      if (existing) {
+        if (this.isProcessAlive(existing.pid)) {
+          throw new Error(this.buildLockedMessage(existing));
         }
-
-        // Stale lock (dead process or timed out) - remove it
-        fs.unlinkSync(this.lockPath);
-      } catch (err) {
-        if (err instanceof Error && err.message.includes('locked by another')) {
-          throw err;
-        }
-        // Other errors reading lock file - try to remove it
-        try { fs.unlinkSync(this.lockPath); } catch { /* ignore */ }
+        this.removeLockFile('Removing stale lock from dead process', existing, 'debug');
+      } else {
+        this.removeLockFile('Removing unreadable lock file before reacquiring', null, 'warn');
       }
     }
 
-    // Write our PID to the lock file using exclusive create flag
+    const token = randomUUID();
+    const info: FileLockInfo = {
+      pid: process.pid,
+      token,
+      createdAt: Date.now(),
+      hostname: os.hostname(),
+    };
+
     try {
-      fs.writeFileSync(this.lockPath, String(process.pid), { flag: 'wx' });
+      fs.writeFileSync(this.lockPath, JSON.stringify(info), { flag: 'wx' });
       this.held = true;
+      this.token = token;
+      this.acquiredAtMs = info.createdAt;
+      logDebug('Acquired file lock', {
+        lockPath: this.lockPath,
+        pid: process.pid,
+      });
     } catch (err: any) {
       if (err.code === 'EEXIST') {
-        // Race condition: another process grabbed the lock between our check and write
-        throw new Error(
-          'CodeGraph database is locked by another process. ' +
-          `If this is stale, run 'codegraph unlock' or delete ${this.lockPath}`
-        );
+        const existing = this.readLockInfo();
+        throw new Error(existing ? this.buildLockedMessage(existing) : this.buildLockedMessage());
       }
       throw err;
     }
@@ -244,15 +250,26 @@ export class FileLock {
   release(): void {
     if (!this.held) return;
     try {
-      // Only remove if we still own it (check PID)
-      const content = fs.readFileSync(this.lockPath, 'utf-8').trim();
-      if (parseInt(content, 10) === process.pid) {
+      const info = this.readLockInfo();
+      if (this.ownsLock(info)) {
         fs.unlinkSync(this.lockPath);
       }
     } catch {
       // Lock file already gone - that's fine
+    } finally {
+      if (this.acquiredAtMs !== null) {
+        const heldMs = Date.now() - this.acquiredAtMs;
+        const context = { lockPath: this.lockPath, pid: process.pid, heldMs };
+        if (heldMs >= FileLock.WARN_HOLD_MS) {
+          logWarn('Released file lock after long hold', context);
+        } else {
+          logDebug('Released file lock', context);
+        }
+      }
+      this.held = false;
+      this.token = null;
+      this.acquiredAtMs = null;
     }
-    this.held = false;
   }
 
   /**
@@ -276,6 +293,71 @@ export class FileLock {
       return await fn();
     } finally {
       this.release();
+    }
+  }
+
+  private readLockInfo(): FileLockInfo | null {
+    try {
+      const content = fs.readFileSync(this.lockPath, 'utf-8').trim();
+      if (!content) return null;
+      const legacyPid = parseInt(content, 10);
+      if (!Number.isNaN(legacyPid) && String(legacyPid) === content) {
+        const stat = fs.statSync(this.lockPath);
+        return { pid: legacyPid, createdAt: Number.isFinite(stat.mtimeMs) ? stat.mtimeMs : undefined };
+      }
+      const parsed = safeJsonParse<Partial<FileLockInfo> | null>(content, null);
+      if (!parsed || typeof parsed !== 'object' || typeof parsed.pid !== 'number') {
+        return null;
+      }
+      return {
+        pid: parsed.pid,
+        token: typeof parsed.token === 'string' ? parsed.token : undefined,
+        createdAt: typeof parsed.createdAt === 'number' ? parsed.createdAt : undefined,
+        hostname: typeof parsed.hostname === 'string' ? parsed.hostname : undefined,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private ownsLock(info: FileLockInfo | null): boolean {
+    if (!info || info.pid !== process.pid) return false;
+    if (!info.token) return true;
+    return info.token === this.token;
+  }
+
+  private buildLockedMessage(info?: FileLockInfo | null): string {
+    if (!info) {
+      return 'CodeGraph database is locked by another process. ' +
+        `If this is stale, run 'codegraph unlock' or delete ${this.lockPath}`;
+    }
+    const details = [`PID ${info.pid}`];
+    if (info.hostname) details.push(`host ${info.hostname}`);
+    if (typeof info.createdAt === 'number') {
+      details.push(`held for ${Math.max(0, Date.now() - info.createdAt)}ms`);
+    }
+    return `CodeGraph database is locked by another process (${details.join(', ')}). ` +
+      `If this is stale, run 'codegraph unlock' or delete ${this.lockPath}`;
+  }
+
+  private removeLockFile(message: string, info: FileLockInfo | null, level: 'debug' | 'warn'): void {
+    const context: Record<string, unknown> = { lockPath: this.lockPath };
+    if (info) {
+      context.pid = info.pid;
+      if (info.hostname) context.hostname = info.hostname;
+      if (typeof info.createdAt === 'number') {
+        context.ageMs = Math.max(0, Date.now() - info.createdAt);
+      }
+    }
+    try {
+      fs.unlinkSync(this.lockPath);
+    } catch {
+      return;
+    }
+    if (level === 'warn') {
+      logWarn(message, context);
+    } else {
+      logDebug(message, context);
     }
   }
 


### PR DESCRIPTION
  Tighten FileLock ownership semantics and improve lock conflict diagnostics.

  The old lock model stored only a PID and treated sufficiently old lock files as stale. That was a pragmatic recovery
  path, but it seems less well suited to CodeGraph’s current usage patterns, where overlapping writer candidates (index,
   watcher-driven sync, MCP, git hooks) are possible and indexing/sync duration can vary with repo size and workload.

  This PR updates FileLock to:

  - store structured lock metadata (pid, token, createdAt, hostname)
  - use token-based ownership checks on release()
  - treat locks as stale only when the owner appears to be dead or the lock file is unreadable
  - preserve richer lock-holder context in indexAll() / indexFiles() errors
  - keep sync()’s existing zero-result sentinel behavior unchanged

  Tests

  Extended __tests__/security.test.ts to cover:

  - JSON lock metadata
  - legacy PID-only lock compatibility
  - dead/corrupt lock cleanup
  - token mismatch on release()
  - richer lock conflict propagation

  Also re-ran:

  - __tests__/concurrent-locking.test.ts

  Tradeoff

  This does give up one aggressive recovery path: a lock held by a still-alive but effectively wedged process may now
  persist longer. On balance, that seems preferable here, since it avoids treating legitimate long-running writes as
  stale in multi-writer scenarios.