### PR TITLE
fix(wasm): add windowsHide to spawnSync re-exec to suppress terminal popup on Windows

### DIFF
--- a/src/extraction/wasm-runtime-flags.ts
+++ b/src/extraction/wasm-runtime-flags.ts
@@ -97,6 +97,7 @@ export function relaunchWithWasmRuntimeFlagsIfNeeded(scriptPath: string): void {
   const argv = buildRelaunchArgv(scriptPath, process.argv.slice(2));
   const result = spawnSync(process.execPath, argv, {
     stdio: 'inherit',
+    windowsHide: true,
     env: { ...process.env, [RELAUNCH_GUARD_ENV]: '1', [HOST_PPID_ENV]: String(process.ppid) },
   });
 


### PR DESCRIPTION
The `spawnSync` call in `relaunchWithWasmRuntimeFlagsIfNeeded` was missing `windowsHide: true`.

When the MCP server is launched by a host (e.g. VS Code) it is spawned with `windowsHide: true`, so it has no attached console. When the server then re-execs itself with `--liftoff-only` via `spawnSync` — without `windowsHide: true` — Windows finds no existing console to inherit and opens a new one, producing the visible terminal flash on every save/MCP invocation.

The fix is one line: add `windowsHide: true` to the `spawnSync` options, matching the flag already present on the initial daemon spawn in `src/mcp/index.ts`.

Fixes #510