### PR TITLE
[codex] Fix macOS path and symlink edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,80 @@ add a negation — `!vendor/`. The defaults apply uniformly, so committing a
 dependency or build directory doesn't force it into the graph; the `.gitignore`
 negation is the explicit opt-in.
 
+## Contributing
+
+Set up a local checkout from your fork:
+
+```bash
+git clone git@github.com:<your-user>/codegraph.git
+cd codegraph
+git remote add upstream https://github.com/colbymchenry/codegraph.git
+npm install
+npm run build
+```
+
+To point the global `codegraph` command at your local build while developing:
+
+```bash
+npm link
+codegraph --version
+```
+
+To switch back to the published package:
+
+```bash
+npm unlink -g @colbymchenry/codegraph
+npm i -g @colbymchenry/codegraph@latest
+```
+
+You can also run the local build without changing the global command:
+
+```bash
+npm run cli -- status
+```
+
+Useful development commands:
+
+```bash
+npm run dev          # TypeScript watch build
+npm test             # full test suite
+npm test -- <file>   # focused test file
+npm run test:watch   # Vitest watch mode
+```
+
+### macOS Source Builds and FTS5
+
+The self-contained release and npm package use CodeGraph's bundled runtime, so
+end users do not need to manage SQLite or FTS5. Contributors running directly
+from source use their local Node runtime instead. On macOS, some official Node
+22.x and 23.x builds include `node:sqlite` without FTS5 enabled, which makes
+indexing fail with `no such module: fts5`.
+
+Use Node 24.x for local development on macOS if you see that error:
+
+```bash
+nvm install 24
+nvm use 24
+npm install
+npm run build
+```
+
+Quick FTS5 check before indexing:
+
+```bash
+node - <<'NODE'
+const { DatabaseSync } = require('node:sqlite');
+const db = new DatabaseSync(':memory:');
+db.exec('CREATE VIRTUAL TABLE cg_fts_check USING fts5(value)');
+db.close();
+console.log('FTS5 available');
+NODE
+```
+
+PR hygiene: do not bump `package.json` versions unless you are preparing a
+release, and do not update `package-lock.json` unless your change modifies
+dependencies.
+
 ## Supported Platforms
 
 Every release ships a self-contained build (bundled Node runtime — nothing to

--- a/__tests__/extraction.test.ts
+++ b/__tests__/extraction.test.ts
@@ -3382,6 +3382,44 @@ describe('Directory Exclusion', () => {
     expect(files.every((f) => !f.includes('.git'))).toBe(true);
   });
 
+  it('should index git-visible files under non-ASCII directories (issue #541)', async () => {
+    const { execFileSync } = await import('child_process');
+    const git = (...args: string[]) =>
+      execFileSync('git', args, { cwd: tempDir, stdio: 'pipe' });
+
+    git('init', '-q');
+    fs.mkdirSync(path.join(tempDir, 'src', 'english'), { recursive: true });
+    fs.mkdirSync(path.join(tempDir, 'src', '中文目录'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, 'src', 'english', 'Foo.cs'),
+      'namespace Demo;\npublic class Foo { public void Bar() {} }\n',
+    );
+    fs.writeFileSync(
+      path.join(tempDir, 'src', '中文目录', 'Baz.cs'),
+      'namespace Demo;\npublic class Baz { public void Qux() {} }\n',
+    );
+    git('add', '-A');
+
+    const scanned = scanDirectory(tempDir).sort();
+    expect(scanned).toEqual(['src/english/Foo.cs', 'src/中文目录/Baz.cs']);
+
+    const cg = CodeGraph.initSync(tempDir);
+    try {
+      const result = await cg.indexAll();
+      expect(result.filesIndexed).toBe(2);
+      expect(cg.getFiles().map((f) => f.path).sort()).toEqual(scanned);
+
+      fs.writeFileSync(
+        path.join(tempDir, 'src', '中文目录', 'Baz.cs'),
+        'namespace Demo;\npublic class Baz { public void Qux() {} public void Zap() {} }\n',
+      );
+      const changed = cg.getChangedFiles();
+      expect([...changed.added, ...changed.modified]).toContain('src/中文目录/Baz.cs');
+    } finally {
+      cg.close();
+    }
+  });
+
   it('should return forward-slash paths on all platforms', () => {
     const srcDir = path.join(tempDir, 'src', 'components');
     fs.mkdirSync(srcDir, { recursive: true });

--- a/__tests__/security.test.ts
+++ b/__tests__/security.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { FileLock, validateProjectPath } from '../src/utils';
+import { FileLock, validatePathWithinRoot, validateProjectPath } from '../src/utils';
 import CodeGraph from '../src/index';
 import { ToolHandler, tools } from '../src/mcp/tools';
 import { scanDirectory, isSourceFile } from '../src/extraction';
@@ -173,6 +173,72 @@ describe('Path Traversal Prevention', () => {
   it('should return null for non-existent node', async () => {
     const code = await cg.getCode('does-not-exist');
     expect(code).toBeNull();
+  });
+
+  it('should reject symlinked files that resolve outside the project root', () => {
+    const outsideDir = createTempDir();
+    try {
+      const outsideFile = path.join(outsideDir, 'secret.ts');
+      fs.writeFileSync(outsideFile, 'export const secret = "outside";\n');
+
+      const linkPath = path.join(testDir, 'src', 'secret.ts');
+      try {
+        fs.symlinkSync(outsideFile, linkPath, 'file');
+      } catch {
+        return;
+      }
+
+      expect(validatePathWithinRoot(testDir, 'src/secret.ts')).toBeNull();
+    } finally {
+      cleanupTempDir(outsideDir);
+    }
+  });
+
+  it('should reject paths beneath symlinked directories outside the project root', () => {
+    const outsideDir = createTempDir();
+    try {
+      const linkPath = path.join(testDir, 'src', 'external');
+      try {
+        fs.symlinkSync(outsideDir, linkPath, 'dir');
+      } catch {
+        return;
+      }
+
+      expect(validatePathWithinRoot(testDir, 'src/external/new-file.ts')).toBeNull();
+    } finally {
+      cleanupTempDir(outsideDir);
+    }
+  });
+
+  it('should allow symlinked files that resolve inside the project root', () => {
+    const linkPath = path.join(testDir, 'src', 'hello-link.ts');
+    try {
+      fs.symlinkSync(path.join(testDir, 'src', 'hello.ts'), linkPath, 'file');
+    } catch {
+      return;
+    }
+
+    expect(validatePathWithinRoot(testDir, 'src/hello-link.ts')).toBe(linkPath);
+  });
+
+  it('should not index symlinked files that resolve outside the project root', async () => {
+    const outsideDir = createTempDir();
+    try {
+      const outsideFile = path.join(outsideDir, 'secret.ts');
+      fs.writeFileSync(outsideFile, 'export const secret = "outside";\n');
+
+      try {
+        fs.symlinkSync(outsideFile, path.join(testDir, 'src', 'secret.ts'), 'file');
+      } catch {
+        return;
+      }
+
+      const result = await cg.indexAll();
+      expect(result.success).toBe(true);
+      expect(cg.getFiles().map((file) => file.path)).not.toContain('src/secret.ts');
+    } finally {
+      cleanupTempDir(outsideDir);
+    }
   });
 });
 
@@ -549,6 +615,28 @@ describe('Symlink Cycle Detection', () => {
     // Should not throw
     const files = scanDirectory(tempDir);
     expect(files).toContain('src/valid.ts');
+  });
+
+  it('should skip symlinks that resolve outside the root', () => {
+    const srcDir = path.join(tempDir, 'src');
+    fs.mkdirSync(srcDir);
+    fs.writeFileSync(path.join(srcDir, 'valid.ts'), 'export const valid = true;\n');
+
+    const outsideDir = createTempDir();
+    try {
+      fs.writeFileSync(path.join(outsideDir, 'secret.ts'), 'export const secret = true;\n');
+      try {
+        fs.symlinkSync(outsideDir, path.join(srcDir, 'external'), 'dir');
+      } catch {
+        return;
+      }
+
+      const files = scanDirectory(tempDir);
+      expect(files).toContain('src/valid.ts');
+      expect(files).not.toContain('src/external/secret.ts');
+    } finally {
+      cleanupTempDir(outsideDir);
+    }
   });
 });
 

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -160,6 +160,22 @@ const DEFAULT_IGNORE_PATTERNS: string[] = [
 ];
 
 /**
+ * Git quotes non-ASCII path bytes by default (e.g. CJK segments become octal
+ * escapes wrapped in quotes). We parse git path output as UTF-8 strings, so all
+ * path-emitting commands must disable that quoting or source files under
+ * non-ASCII directories fail extension detection.
+ */
+const GIT_PATH_OUTPUT_ARGS = ['-c', 'core.quotePath=false'];
+
+function gitPathLines(output: string): string[] {
+  const lines = output.split('\n');
+  if (lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+  return lines.filter((line) => line.length > 0);
+}
+
+/**
  * An `ignore` matcher seeded with the built-in defaults, merged with the project's
  * root .gitignore so a negation there (e.g. `!vendor/`) overrides a default. Shared
  * by both enumeration paths so behavior is identical with or without git — and so
@@ -198,32 +214,27 @@ function collectGitFiles(repoDir: string, prefix: string, files: Set<string>): v
   // Without this, monorepos using submodules index 0 files. (See issue #147.)
   // Note: --recurse-submodules only supports -c/--cached and --stage modes — it
   // can't be combined with -o, so untracked files are gathered separately below.
-  const tracked = execFileSync('git', ['ls-files', '-c', '--recurse-submodules'], gitOpts);
-  for (const line of tracked.split('\n')) {
-    const trimmed = line.trim();
-    if (trimmed) {
-      files.add(normalizePath(prefix + trimmed));
-    }
+  const tracked = execFileSync('git', [...GIT_PATH_OUTPUT_ARGS, 'ls-files', '-c', '--recurse-submodules'], gitOpts);
+  for (const filePath of gitPathLines(tracked)) {
+    files.add(normalizePath(prefix + filePath));
   }
 
   // Untracked files (submodules manage their own untracked state). Embedded git
   // repos surface here as a single "subdir/" entry that git refuses to descend
   // into — recurse into those as their own repos so their source gets indexed.
-  const untracked = execFileSync('git', ['ls-files', '-o', '--exclude-standard'], gitOpts);
-  for (const line of untracked.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    if (trimmed.endsWith('/')) {
+  const untracked = execFileSync('git', [...GIT_PATH_OUTPUT_ARGS, 'ls-files', '-o', '--exclude-standard'], gitOpts);
+  for (const filePath of gitPathLines(untracked)) {
+    if (filePath.endsWith('/')) {
       // git only emits a trailing-slash directory entry for an embedded repo.
       // Guard with a .git check anyway, and skip anything else exactly as git
       // itself skips it (we never descend into a non-repo opaque dir).
-      const childDir = path.join(repoDir, trimmed);
+      const childDir = path.join(repoDir, filePath);
       if (fs.existsSync(path.join(childDir, '.git'))) {
-        collectGitFiles(childDir, prefix + trimmed, files);
+        collectGitFiles(childDir, prefix + filePath, files);
       }
       continue;
     }
-    files.add(normalizePath(prefix + trimmed));
+    files.add(normalizePath(prefix + filePath));
   }
 }
 
@@ -240,9 +251,9 @@ function getGitVisibleFiles(rootDir: string): Set<string> | null {
     // `git ls-files` returns nothing — fall back to filesystem walk.
     const gitRoot = execFileSync(
       'git',
-      ['rev-parse', '--show-toplevel'],
+      [...GIT_PATH_OUTPUT_ARGS, 'rev-parse', '--show-toplevel'],
       { cwd: rootDir, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
-    ).trim();
+    ).trimEnd();
 
     if (path.resolve(gitRoot) !== path.resolve(rootDir)) {
       try {
@@ -290,7 +301,7 @@ function getGitChangedFiles(rootDir: string): GitChanges | null {
   try {
     const output = execFileSync(
       'git',
-      ['status', '--porcelain', '--no-renames'],
+      [...GIT_PATH_OUTPUT_ARGS, 'status', '--porcelain', '--no-renames'],
       { cwd: rootDir, encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
     );
 
@@ -298,7 +309,7 @@ function getGitChangedFiles(rootDir: string): GitChanges | null {
     const added: string[] = [];
     const deleted: string[] = [];
 
-    for (const line of output.split('\n')) {
+    for (const line of gitPathLines(output)) {
       if (line.length < 4) continue; // Minimum: "XY file"
 
       const statusCode = line.substring(0, 2);
@@ -462,6 +473,10 @@ function scanDirectoryWalk(
 
       if (entry.isSymbolicLink()) {
         try {
+          if (!validatePathWithinRoot(rootDir, relativePath)) {
+            logDebug('Skipping symlink outside root', { path: fullPath });
+            continue;
+          }
           const realTarget = fs.realpathSync(fullPath);
           const stat = fs.statSync(realTarget);
           if (stat.isDirectory()) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,9 +46,29 @@ const SENSITIVE_PATHS = new Set([
   'c:\\', 'c:\\windows', 'c:\\windows\\system32',
 ]);
 
+function isResolvedPathWithinRoot(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function nearestExistingPath(absPath: string): string | null {
+  let current = absPath;
+
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+
+  return current;
+}
+
 /**
  * Validate that a resolved file path stays within the project root.
  * Prevents path traversal attacks (e.g. node.filePath = "../../etc/passwd").
+ * Also resolves existing files and parent directories to catch symlink escapes.
  *
  * @param projectRoot - The project root directory
  * @param filePath - The relative file path to validate
@@ -58,9 +78,35 @@ export function validatePathWithinRoot(projectRoot: string, filePath: string): s
   const resolved = path.resolve(projectRoot, filePath);
   const normalizedRoot = path.resolve(projectRoot);
 
-  if (!resolved.startsWith(normalizedRoot + path.sep) && resolved !== normalizedRoot) {
+  if (!isResolvedPathWithinRoot(normalizedRoot, resolved)) {
     return null;
   }
+
+  try {
+    const realRoot = fs.realpathSync(normalizedRoot);
+    const realPath = fs.realpathSync(resolved);
+    if (!isResolvedPathWithinRoot(realRoot, realPath)) {
+      return null;
+    }
+    return resolved;
+  } catch {
+    // If the target does not exist, still validate the nearest existing parent
+    // so writes/reads under a symlinked directory cannot escape the root.
+    try {
+      const realRoot = fs.realpathSync(normalizedRoot);
+      const existingPath = nearestExistingPath(resolved);
+      if (existingPath) {
+        const realExistingPath = fs.realpathSync(existingPath);
+        if (!isResolvedPathWithinRoot(realRoot, realExistingPath)) {
+          return null;
+        }
+      }
+    } catch {
+      // Preserve the historical behavior for inaccessible/nonexistent roots
+      // after the lexical containment check above.
+    }
+  }
+
   return resolved;
 }
 
@@ -119,7 +165,7 @@ export function validateProjectPath(dirPath: string): string | null {
 export function isPathWithinRoot(filePath: string, rootDir: string): boolean {
   const resolvedPath = path.resolve(rootDir, filePath);
   const resolvedRoot = path.resolve(rootDir);
-  return resolvedPath.startsWith(resolvedRoot + path.sep) || resolvedPath === resolvedRoot;
+  return isResolvedPathWithinRoot(resolvedRoot, resolvedPath);
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes the macOS/path-related issue reports by hardening path handling and documenting the local development trap around FTS5:

- Disable Git path quoting for path-emitting commands so tracked and changed files under non-ASCII/CJK directories are parsed as UTF-8 paths.
- Preserve path bytes except the final record separator, so valid path names with spaces are not accidentally trimmed while parsing Git output.
- Add realpath containment checks to `validatePathWithinRoot` so symlinked files and symlinked parent directories cannot escape the project root.
- Skip symlink targets that resolve outside the root during filesystem scanning before they can be queued for indexing.
- Add README contributor setup docs, including `npm link`, focused test commands, and the macOS Node/FTS5 source-build workaround.

## Issue Mapping

- Fixes #541: Git-visible files under non-ASCII/CJK directories are indexed and detected as changed.
- Fixes #527: symlink escapes through files or parent directories are blocked before reads/indexing.
- Fixes #305: README now documents local contributor setup and the macOS FTS5 workaround.

## Root Cause

Git quotes non-ASCII path bytes by default (`core.quotePath=true`), returning quoted octal escapes for CJK path segments. CodeGraph parsed that output as normal UTF-8 file paths, so extension checks could silently reject otherwise supported source files.

Path containment also relied on lexical `path.resolve` checks. A path like `src/secret.ts` could pass because it was textually inside the project, even if `src/secret.ts` was a symlink to a file outside the root. The fix keeps the lexical check, then verifies existing targets and nearest existing parents with `realpath` so both direct symlink files and symlinked directories are rejected.

For contributors, the README only covered end-user installation. That left macOS source builds with no guidance for the `node:sqlite` / FTS5 mismatch that can appear on some local Node builds.

## Validation

- `npx -y -p node@22 node ./node_modules/vitest/vitest.mjs run __tests__/extraction.test.ts __tests__/security.test.ts`
  - 2 files passed, 317 passed, 2 skipped
- `npm run build`
- `git diff --check`

## Notes

This PR is split from the Claude installer/MCP guidance fixes so the path/security changes can be reviewed independently.
