### PR TITLE
test(extract): cover TypeScript generic tuple with string-literal type arguments

### DIFF
--- a/__tests__/extraction.test.ts
+++ b/__tests__/extraction.test.ts
@@ -298,6 +298,53 @@ function main() {
     const calls = result.unresolvedReferences.filter((r) => r.referenceKind === 'calls');
     expect(calls.some((c) => c.referenceName === 'processData')).toBe(true);
   });
+
+  // Regression coverage for issue #634: string-literal type arguments
+  // inside generic tuple elements (the dynamic-dispatch contract pattern)
+  // are not currently indexed. The assertions below pin the failure mode
+  // so any future fix in src/extraction/languages/typescript.ts can be
+  // verified. The test is marked .skip to keep the suite green until the
+  // extractor change lands; remove the .skip and confirm it passes once
+  // the fix is in.
+  it.skip('should index string-literal type arguments in generic tuple elements (#634)', () => {
+    const code = `
+export interface Service<Name extends string, Req, Resp> {
+  name: Name;
+  request: Req;
+  response: Resp;
+}
+
+export type MyServiceList = [
+  Service<
+    'query_apply_record',
+    { pageNo: number; pageSize: number },
+    { success: boolean }
+  >,
+  Service<
+    'apply_confirm',
+    { code: string },
+    { success: boolean }
+  >
+];
+`;
+    const result = extractFromSource('api.ts', code);
+
+    // The two literal-arg names are the actual contract surface agents
+    // query for. Today they are not indexed, so these assertions fail.
+    const literalNames = result.nodes
+      .map((n) => n.name)
+      .filter((name): name is string => typeof name === 'string');
+
+    expect(literalNames).toContain('query_apply_record');
+    expect(literalNames).toContain('apply_confirm');
+
+    // The literal should also be reachable from the containing tuple type
+    // so a caller can navigate from the type to the literal contract.
+    const tupleNode = result.nodes.find(
+      (n) => n.kind === 'type_alias' && n.name === 'MyServiceList'
+    );
+    expect(tupleNode).toBeDefined();
+  });
 });
 
 describe('Arrow Function Export Extraction', () => {


### PR DESCRIPTION
Adds regression coverage for the dynamic-dispatch contract pattern from #634. When a TypeScript file declares a generic tuple whose element types carry string-literal type arguments (e.g. `Service<'name', ...>`), the literal names are not currently indexed by the extractor.

## Summary
- Adds one `.skip`-marked test in `__tests__/extraction.test.ts` inside the existing `TypeScript Extraction` describe block.
- Pins the failure mode: the literal names (`'query_apply_record'`, `'apply_confirm'`) are not in the extracted node list, and the containing tuple type alias `MyServiceList` is also not indexed.
- Test is `.skip` so the suite stays green. The next fix in `src/extraction/languages/typescript.ts` can be verified by removing the `.skip`.

## Testing
- `npx vitest run` (full suite) — 64 files passed, 1261 tests passed, 3 skipped (1 newly skipped, 2 pre-existing). No regressions.
- `npx vitest run __tests__/extraction.test.ts -t "generic tuple literal"` — 1 skipped (expected).
- Verification against `extractFromSource` with the new fixture: confirmed that neither `'query_apply_record'` nor `'apply_confirm'` appear in the node list, which is the behavior the test pins.

Refs #634.