### PR TITLE
chore(release): bump version to 0.9.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@colbymchenry/codegraph",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@colbymchenry/codegraph",
-      "version": "0.9.7",
+      "version": "0.9.8",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colbymchenry/codegraph",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Supercharge Claude Code with semantic code intelligence. 94% fewer tool calls • 77% faster exploration • 100% local.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps `package.json` + `package-lock.json` to **0.9.8** so the Release workflow can be run.

0.9.8 ships the restored embedded/programmatic SDK API (#354) plus the rest of the `[Unreleased]` changelog. CHANGELOG promotion (`[Unreleased]` → `[0.9.8]`) and the link reference are handled automatically by `prepare-release.mjs` at release time, so no CHANGELOG edits here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)