### PR TITLE
feat(cli): `codegraph init` builds the initial index by default (#483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### New Features
+
+- `codegraph init` now builds the initial index by default — you no longer need the `-i`/`--index` flag (it's still accepted, so existing commands and scripts keep working). (#483)
+
 ### Fixes
 
 - Indexing a project that contains only config-style files (YAML, Twig, or `.properties`) no longer misleadingly reports "No files found to index" — these files are tracked at the file level and are now counted as indexed. Thanks @luojiyin1987 (#357).

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -416,8 +416,8 @@ function writeErrorLog(projectPath: string, errors: Array<{ message: string; fil
  */
 program
   .command('init [path]')
-  .description('Initialize CodeGraph in a project directory')
-  .option('-i, --index', 'Run initial indexing after initialization')
+  .description('Initialize CodeGraph in a project directory and build the initial index')
+  .option('-i, --index', 'Deprecated: indexing now runs by default; flag accepted for backward compatibility')
   .option('-v, --verbose', 'Show detailed worker lifecycle and memory info')
   .action(async (pathArg: string | undefined, options: { index?: boolean; verbose?: boolean }) => {
     const projectPath = path.resolve(pathArg || process.cwd());
@@ -441,27 +441,24 @@ program
       const cg = await CodeGraph.init(projectPath, { index: false });
       clack.log.success(`Initialized in ${projectPath}`);
 
-      if (options.index) {
-        let result: IndexResult;
-
-        if (options.verbose) {
-          result = await cg.indexAll({
-            onProgress: createVerboseProgress(),
-            verbose: true,
-          });
-        } else {
-          process.stdout.write(`${colors.dim}${getGlyphs().rail}${colors.reset}\n`);
-          const progress = createShimmerProgress();
-          result = await cg.indexAll({
-            onProgress: progress.onProgress,
-          });
-          await progress.stop();
-        }
-
-        printIndexResult(clack, result, projectPath);
+      // Indexing runs by default now. The legacy -i/--index flag is still
+      // accepted (so existing muscle memory and scripts don't break) but is a
+      // no-op — initializing always builds the initial index.
+      let result: IndexResult;
+      if (options.verbose) {
+        result = await cg.indexAll({
+          onProgress: createVerboseProgress(),
+          verbose: true,
+        });
       } else {
-        clack.log.info('Run "codegraph index" to index the project');
+        process.stdout.write(`${colors.dim}${getGlyphs().rail}${colors.reset}\n`);
+        const progress = createShimmerProgress();
+        result = await cg.indexAll({
+          onProgress: progress.onProgress,
+        });
+        await progress.stop();
       }
+      printIndexResult(clack, result, projectPath);
 
       try {
         const { offerWatchFallback } = await import('../installer');


### PR DESCRIPTION
Relates to #483 (a user asked why `-i` wasn't implicit).

`codegraph init` now runs the initial index automatically. The `-i`/`--index` flag is **kept but is now a no-op**, accepted for backward compatibility so existing muscle memory and scripts (`codegraph init -i`) keep working without an "unknown option" error.

### ⚠️ Ships in 0.9.8 — docs intentionally deferred
README and `site/` docs are **not** updated here. They describe the currently-released **0.9.7** behavior, where `-i` is still required to index. Updating them now would mislead users on 0.9.7. **Update README + site docs at the 0.9.8 release.** (CHANGELOG `[Unreleased]` is updated, since that section is explicitly next-release.)

### Validation
- `codegraph init` (no flag) → `Indexed 1 files · 3 nodes` (was: "Run codegraph index to index the project").
- `codegraph init -i` → still works, no error.
- `init --help` shows `-i` as deprecated.
- Full suite: 1080 passed; only the 5 pre-existing `npm-shim` local-HTTPS failures remain (reproduce on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)