### PR TITLE
fix(installer): include codegraph_files in Claude auto-allow (#565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
+- Claude installer auto-allow now includes `codegraph_files`, matching the documented manual Claude `settings.json` example. (#565)
 - Indexing a project that contains only config-style files (YAML, Twig, or `.properties`) no longer misleadingly reports "No files found to index" — these files are tracked at the file level and are now counted as indexed. Thanks @luojiyin1987 (#357).
 
 ## [0.9.7] - 2026-05-28

--- a/__tests__/installer-targets.test.ts
+++ b/__tests__/installer-targets.test.ts
@@ -1021,6 +1021,7 @@ describe('Installer targets — partial-state idempotency', () => {
     expect(stopCommands.some((c: string) => c.includes('gk') && c.includes('ai hook run'))).toBe(true);
     // Permissions still written as normal alongside the cleanup.
     expect(after.permissions?.allow).toContain('mcp__codegraph__codegraph_search');
+    expect(after.permissions?.allow).toContain('mcp__codegraph__codegraph_files');
   });
 
   it('claude: cleanupLegacyHooks preserves a sibling hook sharing our matcher group', () => {

--- a/src/installer/targets/shared.ts
+++ b/src/installer/targets/shared.ts
@@ -38,6 +38,7 @@ export function getCodeGraphPermissions(): string[] {
     'mcp__codegraph__codegraph_impact',
     'mcp__codegraph__codegraph_node',
     'mcp__codegraph__codegraph_status',
+    'mcp__codegraph__codegraph_files',
   ];
 }
 


### PR DESCRIPTION
## Summary

Closes #565.

The Claude installer's auto-allow list omitted `mcp__codegraph__codegraph_files`, so `codegraph install --target=claude ...` wrote a `settings.json` that still prompted for `codegraph_files` even though the documented manual Claude example already includes it.

## Change

- add `mcp__codegraph__codegraph_files` to `getCodeGraphPermissions()` in `src/installer/targets/shared.ts`
- add one installer regression assertion in `__tests__/installer-targets.test.ts`
- add an `[Unreleased]` fix note to `CHANGELOG.md`

This PR is intentionally narrow. It does not expand the Claude allowlist to `codegraph_explore` or `codegraph_trace`; those can be discussed separately.

## Validation

- `npx vitest run __tests__/installer-targets.test.ts`
- `npm run build`