### PR TITLE
fix(cpp): name reference-returning free functions + resolve qualified calls ns::a::Func(...)

### DIFF
--- a/__tests__/extraction.test.ts
+++ b/__tests__/extraction.test.ts
@@ -3842,6 +3842,42 @@ std::string use() {
     }
   });
 
+  it('names a reference-returning free function from its name node (not `& Name(...)`)', async () => {
+    const src = path.join(tempDir, 'src');
+    fs.mkdirSync(src, { recursive: true });
+
+    // `const std::string& GetRef(a::Ctx&)` wraps the function_declarator in a
+    // reference_declarator. The generic declarator-text fallback kept the
+    // leading `&` and the whole signature, indexing it as
+    // `& GetRef(a::Ctx& c)` — unsearchable, so callers never resolved.
+    fs.writeFileSync(
+      path.join(src, 'ref.cc'),
+      `#include <string>
+namespace a { struct Ctx {}; }
+const std::string& GetRef(a::Ctx& c) { static std::string s; return s; }
+`
+    );
+    fs.writeFileSync(
+      path.join(src, 'use_ref.cc'),
+      `#include <string>
+namespace a { struct Ctx {}; }
+void useRef(a::Ctx& c) { (void)GetRef(c); }
+`
+    );
+
+    cg = CodeGraph.initSync(tempDir);
+    await cg.indexAll();
+    cg.resolveReferences();
+
+    const fns = cg.getNodesByKind('function');
+    const getRef = fns.find((n) => n.name === 'GetRef');
+    expect(getRef, 'GetRef extracted under its real name (not "& GetRef(...)")').toBeDefined();
+    expect(fns.some((n) => n.name.includes('&')), 'no function indexed with a stray "&" in its name').toBe(false);
+
+    const reached = [...cg.getImpactRadius(getRef!.id, 3).nodes.values()].map((n) => n.filePath ?? '');
+    expect(reached.some((p) => p.endsWith('use_ref.cc')), 'GetRef should be called from use_ref.cc').toBe(true);
+  });
+
   it('resolves a fully-qualified call `ns::a::Func(...)` to its definition', async () => {
     const src = path.join(tempDir, 'src');
     fs.mkdirSync(src, { recursive: true });

--- a/__tests__/extraction.test.ts
+++ b/__tests__/extraction.test.ts
@@ -3841,6 +3841,45 @@ std::string use() {
       expect(reached.some((p) => p.endsWith('user.cc')), `${fn.name} should be called from user.cc`).toBe(true);
     }
   });
+
+  it('resolves a fully-qualified call `ns::a::Func(...)` to its definition', async () => {
+    const src = path.join(tempDir, 'src');
+    fs.mkdirSync(src, { recursive: true });
+
+    // The callee node is stored under its SIMPLE name (`GetInsured`), but the
+    // call site uses the fully-qualified `ns::insured::GetInsured(...)`. Storing
+    // the full qualified text as the callee left the name-based resolver unable
+    // to link the `calls` edge, so `GetInsured` reported no callers.
+    fs.writeFileSync(
+      path.join(src, 'insured.cc'),
+      `#include <string>
+namespace mmpayinspolicymgrao { namespace insured {
+std::string GetInsured(const std::string& id) { return id; }
+} }
+`
+    );
+    fs.writeFileSync(
+      path.join(src, 'caller.cc'),
+      `#include <string>
+std::string CallIt() {
+  return mmpayinspolicymgrao::insured::GetInsured("x");
+}
+`
+    );
+
+    cg = CodeGraph.initSync(tempDir);
+    await cg.indexAll();
+    cg.resolveReferences();
+
+    const getInsured = cg.getNodesByKind('function').find((n) => n.name === 'GetInsured');
+    expect(getInsured, 'GetInsured extracted').toBeDefined();
+
+    const reached = [...cg.getImpactRadius(getInsured!.id, 3).nodes.values()].map((n) => n.filePath ?? '');
+    expect(
+      reached.some((p) => p.endsWith('caller.cc')),
+      'qualified call ns::insured::GetInsured should resolve to caller.cc',
+    ).toBe(true);
+  });
 });
 
 describe('Dart mixins and type references', () => {

--- a/src/extraction/languages/c-cpp.ts
+++ b/src/extraction/languages/c-cpp.ts
@@ -3,46 +3,55 @@ import { getChildByField, getNodeText } from '../tree-sitter-helpers';
 import type { LanguageExtractor } from '../tree-sitter-types';
 
 /**
- * Find the function NAME's `qualified_identifier` (`Foo::bar`) inside a
- * declarator, skipping the `parameter_list` — a parameter with a qualified type
- * (`const std::string& x`) must NOT be mistaken for the method name. Without the
- * skip, a plain free function `std::string TableFileName(const std::string&...)`
- * was named `string` (from the parameter type), so calls to it never resolved
- * and its file looked like nothing depended on it.
+ * Walk the declarator chain to the function's NAME node only, unwrapping
+ * pointer / reference / parenthesized wrappers and never descending into the
+ * `parameter_list`. This keeps two failure modes out of the extracted name:
+ *   - a free function named after its first namespaced PARAMETER type
+ *     (`X GetThing(a::Ctx& c)` must be `GetThing`, not `Ctx`), and
+ *   - a reference-returning free function whose generic declarator-text
+ *     fallback kept the leading `&` and the whole signature
+ *     (`const std::string& GetRef(a::Ctx& c)` must be `GetRef`, not
+ *     `& GetRef(a::Ctx& c)`).
  */
-function findDeclaratorQualifiedId(declarator: SyntaxNode): SyntaxNode | undefined {
-  const queue: SyntaxNode[] = [declarator];
-  while (queue.length > 0) {
-    const current = queue.shift()!;
-    if (current.type === 'qualified_identifier') return current;
-    for (let i = 0; i < current.namedChildCount; i++) {
-      const child = current.namedChild(i);
-      // Don't descend into parameters or the trailing return type — their types
-      // (`const std::string&`, `-> std::string`) aren't the function name.
-      if (child && child.type !== 'parameter_list' && child.type !== 'trailing_return_type') {
-        queue.push(child);
-      }
-    }
+function getCppNameDeclarator(node: SyntaxNode): SyntaxNode | undefined {
+  let current: SyntaxNode | null | undefined = getChildByField(node, 'declarator');
+  while (
+    current &&
+    (current.type === 'function_declarator' ||
+      current.type === 'pointer_declarator' ||
+      current.type === 'reference_declarator' ||
+      current.type === 'parenthesized_declarator')
+  ) {
+    current = getChildByField(current, 'declarator') ?? current.namedChild(0);
+  }
+  return current ?? undefined;
+}
+
+function extractCppQualifiedMethodName(node: SyntaxNode, source: string): string | undefined {
+  const nameNode = getCppNameDeclarator(node);
+  if (!nameNode) return undefined;
+  if (nameNode.type === 'qualified_identifier') {
+    const parts = getNodeText(nameNode, source).trim().split('::').filter(Boolean);
+    return parts[parts.length - 1];
+  }
+  // Return plain names directly so we don't fall through to the generic
+  // declarator-text fallback, which doesn't unwrap reference_declarator
+  // (`T& Foo(...)` -> "& Foo(...)"). operator_name / destructor_name /
+  // template_function are intentionally left to that fallback, which names
+  // them correctly.
+  if (nameNode.type === 'identifier' || nameNode.type === 'field_identifier') {
+    return getNodeText(nameNode, source).trim();
   }
   return undefined;
 }
 
-function extractCppQualifiedMethodName(node: SyntaxNode, source: string): string | undefined {
-  const declarator = getChildByField(node, 'declarator');
-  if (!declarator) return undefined;
-  const qid = findDeclaratorQualifiedId(declarator);
-  if (!qid) return undefined;
-  const parts = getNodeText(qid, source).trim().split('::').filter(Boolean);
-  return parts[parts.length - 1];
-}
-
 function extractCppReceiverType(node: SyntaxNode, source: string): string | undefined {
-  const declarator = getChildByField(node, 'declarator');
-  if (!declarator) return undefined;
-  const qid = findDeclaratorQualifiedId(declarator);
-  if (!qid) return undefined;
-  const parts = getNodeText(qid, source).trim().split('::').filter(Boolean);
-  return parts.length > 1 ? parts.slice(0, -1).join('::') : undefined;
+  const nameNode = getCppNameDeclarator(node);
+  if (nameNode && nameNode.type === 'qualified_identifier') {
+    const parts = getNodeText(nameNode, source).trim().split('::').filter(Boolean);
+    if (parts.length > 1) return parts.slice(0, -1).join('::');
+  }
+  return undefined;
 }
 
 /**

--- a/src/extraction/tree-sitter.ts
+++ b/src/extraction/tree-sitter.ts
@@ -2615,6 +2615,15 @@ export class TreeSitterExtractor {
         } else if (func.type === 'scoped_identifier' || func.type === 'scoped_call_expression') {
           // Scoped call: Module::function()
           calleeName = getNodeText(func, this.source);
+        } else if (func.type === 'qualified_identifier') {
+          // C++ qualified call `ns::a::Func(...)`. The callee is stored under its
+          // SIMPLE name (the C++ extractor records the last `::` segment as the
+          // node name), so reference that segment too. Storing the full
+          // `ns::a::Func` here drops through to the generic text below and the
+          // name-based resolver never links the `calls` edge ("No callers").
+          const qtext = getNodeText(func, this.source);
+          const qparts = qtext.split('::').filter(Boolean);
+          calleeName = qparts[qparts.length - 1] || qtext;
         } else if (this.language === 'csharp' && func.type === 'member_access_expression') {
           // C# member call `recv.Method(...)`. When the receiver is itself a call
           // — a chained factory `Foo.Create(args).Bar()` — encode `inner().Bar`


### PR DESCRIPTION
Two related C++ extraction bugs, both rooted in how the function NAME is taken from a `function_definition`'s declarator. tree-sitter parses the code cleanly — these are extractor/resolver issues.

## Fix 1 — reference-returning free functions are mis-named (unsearchable)
`const std::string& GetRef(a::Ctx& c)` wraps the `function_declarator` in a `reference_declarator`. `extractCppQualifiedMethodName` only resolved a name when the declarator contained a `qualified_identifier`; a plain-identifier free function fell through to the generic declarator-text fallback, which doesn't unwrap `reference_declarator` and indexed it as **`& GetRef(a::Ctx& c)`** — unsearchable, and its callers never resolved.

Now we walk the declarator chain to the NAME node only (unwrapping pointer/reference/parenthesized wrappers, never descending into the parameter list) and return plain identifiers directly. `operator_name` / `destructor_name` / `template_function` are still left to the generic fallback, which names them correctly.

10-pattern battery, before → after on current `main`:

| pattern | before | after |
|---|---|---|
| free fn + qualified param `GetThing(a::Ctx&)` | `GetThing` | `GetThing` |
| pointer return `int* GetPtr(...)` | `GetPtr` | `GetPtr` |
| trailing return `auto T(...)->a::Ret` | `Trailing` | `Trailing` |
| qualified-type value return `std::string FreeStrRet(...)` | `FreeStrRet` | `FreeStrRet` |
| **reference return `const std::string& GetRef(a::Ctx&)`** | **`& GetRef(a::Ctx& c)`** ❌ | **`GetRef`** ✅ |
| operator `operator==(const a::A&,...)` | `operator==` | `operator==` |
| out-of-line member `void Klass::Method(a::Ctx&)` | `Method` | `Method` (recv=Klass) |
| template `template<class T> a::R TplFn(a::Ctx&)` | `TplFn` | `TplFn` |
| in-class method `void Process(a::Ctx&)` | `Process` | `Process` |

(The "named after the first namespaced parameter type" variant — `GetThing` → `Ctx` — was already fixed on `main`; this PR closes the remaining reference-return case.)

## Fix 2 — qualified call `ns::a::Func(...)` produces no `calls` edge
A C++ qualified call's `function` field is a `qualified_identifier`. In `extractCall` (`src/extraction/tree-sitter.ts`) it fell through to the generic `else` and stored the **full** `ns::a::Func` text as the callee name. Function nodes are stored under their **simple** name, so the name-based resolver never linked the `calls` edge — the callee reported "No callers".

```cpp
namespace mmpayinspolicymgrao { namespace insured {
std::string GetInsured(const std::string& id) { return id; }
} }
// `callers GetInsured` was empty before this fix:
std::string CallIt() { return mmpayinspolicymgrao::insured::GetInsured("x"); }
```

Added a `qualified_identifier` branch (right after the existing `scoped_identifier` branch) that references the last `::` segment, consistent with how the C++ extractor names nodes and how methods resolve.

## Why safe
- Other languages unaffected: `qualified_identifier` call nodes are C++-specific (Rust uses `scoped_identifier`, which keeps its existing full-text branch); the name-node walk is in the C++ extractor only.
- Fix 1 is a pure rename/reclassify: no nodes added or dropped.
- Fix 2's last-segment matching follows the resolver's existing best-effort, name-based strategy (same as methods) and is strictly better than no edge.

## Tests
New cases under `__tests__/extraction.test.ts` → "C++ free-function name extraction":
- reference-returning free function is named `GetRef` (not `& GetRef(...)`) and resolves cross-file callers;
- fully-qualified call `mmpayinspolicymgrao::insured::GetInsured("x")` resolves to the defining file.

`npm run build` passes; the C++ extraction tests pass.
