### PR TITLE
docs: clarify Codex support scope (CLI vs extension)

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,10 @@ is written):
 - **Antigravity IDE**
 - **Kiro**
 
+> **Note on Codex support:** CodeGraph currently supports **Codex CLI** via
+> `~/.codex/config.toml` (global config). If you're using a separate **Codex VS
+> Code extension**, that setup path is not documented here yet.
+
 ## Supported Languages
 
 | Language | Extension | Status |


### PR DESCRIPTION
# PR Description

## Problem

The README mentions Codex support, which can be read as including both Codex CLI and a Codex VS Code extension setup path.

## What changed

- Added a clarification note under **Supported Agents** in `README.md`.
- Explicitly states current support is **Codex CLI** via `~/.codex/config.toml` (global config).
- Notes that **Codex VS Code extension** setup is not documented yet.

## Why this helps

This removes ambiguity for users during setup and reduces confusion around which Codex integration path is currently documented.

## Validation

- `npm run build` ✅ passed locally.
- `npm test` ⚠️ failed in this Windows environment due unrelated pre-existing timeout/EPERM/OOM issues during full-suite execution.

## Scope

- Docs-only change.
- No runtime, installer behavior, or API changes.
