### PR TITLE
fix(installer): stop writing duplicate instructions block to CLAUDE.m…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `macrozheng/mall` previously reported `20 047 edges` while the DB held
   `45 629`.
 
+### Changed
+- Claude Code: removed the duplicate `<!-- CODEGRAPH_START -->` block from `CLAUDE.md` — identical instructions are delivered automatically via the MCP `initialize` response (`SERVER_INSTRUCTIONS`) every session, making the CLAUDE.md copy redundant and costing ~1500 unnecessary tokens per turn. Re-running `codegraph install` strips the block from existing installs. Other targets (Cursor, Codex, opencode, Gemini, Kiro) are unchanged.
+
 ## [0.9.6] - 2026-05-27
 
 - **C/C++ `#include` resolution — bare-basename includes now connect to the

--- a/__tests__/installer-targets.test.ts
+++ b/__tests__/installer-targets.test.ts
@@ -1018,6 +1018,59 @@ describe('Installer targets — partial-state idempotency', () => {
     expect(fs.readFileSync(file, 'utf-8')).toBe(firstPass);
   });
 
+  it('claude: install does not write CLAUDE.md instructions block', () => {
+    const claude = getTarget('claude')!;
+    const claudeMd = path.join(tmpHome, '.claude', 'CLAUDE.md');
+
+    claude.install('global', { autoAllow: false });
+
+    if (fs.existsSync(claudeMd)) {
+      const content = fs.readFileSync(claudeMd, 'utf-8');
+      expect(content).not.toContain('<!-- CODEGRAPH_START -->');
+    }
+  });
+
+  it('claude: install strips existing CLAUDE.md codegraph block (migration path)', () => {
+    const claude = getTarget('claude')!;
+    const claudeDir = path.join(tmpHome, '.claude');
+    const claudeMd = path.join(claudeDir, 'CLAUDE.md');
+
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(claudeMd, [
+      '# My personal Claude instructions',
+      '',
+      'Always respond concisely.',
+      '',
+      '<!-- CODEGRAPH_START -->',
+      '## CodeGraph',
+      '',
+      'Old codegraph content here.',
+      '<!-- CODEGRAPH_END -->',
+      '',
+      '## Another personal section',
+      '',
+      'Keep this.',
+      '',
+    ].join('\n'));
+
+    const result = claude.install('global', { autoAllow: false });
+
+    // Block is gone, user content outside the markers is preserved.
+    const content = fs.readFileSync(claudeMd, 'utf-8');
+    expect(content).not.toContain('<!-- CODEGRAPH_START -->');
+    expect(content).not.toContain('<!-- CODEGRAPH_END -->');
+    expect(content).not.toContain('Old codegraph content here.');
+    expect(content).toContain('# My personal Claude instructions');
+    expect(content).toContain('Always respond concisely.');
+    expect(content).toContain('## Another personal section');
+    expect(content).toContain('Keep this.');
+
+    // Removal is surfaced in result.files.
+    const instrEntry = result.files.find((f) => f.path === claudeMd);
+    expect(instrEntry).toBeDefined();
+    expect(instrEntry!.action).toBe('removed');
+  });
+
   it('claude: uninstall strips stale hooks written in the npx form (local)', () => {
     const claude = getTarget('claude')!;
     const file = seedSettings('local', {

--- a/src/installer/targets/claude.ts
+++ b/src/installer/targets/claude.ts
@@ -124,7 +124,16 @@ class ClaudeCodeTarget implements AgentTarget {
     if (hookCleanup.action === 'removed') files.push(hookCleanup);
 
     // 3. CLAUDE.md instructions
-    files.push(writeInstructionsEntry(loc));
+    // Claude Code receives identical guidance via SERVER_INSTRUCTIONS in
+    // the MCP initialize response every session — writing it to CLAUDE.md
+    // duplicates ~1500 tokens per turn. Strip the block if a legacy install
+    // left one, so upgrading users stop paying the cost automatically.
+    const instr = instructionsPath(loc);
+    const instrAction = removeMarkedSection(instr, CODEGRAPH_SECTION_START, CODEGRAPH_SECTION_END);
+    if (instrAction === 'removed') {
+      files.push({ path: instr, action: 'removed' });
+    }
+    // 'not-found' / 'kept': nothing to report.
 
     return { files };
   }


### PR DESCRIPTION
## Summary / 概述

Closes #529

**EN:** Claude Code already receives `SERVER_INSTRUCTIONS` via the MCP `initialize` response on every session (~1700 tokens, surfaced as a system reminder). The installer was also writing an `INSTRUCTIONS_TEMPLATE` block to `CLAUDE.md` (~1500 tokens, ~90% identical content), so agents read the same guidance twice on every turn with no benefit — pure token waste.

**CN:** Claude Code 每次会话已通过 MCP `initialize` 响应收到 `SERVER_INSTRUCTIONS`（~1700 tokens，以系统提醒形式展示）。安装器同时还会向 `CLAUDE.md` 写入一份 `INSTRUCTIONS_TEMPLATE` block（~1500 tokens，内容约 90% 重合），导致 agent 每轮都重复读取相同内容，纯粹的 token 浪费。

## Changes / 改动

- **`src/installer/targets/claude.ts`**: In `install()`, replace the `writeInstructionsEntry()` call with `removeMarkedSection()` — strips the existing block if a legacy install left one (automatic migration for upgrading users). Only reports `action: 'removed'` when content was actually stripped. `uninstall()` is unchanged (already calls `removeMarkedSection`). `writeInstructionsEntry()` stays exported for the deprecated `config-writer.ts` shim.
- **Other targets** (Cursor, Codex, opencode, Gemini, Kiro, Hermes, Antigravity): **unchanged** — they don't reliably surface `SERVER_INSTRUCTIONS` and still need their own instructions files.
- **`CHANGELOG.md`**: entry added under `## [Unreleased] / ### Changed`.

---

- **`src/installer/targets/claude.ts`**：在 `install()` 中将 `writeInstructionsEntry()` 改为调用 `removeMarkedSection()`——如果旧版安装留下了 block，自动将其清除（升级用户无需手动操作）。仅在实际移除内容时才向 `files` 添加 `action: 'removed'`。`uninstall()` 保持不变。`writeInstructionsEntry()` 保留导出供已废弃的 `config-writer.ts` shim 使用。
- **其他 target**（Cursor、Codex、opencode、Gemini、Kiro 等）：**不受影响**——这些 target 不能可靠地展示 `SERVER_INSTRUCTIONS`，仍需各自的指令文件。
- **`CHANGELOG.md`**：在 `## [Unreleased] / ### Changed` 下新增条目。

## Test plan / 测试

- [ ] `__tests__/installer-targets.test.ts` passes (134 tests) — all parametrized contract tests for Claude still pass (`files.length > 0`, idempotency, `alreadyConfigured` round-trip)
- [ ] New: `claude: install does not write CLAUDE.md instructions block`
- [ ] New: `claude: install strips existing CLAUDE.md codegraph block (migration path)` — verifies user content outside markers is preserved and removal is surfaced in `result.files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
