### PR TITLE
fix(db): chunk unresolved reference queries during sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixes
 
 - Indexing a project that contains only config-style files (YAML, Twig, or `.properties`) no longer misleadingly reports "No files found to index" — these files are tracked at the file level and are now counted as indexed. Thanks @luojiyin1987 (#357).
+- Syncing very large repositories no longer fails with "too many SQL variables" while resolving changed files; CodeGraph now batches those lookups so large codebases can complete normally. (#540)
 
 ## [0.9.7] - 2026-05-28
 

--- a/__tests__/db-perf.test.ts
+++ b/__tests__/db-perf.test.ts
@@ -10,13 +10,13 @@
  *   4. `insertEdges` validates endpoints from the DB, not stale node cache.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { DatabaseConnection } from '../src/db';
 import { QueryBuilder } from '../src/db/queries';
-import { Node } from '../src/types';
+import { EdgeKind, Node } from '../src/types';
 
 function makeNode(id: string, name = id): Node {
   return {
@@ -171,6 +171,89 @@ describe('insertEdges endpoint validation', () => {
       q.insertEdges([{ source: 'source', target: 'target', kind: 'calls' }])
     ).not.toThrow();
     expect(q.getOutgoingEdges('source')).toEqual([]);
+  });
+});
+
+describe('unresolved reference chunking', () => {
+  let dir: string;
+  let db: DatabaseConnection;
+  let q: QueryBuilder;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'db-perf-unresolved-'));
+    db = DatabaseConnection.initialize(path.join(dir, 'test.db'));
+    q = new QueryBuilder(db.getDb());
+  });
+
+  afterEach(() => {
+    db.close();
+    if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('gets unresolved references for more files than SQLite accepts in one IN list', () => {
+    const count = 1500;
+    const nodes = Array.from({ length: count }, (_, i) =>
+      makeNode(`node-${i}`, `node${i}`)
+    );
+    const filePaths = nodes.map((_, i) => `src/file-${i}.ts`);
+
+    q.insertNodes(nodes.map((node, i) => ({ ...node, filePath: filePaths[i] })));
+    q.insertUnresolvedRefsBatch(
+      nodes.map((node, i) => ({
+        fromNodeId: node.id,
+        referenceName: `target${i}`,
+        referenceKind: 'calls' as EdgeKind,
+        line: 1,
+        column: 0,
+        filePath: filePaths[i],
+        language: 'typescript',
+      }))
+    );
+
+    const prepareSpy = vi.spyOn(db.getDb(), 'prepare');
+    const refs = q.getUnresolvedReferencesByFiles(filePaths);
+    const selectCalls = prepareSpy.mock.calls
+      .map(([sql]) => String(sql))
+      .filter((sql) => sql.includes('FROM unresolved_refs WHERE file_path IN'));
+    const maxPlaceholders = Math.max(
+      ...selectCalls.map((sql) => (sql.match(/\?/g) ?? []).length)
+    );
+
+    expect(refs).toHaveLength(count);
+    expect(refs.map((ref) => ref.filePath).sort()).toEqual([...filePaths].sort());
+    expect(maxPlaceholders).toBeLessThanOrEqual(500);
+  });
+
+  it('deletes resolved references for more nodes than SQLite accepts in one IN list', () => {
+    const count = 1500;
+    const nodes = Array.from({ length: count }, (_, i) =>
+      makeNode(`node-${i}`, `node${i}`)
+    );
+
+    q.insertNodes(nodes);
+    q.insertUnresolvedRefsBatch(
+      nodes.map((node, i) => ({
+        fromNodeId: node.id,
+        referenceName: `target${i}`,
+        referenceKind: 'calls' as EdgeKind,
+        line: 1,
+        column: 0,
+        filePath: `src/file-${i}.ts`,
+        language: 'typescript',
+      }))
+    );
+
+    const prepareSpy = vi.spyOn(db.getDb(), 'prepare');
+    q.deleteResolvedReferences(nodes.map((node) => node.id));
+    const deleteCalls = prepareSpy.mock.calls
+      .map(([sql]) => String(sql))
+      .filter((sql) => sql.includes('DELETE FROM unresolved_refs WHERE from_node_id IN'));
+    const maxPlaceholders = Math.max(
+      ...deleteCalls.map((sql) => (sql.match(/\?/g) ?? []).length)
+    );
+
+    expect(q.getUnresolvedReferences()).toEqual([]);
+    expect(maxPlaceholders).toBeLessThanOrEqual(500);
   });
 });
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1572,10 +1572,17 @@ export class QueryBuilder {
   getUnresolvedReferencesByFiles(filePaths: string[]): UnresolvedReference[] {
     if (filePaths.length === 0) return [];
 
-    const placeholders = filePaths.map(() => '?').join(',');
-    const rows = this.db
-      .prepare(`SELECT * FROM unresolved_refs WHERE file_path IN (${placeholders})`)
-      .all(...filePaths) as UnresolvedRefRow[];
+    const rows: UnresolvedRefRow[] = [];
+    const uniqueFilePaths = [...new Set(filePaths)];
+    for (let i = 0; i < uniqueFilePaths.length; i += SQLITE_PARAM_CHUNK_SIZE) {
+      const chunk = uniqueFilePaths.slice(i, i + SQLITE_PARAM_CHUNK_SIZE);
+      const placeholders = chunk.map(() => '?').join(',');
+      rows.push(
+        ...(this.db
+          .prepare(`SELECT * FROM unresolved_refs WHERE file_path IN (${placeholders})`)
+          .all(...chunk) as UnresolvedRefRow[])
+      );
+    }
 
     return rows.map((row) => ({
       fromNodeId: row.from_node_id,
@@ -1601,8 +1608,14 @@ export class QueryBuilder {
    */
   deleteResolvedReferences(fromNodeIds: string[]): void {
     if (fromNodeIds.length === 0) return;
-    const placeholders = fromNodeIds.map(() => '?').join(',');
-    this.db.prepare(`DELETE FROM unresolved_refs WHERE from_node_id IN (${placeholders})`).run(...fromNodeIds);
+    const uniqueNodeIds = [...new Set(fromNodeIds)];
+    for (let i = 0; i < uniqueNodeIds.length; i += SQLITE_PARAM_CHUNK_SIZE) {
+      const chunk = uniqueNodeIds.slice(i, i + SQLITE_PARAM_CHUNK_SIZE);
+      const placeholders = chunk.map(() => '?').join(',');
+      this.db
+        .prepare(`DELETE FROM unresolved_refs WHERE from_node_id IN (${placeholders})`)
+        .run(...chunk);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- chunk unresolved-reference lookups by changed file path
- chunk resolved-reference cleanup by source node id
- add regression coverage for large unresolved-reference batches
- document the fix in the unreleased changelog

## Problem

Issue #540 reports `codegraph sync` failing on a very large checkout with `too many SQL variables` near the end of parsing.

`getUnresolvedReferencesByFiles()` built one `IN (...)` query containing every changed file path. Large sync batches can exceed SQLite's bind parameter limit, even though nearby node lookup code already chunks at 500 parameters for portability across SQLite backends.

`deleteResolvedReferences()` had the same large `IN (...)` shape for source node IDs, so this patch applies the same batching rule there too.

## Fix

This updates both unresolved-reference paths to deduplicate inputs and process them in `SQLITE_PARAM_CHUNK_SIZE` chunks.

That keeps each prepared statement under the existing 500-parameter safety limit while preserving the old behavior for empty inputs and duplicate file paths or node IDs.

Closes #540.

## Validation

- `npx vitest run __tests__/db-perf.test.ts`
- `npx -y -p node@22 -p npm@10 npm run build`
- `npx -y -p node@22 -p npm@10 npm test`
- `git diff --check`
