### PR TITLE
fix(resolution): same-dir component preference must compare paths at a directory boundary

### DIFF
--- a/__tests__/framework-samedir-boundary.test.ts
+++ b/__tests__/framework-samedir-boundary.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression: "prefer same directory" component resolution must compare
+ * directories at a path-segment boundary, not as a raw string prefix.
+ *
+ * The React/Vue/Svelte framework resolvers disambiguate same-named
+ * components by preferring one in the referencing file's directory:
+ *
+ *   const fromDir = fromFile.substring(0, fromFile.lastIndexOf('/'));
+ *   const sameDir = components.filter((n) => n.filePath.startsWith(fromDir));
+ *
+ * `startsWith(fromDir)` has no trailing-separator boundary, so a file in a
+ * SIBLING directory whose name merely shares a prefix (`src/ui-kit/...`
+ * vs `src/ui/...`) is wrongly treated as same-directory and can win the
+ * tie — resolving a reference to the wrong component (a wrong graph edge).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { reactResolver } from '../src/resolution/frameworks/react';
+import { svelteResolver } from '../src/resolution/frameworks/svelte';
+import type { ResolutionContext, UnresolvedRef } from '../src/resolution/types';
+import type { Node, Language } from '../src/types';
+
+function makeComponent(
+  id: string,
+  name: string,
+  filePath: string,
+  language: Language = 'typescript'
+): Node {
+  return {
+    id,
+    kind: 'component',
+    name,
+    qualifiedName: `${filePath}::${name}`,
+    filePath,
+    language,
+    startLine: 1,
+    endLine: 1,
+    startColumn: 0,
+    endColumn: 0,
+    updatedAt: 0,
+  };
+}
+
+/** Minimal context: only the methods resolveComponent touches need to work. */
+function makeContext(nodesByName: Record<string, Node[]>): ResolutionContext {
+  return {
+    getNodesByName: (name: string) => nodesByName[name] ?? [],
+    getNodesInFile: () => [],
+    getNodesByQualifiedName: () => [],
+    getNodesByKind: () => [],
+    fileExists: () => false,
+    readFile: () => null,
+    getProjectRoot: () => '/repo',
+    getAllFiles: () => [],
+    getNodesByLowerName: () => [],
+    getImportMappings: () => [],
+  };
+}
+
+describe('framework same-directory preference uses a path boundary', () => {
+  it('does not treat a prefix-sibling directory as the same directory', () => {
+    // Reference site lives in src/ui/. Two components named Widget exist:
+    // the real same-dir one in src/ui/, and a decoy in the prefix-sibling
+    // src/ui-kit/. The decoy is listed FIRST so a raw-prefix match returns
+    // it instead of the true same-directory component.
+    const trueSameDir = makeComponent('id-ui', 'Widget', 'src/ui/Widget.tsx');
+    const prefixSibling = makeComponent('id-uikit', 'Widget', 'src/ui-kit/Widget.tsx');
+
+    const context = makeContext({ Widget: [prefixSibling, trueSameDir] });
+
+    const ref: UnresolvedRef = {
+      fromNodeId: 'caller',
+      referenceName: 'Widget',
+      referenceKind: 'references',
+      line: 5,
+      column: 0,
+      filePath: 'src/ui/Card.tsx',
+      language: 'typescript',
+    };
+
+    const resolved = reactResolver.resolve(ref, context);
+    expect(resolved).not.toBeNull();
+    // Must resolve to the component actually in src/ui/, never the
+    // src/ui-kit/ sibling that only shares a string prefix.
+    expect(resolved!.targetNodeId).toBe('id-ui');
+  });
+
+  it('still prefers a true same-directory component over an unrelated one', () => {
+    // Sanity: the same-directory preference itself still works after the fix.
+    const sameDir = makeComponent('id-same', 'Panel', 'src/ui/Panel.tsx');
+    const elsewhere = makeComponent('id-other', 'Panel', 'src/widgets/Panel.tsx');
+
+    // List the unrelated one first; the same-dir one must still win.
+    const context = makeContext({ Panel: [elsewhere, sameDir] });
+
+    const ref: UnresolvedRef = {
+      fromNodeId: 'caller',
+      referenceName: 'Panel',
+      referenceKind: 'references',
+      line: 5,
+      column: 0,
+      filePath: 'src/ui/Card.tsx',
+      language: 'typescript',
+    };
+
+    const resolved = reactResolver.resolve(ref, context);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.targetNodeId).toBe('id-same');
+  });
+
+  it('Svelte: prefix-sibling directory is not the same directory', () => {
+    const trueSameDir = makeComponent('sv-ui', 'Widget', 'src/ui/Widget.svelte', 'svelte');
+    const prefixSibling = makeComponent('sv-uikit', 'Widget', 'src/ui-kit/Widget.svelte', 'svelte');
+
+    const context = makeContext({ Widget: [prefixSibling, trueSameDir] });
+
+    // Svelte dispatches component resolution on `calls` refs.
+    const ref: UnresolvedRef = {
+      fromNodeId: 'caller',
+      referenceName: 'Widget',
+      referenceKind: 'calls',
+      line: 5,
+      column: 0,
+      filePath: 'src/ui/Card.svelte',
+      language: 'svelte',
+    };
+
+    const resolved = svelteResolver.resolve(ref, context);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.targetNodeId).toBe('sv-ui');
+  });
+});

--- a/src/resolution/frameworks/react.ts
+++ b/src/resolution/frameworks/react.ts
@@ -280,6 +280,17 @@ const BUILT_IN_TYPES = new Set([
 const COMPONENT_KINDS = new Set(['component', 'function', 'class']);
 
 /**
+ * Directory portion of a posix-style path, or '' for a root-level file.
+ * `src/ui/Card.tsx` -> `src/ui`; `App.tsx` -> ''. Used for exact
+ * same-directory comparison (vs a raw `startsWith`, which matches
+ * prefix-sibling directories like `src/ui-kit` for `src/ui`).
+ */
+function dirOf(filePath: string): string {
+  const slash = filePath.lastIndexOf('/');
+  return slash >= 0 ? filePath.slice(0, slash) : '';
+}
+
+/**
  * Resolve a component reference using name-based lookup
  */
 function resolveComponent(
@@ -293,9 +304,12 @@ function resolveComponent(
   const components = candidates.filter((n) => COMPONENT_KINDS.has(n.kind));
   if (components.length === 0) return null;
 
-  // Prefer same directory
-  const fromDir = fromFile.substring(0, fromFile.lastIndexOf('/'));
-  const sameDir = components.filter((n) => n.filePath.startsWith(fromDir));
+  // Prefer same directory. Compare directory paths exactly — a raw
+  // `startsWith(fromDir)` would treat a prefix-sibling directory
+  // (`src/ui-kit/` for `src/ui/`) as the same directory and resolve to
+  // the wrong component.
+  const fromDir = dirOf(fromFile);
+  const sameDir = components.filter((n) => dirOf(n.filePath) === fromDir);
   if (sameDir.length > 0) return sameDir[0]!.id;
 
   // Prefer component directories

--- a/src/resolution/frameworks/svelte.ts
+++ b/src/resolution/frameworks/svelte.ts
@@ -202,6 +202,17 @@ function isPascalCase(str: string): boolean {
 }
 
 /**
+ * Directory portion of a posix-style path, or '' for a root-level file.
+ * `src/ui/Card.svelte` -> `src/ui`; `App.svelte` -> ''. Used for exact
+ * same-directory comparison (vs a raw `startsWith`, which matches
+ * prefix-sibling directories like `src/ui-kit` for `src/ui`).
+ */
+function dirOf(filePath: string): string {
+  const slash = filePath.lastIndexOf('/');
+  return slash >= 0 ? filePath.slice(0, slash) : '';
+}
+
+/**
  * Resolve a Svelte component reference using name-based lookup
  */
 function resolveComponent(
@@ -215,9 +226,12 @@ function resolveComponent(
 
   if (components.length === 0) return null;
 
-  // Prefer same directory
-  const fromDir = fromFile.substring(0, fromFile.lastIndexOf('/'));
-  const sameDir = components.filter((n) => n.filePath.startsWith(fromDir));
+  // Prefer same directory. Compare directory paths exactly — a raw
+  // `startsWith(fromDir)` would treat a prefix-sibling directory
+  // (`src/ui-kit/` for `src/ui/`) as the same directory and resolve to
+  // the wrong component.
+  const fromDir = dirOf(fromFile);
+  const sameDir = components.filter((n) => dirOf(n.filePath) === fromDir);
   if (sameDir.length > 0) return sameDir[0]!.id;
 
   return components[0]!.id;


### PR DESCRIPTION
## The bug

The React and Svelte framework resolvers disambiguate same-named components by preferring the one in the **referencing file's directory**:

```ts
// src/resolution/frameworks/react.ts  (and svelte.ts)
const fromDir = fromFile.substring(0, fromFile.lastIndexOf('/'));
const sameDir = components.filter((n) => n.filePath.startsWith(fromDir));
if (sameDir.length > 0) return sameDir[0]!.id;
```

`startsWith(fromDir)` matches on a raw string prefix with **no path-separator boundary**. So a component in a *sibling* directory whose name merely shares a prefix is wrongly treated as "same directory":

- referencing file: `src/ui/Card.tsx` → `fromDir = "src/ui"`
- candidates named `Widget`: `src/ui/Widget.tsx` (the true same-dir one) and `src/ui-kit/Widget.tsx` (a prefix sibling)
- `"src/ui-kit/Widget.tsx".startsWith("src/ui")` is **true**, so `src/ui-kit/Widget.tsx` lands in `sameDir` and — depending on candidate order — can be returned instead of the real `src/ui/Widget.tsx`.

The result is a **wrong `references` edge** to a different component in a prefix-sibling directory. This is the same data-integrity hazard the workspace-package matcher already guards against with `importPath === name || importPath.startsWith(name + '/')`.

There's also a secondary edge: for a root-level file like `App.tsx` (no `/`), `lastIndexOf('/')` is `-1` and `substring(0, -1)` returns `''`, so `startsWith('')` matches **every** file — silently defeating the "same directory" preference entirely.

## Repro (fail-before / pass-after)

Added `__tests__/framework-samedir-boundary.test.ts`. It drives the public `reactResolver.resolve()` / `svelteResolver.resolve()` with two same-named components — the true same-dir one and a prefix-sibling decoy listed first — and asserts the resolver picks the same-directory component.

Before this change:
```
× does not treat a prefix-sibling directory as the same directory
  → expected 'id-uikit' to be 'id-ui'
× Svelte: prefix-sibling directory is not the same directory
  → expected 'sv-uikit' to be 'sv-ui'
```
After: all 3 pass. A sanity case (a genuine same-directory component listed *after* an unrelated one) confirms the same-dir preference itself still works.

## The fix

Replace the boundary-unsafe `startsWith` with an **exact directory comparison** via a small `dirOf` helper (which also returns `''` cleanly for root-level files):

```ts
function dirOf(filePath: string): string {
  const slash = filePath.lastIndexOf('/');
  return slash >= 0 ? filePath.slice(0, slash) : '';
}
// ...
const fromDir = dirOf(fromFile);
const sameDir = components.filter((n) => dirOf(n.filePath) === fromDir);
```

Surgical: `+34/-6` across the two affected resolvers, no behavior change beyond fixing the wrong-directory match.

## Scope notes

- `src/resolution/frameworks/vue.ts` has the same `startsWith(fromDir)` idiom, but its loop additionally gates on `componentName === name` (filename basename equals the reference name), so the directory filter there is effectively redundant for the common case and I couldn't construct a realistic wrong-result repro without a contrived filename/component-name mismatch — left untouched rather than ship a speculative change. Happy to follow up if you'd prefer it normalized for consistency.
- Verified no regressions: `frameworks`, `frameworks-integration`, `resolution`, and `react-native-bridge` suites (184 tests) all pass, and `tsc --noEmit` is clean. (The MCP-daemon / `status-json` CLI-spawn suites fail identically on `main` in my environment — pre-existing, unrelated.)
