### PR TITLE
fix: filter non-source files in watcher to prevent FD exhaustion

### DIFF
--- a/__tests__/watcher.test.ts
+++ b/__tests__/watcher.test.ts
@@ -436,4 +436,154 @@ describe('FileWatcher', () => {
       cg.unwatch();
     });
   });
+
+  describe('shouldIgnore source-file filter (FD exhaustion fix)', () => {
+    it('should ignore non-source files when stats are provided', async () => {
+      const syncFn = vi.fn().mockResolvedValue({ filesChanged: 0, durationMs: 0 });
+      const watcher = new FileWatcher(testDir, syncFn);
+      watcher.start();
+      await watcher.waitUntilReady();
+
+      // Non-source file with file stats → ignored (no fs.watch FD created)
+      const result = (watcher as any).shouldIgnore(
+        path.join(testDir, 'readme.md'),
+        { isDirectory: () => false } as any,
+      );
+      expect(result).toBe(true);
+
+      watcher.stop();
+    });
+
+    it('should not ignore source files when stats are provided', async () => {
+      const syncFn = vi.fn().mockResolvedValue({ filesChanged: 0, durationMs: 0 });
+      const watcher = new FileWatcher(testDir, syncFn);
+      watcher.start();
+      await watcher.waitUntilReady();
+
+      const result = (watcher as any).shouldIgnore(
+        path.join(testDir, 'src', 'index.ts'),
+        { isDirectory: () => false } as any,
+      );
+      expect(result).toBe(false);
+
+      watcher.stop();
+    });
+
+    it('should not ignore directories so chokidar can recurse', async () => {
+      const syncFn = vi.fn().mockResolvedValue({ filesChanged: 0, durationMs: 0 });
+      const watcher = new FileWatcher(testDir, syncFn);
+      watcher.start();
+      await watcher.waitUntilReady();
+
+      const result = (watcher as any).shouldIgnore(
+        path.join(testDir, 'src'),
+        { isDirectory: () => true } as any,
+      );
+      expect(result).toBe(false);
+
+      watcher.stop();
+    });
+
+    it('should not filter by extension when stats are undefined (fallback path)', async () => {
+      const syncFn = vi.fn().mockResolvedValue({ filesChanged: 0, durationMs: 0 });
+      const watcher = new FileWatcher(testDir, syncFn);
+      watcher.start();
+      await watcher.waitUntilReady();
+
+      // Without stats, the extension filter is skipped — only ignoreMatcher applies.
+      // 'somefile.md' is not in DEFAULT_IGNORE_DIRS, so it passes through.
+      const result = (watcher as any).shouldIgnore(
+        path.join(testDir, 'somefile.md'),
+        undefined,
+      );
+      expect(result).toBe(false);
+
+      watcher.stop();
+    });
+
+    it('should not ignore non-source files when CODEGRAPH_WATCH_ALL_FILES=1', async () => {
+      const orig = process.env.CODEGRAPH_WATCH_ALL_FILES;
+      process.env.CODEGRAPH_WATCH_ALL_FILES = '1';
+
+      try {
+        const syncFn = vi.fn().mockResolvedValue({ filesChanged: 0, durationMs: 0 });
+        const watcher = new FileWatcher(testDir, syncFn);
+        watcher.start();
+        await watcher.waitUntilReady();
+
+        const result = (watcher as any).shouldIgnore(
+          path.join(testDir, 'readme.md'),
+          { isDirectory: () => false } as any,
+        );
+        expect(result).toBe(false);
+
+        watcher.stop();
+      } finally {
+        if (orig === undefined) {
+          delete process.env.CODEGRAPH_WATCH_ALL_FILES;
+        } else {
+          process.env.CODEGRAPH_WATCH_ALL_FILES = orig;
+        }
+      }
+    });
+
+    it('should exclude new DEFAULT_IGNORE_DIRS entries (.npm, .bun, .rustup)', async () => {
+      const syncFn = vi.fn().mockResolvedValue({ filesChanged: 0, durationMs: 0 });
+      const watcher = new FileWatcher(testDir, syncFn);
+      watcher.start();
+      await watcher.waitUntilReady();
+
+      for (const dir of ['.npm', '.bun', '.rustup', '.gem', '.Trash', '.matplotlib']) {
+        const result = (watcher as any).shouldIgnore(
+          path.join(testDir, dir, 'somefile'),
+          { isDirectory: () => false } as any,
+        );
+        expect(result).toBe(true);
+      }
+
+      watcher.stop();
+    });
+  });
+
+  describe('home directory warning', () => {
+    it('should log a warning when projectRoot is the home directory', async () => {
+      // Spy on logWarn — it's imported into watcher.ts, so we mock the module.
+      const { logWarn } = await import('../src/errors');
+      const warnSpy = vi.spyOn({ logWarn }, 'logWarn');
+
+      // We can't easily re-import the module, so we verify the behavior
+      // indirectly: creating a watcher with os.homedir() as root should
+      // not throw, and the warning is emitted inside start().
+      // Since logWarn is a direct import in watcher.ts, spy on the errors module.
+      const errorsModule = await import('../src/errors');
+      const spy = vi.spyOn(errorsModule, 'logWarn');
+
+      const syncFn = vi.fn().mockResolvedValue({ filesChanged: 0, durationMs: 0 });
+      const watcher = new FileWatcher(os.homedir(), syncFn);
+      watcher.start();
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining('home directory'),
+      );
+
+      spy.mockRestore();
+      watcher.stop();
+    });
+
+    it('should not log a warning when projectRoot is not the home directory', async () => {
+      const errorsModule = await import('../src/errors');
+      const spy = vi.spyOn(errorsModule, 'logWarn');
+
+      const syncFn = vi.fn().mockResolvedValue({ filesChanged: 0, durationMs: 0 });
+      const watcher = new FileWatcher(testDir, syncFn);
+      watcher.start();
+
+      expect(spy).not.toHaveBeenCalledWith(
+        expect.stringContaining('home directory'),
+      );
+
+      spy.mockRestore();
+      watcher.stop();
+    });
+  });
 });

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -149,6 +149,14 @@ const DEFAULT_IGNORE_DIRS: ReadonlySet<string> = new Set([
   '__history', '__recovery',
   // Generic cache
   '.cache',
+  // Package manager / toolchain caches (no source code, often enormous
+  // when the project root is a home directory)
+  '.npm',            // npm cache
+  '.bun',            // Bun package cache
+  '.rustup',         // Rust toolchain (~50K files)
+  '.gem',            // Ruby gems
+  '.Trash',          // macOS Trash
+  '.matplotlib',     // matplotlib font/cache
 ]);
 
 /** Gitignore-style patterns for the `ignore` matcher: the dirs above plus a few globs. */

--- a/src/sync/watcher.ts
+++ b/src/sync/watcher.ts
@@ -15,6 +15,7 @@
  */
 
 import * as path from 'path';
+import * as os from 'os';
 import type { Stats } from 'fs';
 import chokidar, { FSWatcher } from 'chokidar';
 import type { Ignore } from 'ignore';
@@ -112,6 +113,7 @@ export class FileWatcher {
   private syncStartedMs = 0;
   private syncing = false;
   private stopped = false;
+  private watchAllFiles = false;
   /**
    * False until chokidar fires its `ready` event. Gates `pendingFiles`
    * insertion so the initial crawl's `add` events (one per pre-existing
@@ -171,6 +173,12 @@ export class FileWatcher {
     // chokidar only registers an inotify watch on directories that pass this
     // filter — that's the #276 fix.
     this.ignoreMatcher = buildDefaultIgnore(this.projectRoot);
+    this.watchAllFiles = process.env.CODEGRAPH_WATCH_ALL_FILES === '1';
+    const homeDir = normalizePath(os.homedir());
+    if (normalizePath(this.projectRoot) === homeDir) {
+      logWarn('Watching entire home directory — this may exhaust file descriptors. ' +
+        'Consider using --path to scope to a specific project.');
+    }
 
     try {
       this.watcher = chokidar.watch(this.projectRoot, {
@@ -259,7 +267,12 @@ export class FileWatcher {
     if (this.isAlwaysIgnored(rel)) return true;
     if (!this.ignoreMatcher) return false;
     if (stats) {
-      return this.ignoreMatcher.ignores(stats.isDirectory() ? rel + '/' : rel);
+      if (this.ignoreMatcher.ignores(stats.isDirectory() ? rel + '/' : rel)) return true;
+      // Skip non-source files to avoid unnecessary fs.watch() FDs (fixes FD
+      // exhaustion when the project root contains many non-source files — e.g.
+      // home directory). Directories must pass through so chokidar can recurse.
+      // Set CODEGRAPH_WATCH_ALL_FILES=1 to disable this filter (escape hatch).
+      if (!stats.isDirectory() && !this.watchAllFiles && !isSourceFile(testPath)) return true;
     }
     // Stats unknown: test both forms so a directory match isn't missed.
     return this.ignoreMatcher.ignores(rel) || this.ignoreMatcher.ignores(rel + '/');


### PR DESCRIPTION
chokidar 4.x creates one fs.watch() FD per path that passes the \`ignored\` callback. The current \`shouldIgnore\` only checks gitignore-style patterns — non-source files like .md/.json/.yaml all pass through and get watched, consuming FDs.

When the project root is a home directory (global CodeGraph config without --path), this creates ~180K FDs and exhausts kern.maxfiles (observed: PID hitting 61,429 FDs on macOS).

## Changes

- Add \`isSourceFile()\` check in \`shouldIgnore\` for non-directory paths with stats, skipping fs.watch() on non-source files
- Cache \`CODEGRAPH_WATCH_ALL_FILES\` env var as instance field to avoid per-call \`process.env\` reads
- Add home directory detection with warning log
- Extend \`DEFAULT_IGNORE_DIRS\` with .npm, .bun, .rustup, .gem, .Trash, .matplotlib (large toolchain caches with no source code)
- Add 8 tests covering the filter, escape hatch, and new directories

## Edge case

When \`stats\` is \`undefined\` (chokidar doesn't provide it during certain phases of initial scan), the extension filter is skipped — only ignoreMatcher applies. This is correct behavior: without stats we can't distinguish file vs directory, so we conservatively let it through. chokidar will re-call with stats later.

## Escape hatch

Set \`CODEGRAPH_WATCH_ALL_FILES=1\` to disable source-file filtering and restore previous behavior.