### PR TITLE
docs(readme): clarify what `init -i` does vs plain `init` (#483)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ cd your-project
 codegraph init -i
 ```
 
+<sub>`codegraph init` just creates the local `.codegraph/` index directory; adding `-i` (`--index`) also builds the initial graph in the same step. Without `-i`, run `codegraph index` afterwards to populate it.</sub>
+
 <div align="center">
 
 ![1_C_VYnhpys0UHrOuOgpgoyw](https://github.com/user-attachments/assets/f168182f-4d9a-44e0-94d7-08d018cc8a3a)


### PR DESCRIPTION
Closes #483.

A user asked what `-i` does on `codegraph init` and why it isn't the default. Adds a one-line note under the **Initialize Projects** quickstart:

> `codegraph init` just creates the local `.codegraph/` index directory; adding `-i` (`--index`) also builds the initial graph in the same step. Without `-i`, run `codegraph index` afterwards to populate it.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)