### PR TITLE
Fixes colbymchenry/codegraph#565

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixes
+
+- Claude Code auto-allow setup now includes `codegraph_files`, matching the documented manual configuration so the indexed file-structure tool is ready after install. (#565)
 
 ## [0.9.8] - 2026-06-01
 

--- a/__tests__/installer-targets.test.ts
+++ b/__tests__/installer-targets.test.ts
@@ -910,6 +910,16 @@ describe('Installer targets — partial-state idempotency', () => {
     expect(cfg.mcpServers.codegraph).toBeDefined();
   });
 
+  it('claude: auto-allow includes the indexed file structure tool (#565)', () => {
+    const claude = getTarget('claude')!;
+    claude.install('global', { autoAllow: true });
+
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, '.claude', 'settings.json'), 'utf-8'),
+    );
+    expect(settings.permissions.allow).toContain('mcp__codegraph__codegraph_files');
+  });
+
   it('claude: local install migrates a legacy ./.claude.json codegraph entry into ./.mcp.json', () => {
     const claude = getTarget('claude')!;
     const legacy = path.join(tmpCwd, '.claude.json');

--- a/src/installer/targets/shared.ts
+++ b/src/installer/targets/shared.ts
@@ -38,6 +38,7 @@ export function getCodeGraphPermissions(): string[] {
     'mcp__codegraph__codegraph_impact',
     'mcp__codegraph__codegraph_node',
     'mcp__codegraph__codegraph_status',
+    'mcp__codegraph__codegraph_files',
   ];
 }
 


### PR DESCRIPTION
## Summary

- Add `codegraph_files` to Claude Code installer auto-allow permissions.
- Add a regression test covering the generated Claude settings allowlist.
- Add an Unreleased changelog entry.

Fixes colbymchenry/codegraph#565

## Tests

- `npm run build`
- `npm test`