### PR TITLE
fix: guide models to use short keywords for codegraph_context task param

### DIFF
--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -441,7 +441,7 @@ export const tools: ToolDefinition[] = [
       properties: {
         task: {
           type: 'string',
-          description: 'Description of the task, bug, or feature to build context for',
+          description: 'Short keywords or symbol paths to search for (e.g. "AuthService/login" or "payment webhook handler"). Use concise terms — the search is FTS5-based, so verbose sentences dilute results with noise words.',
         },
         maxNodes: {
           type: 'number',


### PR DESCRIPTION
## Problem

The `task` parameter description of `codegraph_context` currently reads:

> "Description of the task, bug, or feature to build context for"

This leads models to pass verbose natural language sentences, diluting FTS5 search results with noise words.

## Fix

Updated the description to guide models toward short keywords with a concrete explanation:

> `Short keywords or symbol paths to search for (e.g. "AuthService/login" or "payment webhook handler"). Use concise terms — the search is FTS5-based, so verbose sentences dilute results with noise words.`

Fixes #571