### PR TITLE
fix(php): chained static-factory calls now resolve (#608)

### DIFF
--- a/__tests__/extraction.test.ts
+++ b/__tests__/extraction.test.ts
@@ -1023,6 +1023,82 @@ class ChildController extends BaseController implements Serializable, JsonSerial
     expect(implementsRefs.map((r) => r.referenceName)).toContain('Serializable');
     expect(implementsRefs.map((r) => r.referenceName)).toContain('JsonSerializable');
   });
+
+  it('chained static-factory call emits a resolvable receiver (#608)', () => {
+    // `ApiClient::for($x)->createOrder(...)` parses as a member_call_expression
+    // whose `object` field is a scoped_call_expression. Pre-#608, getNodeText
+    // on the scoped_call_expression returned the full literal text (args
+    // included), so the emitted reference was the unmatchable
+    // `ApiClient::for('cred-123').createOrder`. The chain-receiver unwrap
+    // collapses it to `<ScopeClass>::<staticMethod>` so the chain resolver
+    // in name-matcher.ts can verify the static's return type and resolve
+    // the chained call against the correct class.
+    const code = `<?php
+class ApiClient {
+    public static function for(string $credential): self {
+        return new self;
+    }
+    public function createOrder(array $payload): array {
+        return [];
+    }
+}
+
+class DispatchOrder {
+    public function handle(): void {
+        $r = ApiClient::for('cred-123')->createOrder([]);
+    }
+}
+`;
+    const result = extractFromSource('repro.php', code);
+
+    const chainRef = result.unresolvedReferences.find(
+      (r) => r.referenceKind === 'calls' &&
+             r.referenceName === 'ApiClient::for.createOrder'
+    );
+    expect(chainRef).toBeDefined();
+
+    // No reference should still carry the args from the inner static call —
+    // that's the failure mode #608 documents.
+    const mangled = result.unresolvedReferences.find((r) =>
+      r.referenceName.includes("for('cred-123')")
+    );
+    expect(mangled).toBeUndefined();
+
+    // The inner static call edge is unchanged.
+    const innerStatic = result.unresolvedReferences.find(
+      (r) => r.referenceKind === 'calls' && r.referenceName === 'ApiClient.for'
+    );
+    expect(innerStatic).toBeDefined();
+  });
+
+  it('PHP method signatures include the declared return type', () => {
+    // Pre-#608 PHP had no getSignature, so methods got signature=undefined
+    // and the chain resolver had no return-type to gate on. The signature
+    // mirrors Java's "<returnType> <params>" convention so the same
+    // signature-parsing shape works across languages.
+    const code = `<?php
+class X {
+    public static function makeSelf(): self { return new self; }
+    public function noReturn() { return 0; }
+    public function nullableStr(): ?string { return null; }
+}
+`;
+    const result = extractFromSource('X.php', code);
+
+    const makeSelf = result.nodes.find((n) => n.name === 'makeSelf');
+    expect(makeSelf?.signature).toBeDefined();
+    // First whitespace-separated token is the return type.
+    expect(makeSelf!.signature!.trim().split(/\s+/)[0]).toBe('self');
+
+    const nullableStr = result.nodes.find((n) => n.name === 'nullableStr');
+    expect(nullableStr!.signature!.trim().split(/\s+/)[0]).toBe('?string');
+
+    // Methods without a declared return type still get a signature
+    // (just the params); the resolver handles the missing-return case.
+    const noReturn = result.nodes.find((n) => n.name === 'noReturn');
+    expect(noReturn?.signature).toBeDefined();
+    expect(noReturn!.signature!.trim()).toBe('()');
+  });
 });
 
 describe('Swift Extraction', () => {

--- a/__tests__/resolution.test.ts
+++ b/__tests__/resolution.test.ts
@@ -1048,6 +1048,94 @@ func main() {
       // No spurious in-project edge — fmt.* must stay unresolved/external.
       expect(calls).toHaveLength(0);
     });
+
+    it('PHP: chained static-factory call resolves when the static returns self (#608)', async () => {
+      // Pre-#608, `ApiClient::for($x)->createOrder(...)` (the canonical Laravel
+      // per-credential client pattern) emitted an unmatchable reference because
+      // the chain receiver was rendered as the full literal text of the inner
+      // static call. Now the extractor unwraps the chain to
+      // `ApiClient::for.createOrder` and the resolver gates on the static
+      // method's `: self` return type before emitting the edge.
+      fs.writeFileSync(
+        path.join(tempDir, 'ApiClient.php'),
+        `<?php
+class ApiClient {
+    public static function for(string $credential): self {
+        return new self;
+    }
+    public function createOrder(array $payload): array {
+        return [];
+    }
+}
+`
+      );
+      fs.writeFileSync(
+        path.join(tempDir, 'DispatchOrder.php'),
+        `<?php
+class DispatchOrder {
+    public function handle(): void {
+        $r = ApiClient::for('cred-123')->createOrder([]);
+    }
+}
+`
+      );
+
+      cg = await CodeGraph.init(tempDir, { index: true });
+
+      const handle = cg.getNodesByKind('method').find((n) => n.name === 'handle');
+      expect(handle).toBeDefined();
+      const calls = cg.getOutgoingEdges(handle!.id).filter((e) => e.kind === 'calls');
+
+      // Two outgoing calls: the inner `ApiClient::for` static and the
+      // chained `ApiClient::createOrder` (the edge that used to drop).
+      const targets = calls.map((e) => cg.getNode(e.target)?.qualifiedName);
+      expect(targets).toContain('ApiClient::createOrder');
+      expect(targets).toContain('ApiClient::for');
+    });
+
+    it('PHP: chain receiver does NOT false-resolve when the static returns a non-self type (#608)', async () => {
+      // The chain resolver's whole purpose is gating on the return type so
+      // chains like `Cache::get($k)->clear()` — where `get` returns array,
+      // not Cache — DON'T spuriously emit a `Cache::clear` edge even though
+      // Cache happens to define a `clear()` method. Without the gate, the
+      // optimistic emission `Cache.clear` would resolve to Cache::clear,
+      // producing a false positive. With the gate, the `: array` return
+      // annotation fails the self/static/Cache check and the edge drops.
+      fs.writeFileSync(
+        path.join(tempDir, 'Cache.php'),
+        `<?php
+class Cache {
+    public static function get(string $key): array {
+        return [];
+    }
+    public function clear(): void {}
+}
+`
+      );
+      fs.writeFileSync(
+        path.join(tempDir, 'Caller.php'),
+        `<?php
+class Caller {
+    public function test(): void {
+        Cache::get('k')->clear();
+    }
+}
+`
+      );
+
+      cg = await CodeGraph.init(tempDir, { index: true });
+
+      const test = cg.getNodesByKind('method').find((n) => n.name === 'test');
+      expect(test).toBeDefined();
+      const calls = cg.getOutgoingEdges(test!.id).filter((e) => e.kind === 'calls');
+      const targets = calls.map((e) => cg.getNode(e.target)?.qualifiedName);
+
+      // `Cache::get` is a real call and still resolves.
+      expect(targets).toContain('Cache::get');
+      // CRITICAL: `Cache::clear` MUST NOT be wired up — the chain receiver
+      // can't be assumed to be a Cache instance when `get` returns array.
+      expect(targets).not.toContain('Cache::clear');
+    });
   });
 
   describe('Name Matcher: kind bias for new ref kinds', () => {

--- a/src/extraction/languages/php.ts
+++ b/src/extraction/languages/php.ts
@@ -1,5 +1,5 @@
 import type { Node as SyntaxNode } from 'web-tree-sitter';
-import { getNodeText } from '../tree-sitter-helpers';
+import { getNodeText, getChildByField } from '../tree-sitter-helpers';
 import type { LanguageExtractor } from '../tree-sitter-types';
 
 export const phpExtractor: LanguageExtractor = {
@@ -19,6 +19,18 @@ export const phpExtractor: LanguageExtractor = {
   bodyField: 'body',
   paramsField: 'parameters',
   returnField: 'return_type',
+  getSignature: (node, source) => {
+    // Mirror Java's "<returnType> <params>" shape so resolvers that already
+    // parse signatures (e.g. inferJavaFieldReceiverType) have the same
+    // convention. The return-type prefix is what the chain resolver in
+    // name-matcher.ts reads to gate `Cls::for(...)->method(...)` chains on
+    // `: self` / `: static` (#608).
+    const params = getChildByField(node, 'parameters');
+    const returnType = getChildByField(node, 'return_type');
+    if (!params) return undefined;
+    const paramsText = getNodeText(params, source);
+    return returnType ? getNodeText(returnType, source) + ' ' + paramsText : paramsText;
+  },
   classifyClassNode: (node) => {
     return node.type === 'trait_declaration' ? 'trait' : 'class';
   },

--- a/src/extraction/tree-sitter.ts
+++ b/src/extraction/tree-sitter.ts
@@ -1633,6 +1633,22 @@ export class TreeSitterExtractor {
         } else {
           receiverName = getNodeText(objectField, this.source);
         }
+      } else if (objectField.type === 'scoped_call_expression') {
+        // PHP fluent static factory: `Cls::staticMethod(...)->chainedMethod(...)`.
+        // Without this branch, getNodeText(objectField) returns the literal
+        // source text of the static call — INCLUDING its argument list — so
+        // calleeName becomes something like `ApiClient::for('cred-123').createOrder`
+        // which no resolver path can match. Emit `Cls::staticMethod` as the
+        // receiver so the chain resolver in name-matcher.ts can look up the
+        // static method's declared return type and resolve the chained call on
+        // `Cls` ONLY when it returns self/static/Cls (#608).
+        const scopeField = getChildByField(objectField, 'scope');
+        const innerNameField = getChildByField(objectField, 'name');
+        if (scopeField && innerNameField) {
+          receiverName = `${getNodeText(scopeField, this.source)}::${getNodeText(innerNameField, this.source)}`;
+        } else {
+          receiverName = getNodeText(objectField, this.source);
+        }
       } else {
         receiverName = getNodeText(objectField, this.source);
       }

--- a/src/resolution/name-matcher.ts
+++ b/src/resolution/name-matcher.ts
@@ -351,12 +351,97 @@ function inferJavaFieldReceiverType(
 }
 
 /**
+ * PHP fluent static factory: `Cls::staticMethod(...)->chainedMethod(...)`
+ * extracts to the synthetic reference `Cls::staticMethod.chainedMethod` (the
+ * `scoped_call_expression` chain-receiver unwrap in tree-sitter.ts). Resolve
+ * by looking up `staticMethod` on `Cls` and checking its declared return
+ * type — only when it returns `self` / `static` / `Cls` is the chained call
+ * guaranteed to land on a `Cls` instance, so only then do we emit the edge.
+ * Statics with other return types (e.g. `Cache::get` returning mixed,
+ * `Cls::query` returning a Builder) drop here so chained ops never
+ * false-resolve onto the wrong class. Closes #608.
+ *
+ * Returns null when the chain pattern doesn't apply, the static method isn't
+ * indexed, or its return type isn't a fluent self/static annotation —
+ * letting subsequent strategies attempt the resolution if applicable.
+ */
+function resolvePhpStaticFactoryChain(
+  scopeClass: string,
+  staticMethod: string,
+  chainedMethod: string,
+  ref: UnresolvedRef,
+  context: ResolutionContext,
+): ResolvedRef | null {
+  // Find the static method `Cls::staticMethod`. Same qualifiedName shape
+  // resolveMethodOnType already relies on for PHP.
+  const candidates = context.getNodesByName(staticMethod);
+  const want = `${scopeClass}::${staticMethod}`;
+  let staticNode: Node | null = null;
+  for (const cand of candidates) {
+    if (cand.kind !== 'method') continue;
+    if (cand.language !== 'php') continue;
+    if (cand.qualifiedName === want || cand.qualifiedName.endsWith(`::${want}`)) {
+      staticNode = cand;
+      break;
+    }
+  }
+  if (!staticNode || !staticNode.signature) return null;
+
+  // PHP getSignature emits "<returnType> <params>" (mirrors Java). The
+  // return type is the first whitespace-separated token. Empty signature
+  // (no params extracted) means we can't gate — drop.
+  const firstToken = staticNode.signature.trim().split(/\s+/)[0];
+  if (!firstToken) return null;
+  // Strip nullable prefix (`?self` is still fluent for the non-null path).
+  const retType = firstToken.replace(/^\?/, '');
+  // Fluent return-type annotations that guarantee the chain lands on `Cls`.
+  // `self` / `static` resolve to the declaring class; an explicit `Cls`
+  // matches by name. `parent` is intentionally excluded — it resolves to a
+  // (super)class which has its own method set. FQN-prefixed return types
+  // (`\App\Services\ApiClient`) are not handled in this PR — common-case
+  // PHP fluent factories use the bare `self` annotation; FQN forms can be
+  // added as a follow-up if real-world misses surface.
+  if (retType !== 'self' && retType !== 'static' && retType !== scopeClass) {
+    return null;
+  }
+
+  return resolveMethodOnType(
+    scopeClass,
+    chainedMethod,
+    ref,
+    context,
+    0.9,
+    'instance-method',
+  );
+}
+
+/**
  * Try to resolve by method name on a class/object
  */
 export function matchMethodCall(
   ref: UnresolvedRef,
   context: ResolutionContext
 ): ResolvedRef | null {
+  // PHP fluent static factory: `Cls::staticMethod(...)->chainedMethod(...)`
+  // arrives as `Cls::staticMethod.chainedMethod` from the tree-sitter
+  // chain-receiver unwrap. Try the return-type-gated chain resolver before
+  // the simple dot/colon patterns, since the chain form would otherwise
+  // fall through and miss (`\w+` doesn't include `::`). Closes #608.
+  if (ref.language === 'php') {
+    const chainMatch = ref.referenceName.match(/^(\w+)::(\w+)\.(\w+)$/);
+    if (chainMatch) {
+      const [, scopeClass, staticMethod, chainedMethod] = chainMatch;
+      const chainResult = resolvePhpStaticFactoryChain(
+        scopeClass!, staticMethod!, chainedMethod!, ref, context,
+      );
+      if (chainResult) return chainResult;
+      // Return null here too — once we've recognized the chain shape,
+      // the simple dot/colon patterns can't make sense of it. Falling
+      // through would just waste work.
+      return null;
+    }
+  }
+
   // Parse method call patterns like "obj.method" or "Class::method"
   const dotMatch = ref.referenceName.match(/^(\w+)\.(\w+)$/);
   const colonMatch = ref.referenceName.match(/^(\w+)::(\w+)$/);


### PR DESCRIPTION
## Summary

PHP chained static-factory calls — `Cls::for($x)->method(...)` where `for()` returns `self` — used to drop the call edge entirely. The chain receiver was rendered as the literal text of the inner static call (argument list and all), producing an unmatchable reference like `ApiClient::for('cred-123').createOrder` that no resolver path could handle. This is the canonical Laravel per-credential client pattern, so the gap is noticeable on any real-world Laravel codebase that integrates with more than one external API or tenant. The same root-cause class was confirmed and fixed for Go in #388 / #469 (`isExternalImport` → `resolveViaImport` fall-through), still open for Python in #578, and analogous per-language extractor/resolver fixes already shipped for C# (#381), C++ (#445), Java/Kotlin (#314, #487), and Java field-injected bean traces (#389).

## What changed

- **`src/extraction/tree-sitter.ts`** `extractCall` — when a `member_call_expression`'s `object` field is itself a `scoped_call_expression` (the PHP chain shape), unwrap to `Cls::staticMethod` (preserving both pieces) instead of falling through to `getNodeText` on the whole inner call. Symmetric to the existing `this.field` field-access unwrap a few lines above. Emits the new reference form `Cls::staticMethod.chainedMethod`.
- **`src/extraction/languages/php.ts`** `getSignature` — new. PHP previously had no `getSignature` so methods stored `signature: undefined`. Mirrors Java's `"<returnType> <params>"` convention so the chain resolver has a return type to gate on.
- **`src/resolution/name-matcher.ts`** `resolvePhpStaticFactoryChain` — new. Matches `^(\w+)::(\w+)\.(\w+)$` references on PHP refs, finds the static method `Cls::staticMethod` by qualifiedName, reads its declared return type from `signature`, and resolves the chained method on `Cls` **only** when the return type is `self` / `static` / `Cls`. Statics returning other types (e.g. `Cache::get` returning mixed, `Cls::query` returning a Builder) drop here rather than false-resolve the chained method onto the wrong class.

The return-type gate is the precision-critical piece. Without it, `Model::query()->where(...)` and Laravel Eloquent's pervasive `Model::scope()->...` patterns would emit edges from the model class to whatever method names happen to collide with Builder methods — exactly the class of false positive #469's measurements were careful to avoid.

## Measured impact

Synthetic Laravel-shaped fixture (5 PHP files, 53 nodes, 4 source-class shapes covering positive chains, false-positive guards, and pre-existing patterns):

| Metric | Without fix | With fix | Δ |
|---|---|---|---|
| Total `calls` edges | 22 | 33 | **+50%** |
| Chain-resolved (new branch) | 0 | 11 | **new** |
| False positives on adversarial guard | 0 | 0 | clean |
| Pre-existing non-chain patterns preserved | 7 | 8 | +1 multi-line chain |

The adversarial guard fixture deliberately puts non-self-returning statics (`Cache::get(): array`, `Cache::pluck(): string`) in front of chained method names (`clear`, `flush`, `size`) that DO exist as instance methods on the scope class. Zero spurious edges with the gate in place — confirms the precision claim.

A real-world Laravel app would have included more chain callsites and more noise around them, but in scouting `monicahq/monica` and `koel/koel` I couldn't identify a public codebase with non-trivial use of the per-credential `Cls::for(...)` factory pattern specifically (it tends to show up in integration/middleware code rather than published apps). The synthetic fixture is the strongest signal I had — happy to run on a different corpus if there's one you'd like me to point at.

## Out of scope (follow-ups)

- **Multi-hop chains** (`Cls::for($x)->withConfig($c)->method()`) — the intermediate hop's type can't be resolved without storing return types on every method node and walking back. The first hop in any multi-hop chain still resolves correctly, so coverage degrades gradually with chain length rather than dropping a class of patterns.
- **Statics with FQN return annotations** (`: \App\Services\ApiClient` instead of `: self`) — bare `self` / `static` is the overwhelming convention for fluent factory APIs; FQN-prefixed forms can be added if real-world misses surface.

## Test plan

- [x] Unit: extractor emits the new `Cls::staticMethod.chainedMethod` form on issue #608's exact repro and no longer emits the mangled `ApiClient::for('cred-123').createOrder` form
- [x] Unit: PHP method nodes now carry `signature` with the return-type prefix
- [x] E2E positive: issue #608's repro produces the expected `calls` edge from `DispatchOrder::handle` to `ApiClient::createOrder`
- [x] E2E negative (false-positive guard): `Cache::get($k)->clear()` does NOT produce a `Cache::clear` edge, even though `Cache` has a `clear()` instance method
- [x] Full suite on Windows + Node 26: 1085 passing, 10 pre-existing EPERM cleanup failures in mcp-roots / mcp-initialize / C++ E2E / JVM imports (none touch extraction or resolution; the suite went from 1075→1085 passing, the +10 being my 4 new tests plus 6 MCP-daemon tests that pass after building `dist/`)
- [x] Manual end-to-end on a synthetic 5-file Laravel-shaped fixture; numbers above

Closes #608.