### PR TITLE
fix(scan): index files under non-ASCII (CJK) directory names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixes
+
+- Source files under directories with non-ASCII names (e.g. CJK / Chinese folder names) are no longer silently skipped during indexing. `git ls-files` and `git status` octal-escape and quote any path with non-ASCII bytes by default (`core.quotePath`), which mangled the path so extension detection dropped the file; those commands now run with `core.quotePath=false`. Projects organized by non-English folder names now index in full instead of only their all-ASCII paths.
+
 ## [0.9.7] - 2026-05-28
 
 ### New Features

--- a/__tests__/extraction.test.ts
+++ b/__tests__/extraction.test.ts
@@ -3382,6 +3382,52 @@ describe('Git Submodules', () => {
   });
 });
 
+describe('Non-ASCII (CJK) paths', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  it('should index source files under directories with non-ASCII names', async () => {
+    const { execFileSync } = await import('child_process');
+    const git = (cwd: string, ...args: string[]) =>
+      execFileSync('git', args, { cwd, stdio: 'pipe' });
+
+    // git defaults to core.quotePath=true, which octal-escapes and double-quotes
+    // any path byte outside ASCII. Reading `git ls-files` output without
+    // disabling that mangles the path (e.g. `"src/\344\270\255/Foo.cs"`),
+    // breaking extension detection so the file is silently dropped.
+    git(tempDir, 'init', '-q');
+    git(tempDir, 'config', 'user.email', 'test@test.com');
+    git(tempDir, 'config', 'user.name', 'Test');
+
+    // English control file (always worked) + a committed file under a CJK dir.
+    const enDir = path.join(tempDir, 'src', 'english');
+    const cjkDir = path.join(tempDir, 'src', '中文目录');
+    fs.mkdirSync(enDir, { recursive: true });
+    fs.mkdirSync(cjkDir, { recursive: true });
+    fs.writeFileSync(path.join(enDir, 'Foo.cs'), 'public class Foo {}');
+    fs.writeFileSync(path.join(cjkDir, 'Bar.cs'), 'public class Bar {}');
+    git(tempDir, 'add', '-A');
+    git(tempDir, 'commit', '-q', '-m', 'init');
+
+    // An untracked file under a CJK dir goes through the `git ls-files -o` path.
+    fs.writeFileSync(path.join(cjkDir, 'Baz.cs'), 'public class Baz {}');
+
+    const files = scanDirectory(tempDir);
+
+    // All three .cs files must be found...
+    expect(files.filter((f) => f.endsWith('.cs')).length).toBe(3);
+    // ...and no returned path may carry git's quoting artifacts.
+    expect(files.every((f) => !f.includes('"') && !f.includes('\\'))).toBe(true);
+  });
+});
+
 describe('Nested non-submodule git repos', () => {
   let tempDir: string;
 

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -198,7 +198,7 @@ function collectGitFiles(repoDir: string, prefix: string, files: Set<string>): v
   // Without this, monorepos using submodules index 0 files. (See issue #147.)
   // Note: --recurse-submodules only supports -c/--cached and --stage modes — it
   // can't be combined with -o, so untracked files are gathered separately below.
-  const tracked = execFileSync('git', ['ls-files', '-c', '--recurse-submodules'], gitOpts);
+  const tracked = execFileSync('git', ['-c', 'core.quotePath=false', 'ls-files', '-c', '--recurse-submodules'], gitOpts);
   for (const line of tracked.split('\n')) {
     const trimmed = line.trim();
     if (trimmed) {
@@ -209,7 +209,7 @@ function collectGitFiles(repoDir: string, prefix: string, files: Set<string>): v
   // Untracked files (submodules manage their own untracked state). Embedded git
   // repos surface here as a single "subdir/" entry that git refuses to descend
   // into — recurse into those as their own repos so their source gets indexed.
-  const untracked = execFileSync('git', ['ls-files', '-o', '--exclude-standard'], gitOpts);
+  const untracked = execFileSync('git', ['-c', 'core.quotePath=false', 'ls-files', '-o', '--exclude-standard'], gitOpts);
   for (const line of untracked.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -290,7 +290,7 @@ function getGitChangedFiles(rootDir: string): GitChanges | null {
   try {
     const output = execFileSync(
       'git',
-      ['status', '--porcelain', '--no-renames'],
+      ['-c', 'core.quotePath=false', 'status', '--porcelain', '--no-renames'],
       { cwd: rootDir, encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
     );
 


### PR DESCRIPTION
## Problem

Source files under a directory whose name contains non-ASCII characters (e.g. CJK / Chinese folder names) are silently skipped during indexing — no error, no warning. They are not gitignored and parse fine; they simply never enter the index.

On a real .NET solution that groups code into Chinese business-domain folders, only **114 of 902** `.cs` files were indexed — every skipped file lived under a directory with a non-ASCII name; every indexed file lived under an all-ASCII path.

### Minimal reproduction

```sh
REPRO=/tmp/cg-cjk-repro
mkdir -p "$REPRO/src/english" "$REPRO/src/中文目录"
printf 'public class Foo {}\n' > "$REPRO/src/english/Foo.cs"
printf 'public class Bar {}\n' > "$REPRO/src/中文目录/Bar.cs"
cd "$REPRO" && git init -q && git add -A && git commit -qm init
codegraph init "$REPRO" && codegraph index "$REPRO" --force
codegraph files --format flat   # only src/english/Foo.cs shows up
```

## Root cause

`collectGitFiles` and `getGitChangedFiles` read `git ls-files` / `git status` output verbatim. git defaults to `core.quotePath=true`, which octal-escapes **and double-quotes** any path containing a byte outside ASCII. So a tracked file at `src/中文目录/Bar.cs` arrives as:

```
"src/\344\270\255\346\226\207\347\233\256\345\275\225/Bar.cs"
```

The surrounding quotes and escapes mean `isSourceFile()` sees an extension of `.cs"` (trailing quote), which isn't in `EXTENSION_MAP`, so the file is dropped. All-ASCII paths are emitted unquoted and are unaffected — which is exactly why only English-named folders were indexed.

## Fix

Run the three path-reading git commands with `-c core.quotePath=false` so non-ASCII paths come through as real UTF-8:

- `git ls-files -c --recurse-submodules` (tracked)
- `git ls-files -o --exclude-standard` (untracked)
- `git status --porcelain --no-renames` (incremental sync)

## Testing

- Added a regression test (`Non-ASCII (CJK) paths`) that commits one file and leaves one untracked under a CJK-named directory, plus an ASCII control, and asserts all three `.cs` files are scanned with no quoting artifacts in the returned paths. It fails before the change (1 of 3 found) and passes after.
- Full `vitest run` shows no new failures attributable to this change.
- Verified end-to-end on the real repo: indexed file count went from **114 → 892**, and the previously-missing Chinese-path source is now fully present.

No existing issue filed for this; happy to open one to track if preferred.
