### PR TITLE
fix(windows): hide console window for git child processes

### DIFF
--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -191,7 +191,7 @@ export function buildDefaultIgnore(rootDir: string): Ignore {
  * (See issue #193.)
  */
 function collectGitFiles(repoDir: string, prefix: string, files: Set<string>): void {
-  const gitOpts = { cwd: repoDir, encoding: 'utf-8' as const, timeout: 30000, maxBuffer: 50 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] as ['pipe', 'pipe', 'pipe'] };
+  const gitOpts = { cwd: repoDir, encoding: 'utf-8' as const, timeout: 30000, maxBuffer: 50 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] as ['pipe', 'pipe', 'pipe'], windowsHide: true };
 
   // Tracked files. --recurse-submodules pulls in files from active submodules,
   // which the index would otherwise represent only as a commit pointer.
@@ -241,7 +241,7 @@ function getGitVisibleFiles(rootDir: string): Set<string> | null {
     const gitRoot = execFileSync(
       'git',
       ['rev-parse', '--show-toplevel'],
-      { cwd: rootDir, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }
+      { cwd: rootDir, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
     ).trim();
 
     if (path.resolve(gitRoot) !== path.resolve(rootDir)) {
@@ -250,7 +250,7 @@ function getGitVisibleFiles(rootDir: string): Set<string> | null {
         execFileSync(
           'git',
           ['check-ignore', '-q', path.resolve(rootDir)],
-          { cwd: rootDir, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }
+          { cwd: rootDir, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
         );
         // Directory is gitignored by parent repo — fall back to filesystem walk
         return null;
@@ -291,7 +291,7 @@ function getGitChangedFiles(rootDir: string): GitChanges | null {
     const output = execFileSync(
       'git',
       ['status', '--porcelain', '--no-renames'],
-      { cwd: rootDir, encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] }
+      { cwd: rootDir, encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
     );
 
     const modified: string[] = [];

--- a/src/sync/git-hooks.ts
+++ b/src/sync/git-hooks.ts
@@ -44,6 +44,7 @@ export function isGitRepo(projectRoot: string): boolean {
       cwd: projectRoot,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
     }).trim();
     return out === 'true';
   } catch {
@@ -61,6 +62,7 @@ function gitHooksDir(projectRoot: string): string | null {
       cwd: projectRoot,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
     }).trim();
     if (!out) return null;
     return path.isAbsolute(out) ? out : path.resolve(projectRoot, out);

--- a/src/sync/worktree.ts
+++ b/src/sync/worktree.ts
@@ -35,6 +35,7 @@ export function gitWorktreeRoot(dir: string): string | null {
       cwd: dir,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
     }).trim();
     return out ? realpath(out) : null;
   } catch {


### PR DESCRIPTION
Fixes #485.

## Summary

On Windows, the daemon flashes a black `git.exe` console window on every auto-sync. The cause is `execFileSync('git', …)` call sites in the daemon's code paths missing `windowsHide: true`. This PR adds the option to all 7 sites; the change is a one-liner per call site and a no-op on macOS/Linux.

## Root cause

The daemon is launched with `detached: true` (`mcp/index.ts`, the existing `spawn(process.execPath, …)` call), which deliberately leaves it without a parent console. On Windows, when a Console-subsystem child (`git.exe`) is started from a console-less parent, Windows allocates a fresh console window for it unless `CREATE_NO_WINDOW` is set. Node maps `windowsHide: true` to `CREATE_NO_WINDOW`. Without it, every short-lived `git` invocation flashes its own window. The daemon launcher itself already passes `windowsHide: true` — it's the git call sites that were missed.

## Call sites changed (7 total)

| File | Function / line | git command |
|---|---|---|
| `src/extraction/index.ts` | `collectGitFiles` shared `gitOpts` | `ls-files -c --recurse-submodules`, `ls-files -o --exclude-standard` |
| `src/extraction/index.ts` | `getGitVisibleFiles` | `rev-parse --show-toplevel` |
| `src/extraction/index.ts` | `getGitVisibleFiles` | `check-ignore -q` |
| `src/extraction/index.ts` | `getGitChangedFiles` | `status --porcelain --no-renames` |
| `src/sync/worktree.ts` | `gitWorktreeRoot` | `rev-parse --show-toplevel` |
| `src/sync/git-hooks.ts` | `isGitRepo` | `rev-parse --is-inside-work-tree` |
| `src/sync/git-hooks.ts` | `gitHooksDir` | `rev-parse --git-path hooks` |

The fix is the same one-line addition (`windowsHide: true`) on each options object.

## Verification

1. Apply the patch and rebuild (`npm run build`).
2. Restart the daemon: kill the PID in `.codegraph/daemon.pid`, then trigger any CodeGraph CLI/MCP call so it respawns.
3. Edit files in an indexed repo at >1 write/sec. The `git.exe` console window should no longer flash. `.codegraph/daemon.log` still shows the `[CodeGraph MCP] Auto-synced N file(s) in <ms>ms` lines — i.e. the sync still runs, just hidden.
4. macOS/Linux: `windowsHide` is ignored, behavior unchanged.

## Notes for reviewers

- `extraction/wasm-runtime-flags.ts` uses `spawnSync(process.execPath, …, { stdio: 'inherit' })` — the relaunch shim spawns Node from a Node parent that already owns a console, so no new window is allocated and no change is needed.
- Optional follow-up (not in this PR to keep the diff minimal): extract a `runGit(args, opts)` helper that injects `windowsHide: true` so this can't regress.