### PR TITLE
feat(mcp): surface supported languages in MCP server instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### New Features
 
 - `codegraph status --json` now also reports the running CLI `version`, the index directory (`indexPath`), and a `lastIndexed` timestamp (ISO-8601, or null when nothing's indexed yet), so CI and scripts can pin the CLI version and check index freshness from a single command. A matching `CodeGraph.getLastIndexedAt()` library method exposes the same freshness check without shelling out. Thanks @12122J and @eddieran. (#329)
+- When an agent connects over MCP, CodeGraph now states up front which languages it indexes — 20+, including TypeScript/JavaScript, Python, Go, Rust, Java, C#, C/C++, PHP, Ruby, Swift, and Kotlin — so agents no longer assume a language (such as Rust) isn't supported and skip the tools. (#671)
 
 ### Fixes
 

--- a/src/mcp/server-instructions.ts
+++ b/src/mcp/server-instructions.ts
@@ -18,7 +18,9 @@
 export const SERVER_INSTRUCTIONS = `# Codegraph — code intelligence over an indexed knowledge graph
 
 Codegraph is a SQLite knowledge graph of every symbol, edge, and file
-in the workspace. Reads are sub-millisecond; the index lags writes by
+in the workspace. It indexes 20+ languages — TypeScript/JavaScript,
+Python, Go, Rust, Java, C#, C/C++, PHP, Ruby, Swift, Kotlin, and more.
+Reads are sub-millisecond; the index lags writes by
 about a second through the file watcher. Consult it BEFORE writing or
 editing code, not during.
 


### PR DESCRIPTION
## What

The MCP `initialize` instructions — the first thing every agent sees about codegraph — listed **no languages**. So agents (and the users driving them) assumed languages like Rust weren't supported even though they're fully indexed, and skipped the codegraph tools entirely. That was the real gap behind #671 ("Rust support"), where Rust has in fact worked end-to-end for several releases (verified: structs/traits/`impl`/methods/calls, `callers`/`callees`/`impact`, trait `implements` edges, and Axum/Actix/Rocket route extraction + cargo-workspace resolution).

This adds one concise line to the opening paragraph of `server-instructions.ts`:

> It indexes 20+ languages — TypeScript/JavaScript, Python, Go, Rust, Java, C#, C/C++, PHP, Ruby, Swift, Kotlin, and more.

## Why here

`server-instructions.ts` is the single source of truth for agent-facing guidance (#529) and the first place the false "language X isn't supported" assumption forms. The README documents the full list, but it isn't reachable from *inside* the tool, which is where agents actually meet it.

## Testing

- `npm run build` — clean
- `npx vitest run __tests__/mcp-initialize.test.ts` — 3/3 pass (exercises the `initialize` response that carries these instructions)

refs #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)