### PR TITLE
fix: document setup order and handle mcp discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,15 @@ npx @colbymchenry/codegraph        # zero-install, or:
 npm i -g @colbymchenry/codegraph
 ```
 
-<sub>CodeGraph bundles its own runtime — nothing to compile, no native build, works the same everywhere. The interactive installer auto-configures your agent(s) — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro.</sub>
+<sub>CodeGraph bundles its own runtime — nothing to compile, no native build, works the same everywhere.</sub>
+
+### Wire Up Your Agent
+
+```bash
+codegraph install
+```
+
+<sub>The interactive installer writes the MCP server config for your agent(s) — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro. If you are using the zero-install npm flow, run `npx @colbymchenry/codegraph` for the same setup. Restart your agent afterwards so it loads the new MCP server.</sub>
 
 ### Initialize Projects
 
@@ -55,7 +63,7 @@ cd your-project
 codegraph init -i
 ```
 
-<sub>`codegraph init` just creates the local `.codegraph/` index directory; adding `-i` (`--index`) also builds the initial graph in the same step. Without `-i`, run `codegraph index` afterwards to populate it.</sub>
+<sub>`codegraph init` just creates the local `.codegraph/` index directory; adding `-i` (`--index`) also builds the initial graph in the same step. It does not install CodeGraph into your agent by itself. Without `-i`, run `codegraph index` afterwards to populate it.</sub>
 
 <div align="center">
 

--- a/__tests__/mcp-initialize.test.ts
+++ b/__tests__/mcp-initialize.test.ts
@@ -49,6 +49,10 @@ function sendInitialize(child: ChildProcessWithoutNullStreams, projectPath: stri
   child.stdin.write(msg + '\n');
 }
 
+function sendMessage(child: ChildProcessWithoutNullStreams, message: Record<string, unknown>) {
+  child.stdin.write(JSON.stringify({ jsonrpc: '2.0', ...message }) + '\n');
+}
+
 /**
  * Collect stdout lines and stderr text from the child, tagging each piece
  * with a monotonic sequence number. Lets us assert ordering between the
@@ -125,6 +129,30 @@ describe('MCP initialize handshake (issue #172)', () => {
     expect(json.id).toBe(0);
     expect(json.result.protocolVersion).toBeDefined();
     expect(json.result.capabilities.tools).toBeDefined();
+  }, 10000);
+
+  it('answers empty resource and prompt discovery lists', async () => {
+    child = spawnServer(tempDir);
+    const events = tagStreams(child);
+    sendInitialize(child, tempDir);
+    await waitFor(events, (e) => e.stream === 'stdout', 5000);
+
+    sendMessage(child, { id: 1, method: 'resources/list' });
+    sendMessage(child, { id: 2, method: 'prompts/list' });
+
+    const resources = await waitFor(
+      events,
+      (e) => e.stream === 'stdout' && JSON.parse(e.text).id === 1,
+      5000,
+    );
+    const prompts = await waitFor(
+      events,
+      (e) => e.stream === 'stdout' && JSON.parse(e.text).id === 2,
+      5000,
+    );
+
+    expect(JSON.parse(resources.text).result).toEqual({ resources: [] });
+    expect(JSON.parse(prompts.text).result).toEqual({ prompts: [] });
   }, 10000);
 
   it('sends initialize response BEFORE tryInitializeDefault finishes', async () => {

--- a/site/src/content/docs/getting-started/quickstart.md
+++ b/site/src/content/docs/getting-started/quickstart.md
@@ -22,7 +22,15 @@ npx @colbymchenry/codegraph        # zero-install, or:
 npm i -g @colbymchenry/codegraph
 ```
 
-CodeGraph bundles its own runtime — nothing to compile, no native build, works the same everywhere. The interactive installer auto-configures your agent(s) — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro.
+CodeGraph bundles its own runtime — nothing to compile, no native build, works the same everywhere.
+
+## Wire Up Your Agent
+
+```bash
+codegraph install
+```
+
+The interactive installer writes the MCP server config for your agent(s) — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro. If you are using the zero-install npm flow, run `npx @colbymchenry/codegraph` for the same setup. Restart your agent afterwards so it loads the new MCP server.
 
 ## Initialize Projects
 
@@ -31,6 +39,6 @@ cd your-project
 codegraph init -i
 ```
 
-That's it — your agent will use CodeGraph tools automatically when a `.codegraph/` directory exists.
+`codegraph init` creates the local `.codegraph/` index directory; adding `-i` (`--index`) also builds the initial graph in the same step. It does not install CodeGraph into your agent by itself.
 
 Next: build [Your First Graph](/codegraph/getting-started/your-first-graph/), or see the full [Installation](/codegraph/getting-started/installation/) options.

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -230,6 +230,10 @@ export async function runLocalHandshakeProxy(deps: LocalHandshakeDeps): Promise<
         routeToDaemon(line); // prime the daemon so it resolves the project (its reply is suppressed below)
       } else if (msg.method === 'tools/list') {
         writeClient({ jsonrpc: '2.0', id: msg.id, result: { tools: getStaticTools() } });
+      } else if (msg.method === 'resources/list') {
+        writeClient({ jsonrpc: '2.0', id: msg.id, result: { resources: [] } });
+      } else if (msg.method === 'prompts/list') {
+        writeClient({ jsonrpc: '2.0', id: msg.id, result: { prompts: [] } });
       } else {
         routeToDaemon(line);
       }

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -1,6 +1,6 @@
 /**
  * MCP per-connection session — speaks the JSON-RPC protocol (initialize,
- * tools/list, tools/call) over a single {@link JsonRpcTransport}. It owns
+ * tools/list, tools/call, resources/list, prompts/list) over a single {@link JsonRpcTransport}. It owns
  * per-client state only (which protocol version the client asked for, whether
  * it advertised `roots`, the one-shot roots/list latch); the heavyweight
  * resources (CodeGraph, watcher, ToolHandler) live in the shared
@@ -125,6 +125,12 @@ export class MCPSession {
         break;
       case 'tools/list':
         if (isRequest) await this.handleToolsList(message as JsonRpcRequest);
+        break;
+      case 'resources/list':
+        if (isRequest) this.transport.sendResult((message as JsonRpcRequest).id, { resources: [] });
+        break;
+      case 'prompts/list':
+        if (isRequest) this.transport.sendResult((message as JsonRpcRequest).id, { prompts: [] });
         break;
       case 'tools/call':
         if (isRequest) await this.handleToolsCall(message as JsonRpcRequest);


### PR DESCRIPTION
## Summary
- add the missing agent wiring step to the README and docs quickstart before project initialization
- clarify that `codegraph init -i` builds the local index but does not install the MCP server into an agent
- return empty `resources/list` and `prompts/list` discovery responses in both session and proxy paths

Closes #631
Closes #621

## Tests
- `npm run build`
- `npm test -- __tests__/mcp-initialize.test.ts`
- `(cd site && npm run build)`