### PR TITLE
fix(watcher): ignore .git and CodeGraph data dirs at any depth

### DIFF
--- a/__tests__/watcher.test.ts
+++ b/__tests__/watcher.test.ts
@@ -401,6 +401,27 @@ describe('FileWatcher', () => {
       watcher.stop();
     });
 
+    it('should ignore nested .git and CodeGraph data dirs at any depth (#517)', async () => {
+      const syncFn = vi.fn().mockResolvedValue({ filesChanged: 0, durationMs: 0 });
+      const watcher = newWatcher(syncFn, { debounceMs: 200 });
+
+      watcher.start();
+      await watcher.waitUntilReady();
+
+      // A nested `.git` (git subtree/submodule) and a sibling data dir like
+      // `.codegraph-win` (#636) below the root must be dropped by isAlwaysIgnored
+      // — even when the leaf looks like a source file. Otherwise the Linux walk
+      // descends into them and burns the inotify watch budget. The `.ts` leaves
+      // would pass isSourceFile, so only the segment check can drop them.
+      __emitWatchEventForTests(testDir, 'packages/sub/.git/hooks/x.ts');
+      __emitWatchEventForTests(testDir, 'packages/sub/.codegraph-win/cache.ts');
+
+      await new Promise((r) => setTimeout(r, 400));
+      expect(syncFn).not.toHaveBeenCalled();
+
+      watcher.stop();
+    });
+
     it('should drop ignored/non-source paths but sync real source edits', async () => {
       const syncFn = vi.fn().mockResolvedValue({ filesChanged: 0, durationMs: 0 });
       const watcher = newWatcher(syncFn, { debounceMs: 200 });

--- a/src/sync/watcher.ts
+++ b/src/sync/watcher.ts
@@ -564,14 +564,15 @@ export class FileWatcher {
 
   /** Our own dirs are always ignored, regardless of .gitignore. */
   private isAlwaysIgnored(rel: string): boolean {
-    // First path segment. Ignore any CodeGraph data dir — the active one AND a
-    // sibling like `.codegraph-win` a second environment (Windows/WSL) created
-    // in the same tree, so neither side watches the other's index (#636).
-    const top = rel.split('/')[0] ?? rel;
-    return (
-      isCodeGraphDataDir(top) ||
-      rel === '.git' || rel.startsWith('.git/')
-    );
+    // Check EVERY path segment, not just the root one. A monorepo with git
+    // subtrees/submodules has nested `.git` directories; on Linux the
+    // per-directory walk would otherwise descend into each one and burn the
+    // inotify watch budget, and on macOS/Windows the recursive watcher would
+    // stream their churn through handleChange (#517). isCodeGraphDataDir is
+    // applied per-segment so a sibling data dir like `.codegraph-win` a second
+    // environment (Windows/WSL) created is still matched at depth (#636).
+    const parts = rel.split('/');
+    return parts.some(isCodeGraphDataDir) || parts.includes('.git');
   }
 
   /**


### PR DESCRIPTION
### Problem
`isAlwaysIgnored` in `src/sync/watcher.ts` only matched `.git` and the CodeGraph data dir when they sat at the **workspace root**. In a monorepo with git subtrees/submodules, nested `.git` directories live deeper in the tree and were not recognized:

- **Linux** (per-directory `fs.watch` walk): the walker descends into every nested `.git`, consuming the inotify watch budget (`maxDirWatches()` cap / `ENOSPC`) on directories that hold no source.
- **macOS/Windows** (single recursive `fs.watch`): their churn is streamed through `handleChange` on every git operation.

> The original report was an `ENFILE` crash under the old chokidar watcher. The watcher has since been rewritten to native `fs.watch`, so that crash no longer reproduces — but the nested-`.git` handling gap remains.

### Fix
Check **every** path segment instead of only the first. `isCodeGraphDataDir` is applied per-segment, so a sibling data dir like `.codegraph-win` (#636) is still matched at any depth.

```ts
const parts = rel.split('/');
return parts.some(isCodeGraphDataDir) || parts.includes('.git');
```

Adds a regression test that emits nested `.git/*.ts` and `.codegraph-win/*.ts` events (leaves that would otherwise pass `isSourceFile`) and asserts no sync is scheduled.

### Notes
- Rebased onto current `main` as a single commit (was conflicting against the pre-rewrite chokidar code).
- The earlier `graphify-out` default-ignore change was dropped — out of scope; a root `.gitignore` already covers per-project tool output dirs.