### PR TITLE
docs(readme): update Pascal/Delphi coverage 75.7% → 77.4%

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ Impact and blast-radius queries are only as good as the dependency graph behind 
 | Lua | nvim-telescope/telescope.nvim | 84.2% |
 | Luau | dphfox/Fusion | 92.2% |
 | Liquid | Shopify/dawn | 73.8% |
-| Pascal / Delphi | PascalCoin | 75.7% |
+| Pascal / Delphi | PascalCoin | 77.4% |
 
 Framework routing is validated the same way, on a canonical app per framework: Express 100%, FastAPI 98%, Flask 100%, NestJS 96.8%, Gin 96.5%, Axum 100%, Rocket 93.8%, Vapor 100%, Laravel 92%, Rails 89.6%, React Router 100% — and the convention/reflection-heavy ones at their honest static-analysis ceiling: ASP.NET 83.9%, Spring 83.3%, Drupal 78.9%, Django 74.1%.
 


### PR DESCRIPTION
Updates the measured cross-file coverage figure for Pascal/Delphi from **75.7% → 77.4%** on the PascalCoin benchmark.

This session's Pascal extraction work — paren-less call extraction (#793) and free-routine attribution (#795) — added real call coverage. Validated with a controlled A/B on a fresh PascalCoin clone, identical source-file filter, only the build differing:

| Build | Coverage |
|---|---|
| baseline (pre-Pascal-work, `d21d2df`) | 75.79% |
| current (`main`, EXTRACTION_VERSION 18) | 77.37% (**+1.58**) |

The baseline reproducing the documented **75.7%** confirms the metric matches the README table's methodology; the **+1.58** is the genuine coverage gain (mostly the +1,131 paren-less call edges landing on previously-uncovered files). The chained-call retargets are precision work and don't move "fair coverage," as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)