### PR TITLE
fix: resolve install.ps1 latest version without the GitHub API

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -21,11 +21,27 @@ $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture 
 $target = "win32-$arch"
 
 # 2. Resolve the version (latest release unless pinned).
+#    Use the releases/latest *web* redirect first — the unauthenticated GitHub API
+#    is rate-limited to 60 requests/hour per IP and returns 403 on shared hosts
+#    and CI (issue #325). The redirect has no such limit. Fall back to the API.
 $version = $env:CODEGRAPH_VERSION
 if (-not $version) {
-  $version = (Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest").tag_name
+  try {
+    # Follow the redirect and read the final URL (no API call, no rate limit).
+    $resp = Invoke-WebRequest -Uri "https://github.com/$repo/releases/latest" -UseBasicParsing
+    if ($resp.BaseResponse.ResponseUri.AbsoluteUri -match '/releases/tag/(.+)') {
+      $version = $Matches[1]
+    }
+  } catch { }
 }
-if (-not $version) { throw "codegraph: could not resolve latest version; set CODEGRAPH_VERSION." }
+if (-not $version) {
+  try {
+    $version = (Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest").tag_name
+  } catch { }
+}
+# Release tags are vX.Y.Z; accept a bare X.Y.Z in CODEGRAPH_VERSION too.
+if ($version -and $version -notmatch '^v') { $version = "v$version" }
+if (-not $version) { throw "codegraph: could not resolve latest version; set CODEGRAPH_VERSION (e.g. CODEGRAPH_VERSION=v0.9.7)." }
 
 # 3. Download + extract the bundle into a stable 'current' dir (overwritten on upgrade).
 $url = "https://github.com/$repo/releases/download/$version/codegraph-$target.zip"


### PR DESCRIPTION
## Problem

fixed `install.sh` to resolve the latest version via the web redirect instead of the GitHub API (rate-limited to 60 requests/hour per IP, returning 403 on shared hosts). The same fix was not applied to `install.ps1`, which still uses the API directly.

## Fix

Port the same three optimizations from #336 to `install.ps1`:

- Resolve "latest" from the `releases/latest` **web redirect** (`github.com/<repo>/releases/latest` → `BaseResponse.ResponseUri` → `.../tag/vX.Y.Z`) instead of the API — no token, no rate limit. Falls back to the API if the redirect can't be read.
- Wrap both resolution attempts in `try/catch` so a network failure on one path doesn't abort the installer before the fallback runs.

## Validation

- `pwsh -NoProfile -Command "& { Get-Content install.ps1 | Out-Null }"` — syntax check passes.
- Logic mirrors `install.sh` post-#336: redirect-first, API-fallback, version normalization.