### PR TITLE
docs: add GitHub Copilot CLI MCP setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,39 @@ npm install -g @colbymchenry/codegraph
 </details>
 
 <details>
+<summary><strong>GitHub Copilot CLI (manual setup)</strong></summary>
+
+The interactive installer doesn't auto-configure [GitHub Copilot CLI](https://docs.github.com/copilot/concepts/agents/about-copilot-cli) yet, so wire it up by hand — it takes about a minute.
+
+**1. Install the `codegraph` CLI** (if you haven't already) — see [Get Started](#get-started).
+
+**2. Add the MCP server to `~/.copilot/mcp-config.json`:**
+```json
+{
+  "mcpServers": {
+    "codegraph": {
+      "type": "stdio",
+      "command": "codegraph",
+      "args": ["serve", "--mcp"],
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+<sub>Unlike Claude Code, Copilot CLI **requires the `tools` key** — without it, none of CodeGraph's tools are enabled. `["*"]` enables them all; to allowlist explicitly instead, list the tool names (`codegraph_search`, `codegraph_explore`, `codegraph_callers`, `codegraph_callees`, `codegraph_impact`, `codegraph_node`, `codegraph_status`, `codegraph_files`). The config file lives in `~/.copilot` by default — set `COPILOT_HOME` to relocate it. You can also add the server interactively with the `/mcp add` slash command instead of editing the file.</sub>
+
+**3. Reload MCP servers** — run `/mcp` in an interactive session (or `/restart`) so Copilot CLI launches `codegraph serve --mcp`. Confirm it connected with `/mcp` or `/env`.
+
+**4. Initialize the project** so the server has an index to answer against:
+```bash
+cd your-project
+codegraph init -i
+```
+
+</details>
+
+<details>
 <summary><strong>Agent Tool Guidance</strong></summary>
 
 CodeGraph's MCP server delivers its usage guidance to your agent **automatically**, in the MCP `initialize` response — there's no instructions file to manage and nothing is added to your `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`. In short, it tells the agent to:
@@ -611,6 +644,8 @@ is written):
 - **Gemini CLI**
 - **Antigravity IDE**
 - **Kiro**
+
+> **GitHub Copilot CLI** is also supported via a quick manual config — see [GitHub Copilot CLI (manual setup)](#quick-start) under Quick Start.
 
 ## Supported Languages
 


### PR DESCRIPTION
Adds documentation for configuring the CodeGraph MCP server with [GitHub Copilot CLI](https://docs.github.com/copilot/concepts/agents/about-copilot-cli), which the interactive installer doesn't auto-configure yet.

## Changes
- New **"GitHub Copilot CLI (manual setup)"** collapsible section under Quick Start with a 4-step guide:
  1. Install the `codegraph` CLI
  2. Add the server to `~/.copilot/mcp-config.json`
  3. Reload via `/mcp` (or `/restart`)
  4. Initialize the project with `codegraph init -i`
- Cross-reference note under **Supported Agents**.

## Notes
- Calls out the Copilot-specific requirement that the `tools` key must be present (Copilot CLI won't enable any tools without it, unlike Claude Code's config).
- Mentions `COPILOT_HOME` for relocating the config and the `/mcp add` interactive alternative.
- Docs-only change; matches the existing JSON style used elsewhere in the README.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>