### PR TITLE
fix(mcp): steer codegraph_context task param toward keywords (#571)

### DIFF
--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -441,7 +441,7 @@ export const tools: ToolDefinition[] = [
       properties: {
         task: {
           type: 'string',
-          description: 'Description of the task, bug, or feature to build context for',
+          description: 'Short keywords or symbol names to build context for (e.g., "auth signIn UserService"). Keyword-based search, so prefer terse queries over full sentences.',
         },
         maxNodes: {
           type: 'number',


### PR DESCRIPTION
The `task` parameter described itself as "Description of the task, bug, or feature," which leads models to pass full natural-language sentences. The context search is FTS5 keyword-based, so those extra words dilute the query and cause misses.

Reworded it to ask for short keywords or symbol names, matching how the other params in this file are described.

Ran `tsc --noEmit` to confirm it still compiles. Fixes #571.
