### PR TITLE
docs(readme): fill framework-coverage gaps — Play, Vue/Nuxt, Scala

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ CodeGraph cuts **tokens, tool calls, and wall-clock time on every repo** — acr
 | **Full-Text Search** | Find code by name instantly across your entire codebase, powered by FTS5 |
 | **Impact Analysis** | Trace callers, callees, and the full impact radius of any symbol before making changes |
 | **Always Fresh** | File watcher uses native OS events (FSEvents/inotify/ReadDirectoryChangesW) with debounced auto-sync — the graph stays current as you code, zero config |
-| **20+ Languages** | TypeScript, JavaScript, Python, Go, Rust, Java, C#, PHP, Ruby, C, C++, Objective-C, Swift, Kotlin, Dart, Lua, Luau, Svelte, Liquid, Pascal/Delphi |
-| **Framework-aware Routes** | Recognizes web-framework routing files and links URL patterns to their handlers across 14 frameworks |
+| **20+ Languages** | TypeScript, JavaScript, Python, Go, Rust, Java, C#, PHP, Ruby, C, C++, Objective-C, Swift, Kotlin, Scala, Dart, Lua, Luau, Svelte, Vue, Liquid, Pascal/Delphi |
+| **Framework-aware Routes** | Recognizes web-framework routing files and links URL patterns to their handlers across 16 frameworks |
 | **Mixed iOS / React Native / Expo** | Closes cross-language flows that static parsing misses: Swift ↔ ObjC bridging, React Native legacy bridge + TurboModules + Fabric view components, native → JS event emitters, Expo Modules |
 | **100% Local** | No data leaves your machine. No API keys. No external services. SQLite database only |
 
@@ -274,11 +274,13 @@ CodeGraph detects web-framework routing files and emits `route` nodes linked by 
 | **Drupal** | `*.routing.yml` routes (`_controller`, `_form`, entity handlers); `hook_*` implementations in `.module`/`.theme`/`.install`/`.inc` |
 | **Rails** | `get '/x', to: 'users#index'`, hash-rocket `=>` syntax |
 | **Spring** | `@GetMapping`, `@PostMapping`, `@RequestMapping` on methods |
+| **Play** | `GET`/`POST`/… verb routes in `conf/routes` → `Controller.method` actions (Scala + Java) |
 | **Gin / chi / gorilla / mux** | `r.GET(...)`, `router.HandleFunc(...)` |
 | **Axum / actix / Rocket** | `.route("/x", get(handler))` |
 | **ASP.NET** | `[HttpGet("/x")]` attributes on action methods |
 | **Vapor** | `app.get("x", use: handler)` |
 | **React Router** / **SvelteKit** | Route component nodes |
+| **Vue Router** / **Nuxt** | `pages/` file-based routes, `server/api/` endpoints, route middleware |
 
 ---
 
@@ -667,7 +669,7 @@ Impact and blast-radius queries are only as good as the dependency graph behind 
 | Liquid | Shopify/dawn | 73.8% |
 | Pascal / Delphi | PascalCoin | 77.4% |
 
-Framework routing is validated the same way, on a canonical app per framework: Express 100%, FastAPI 98%, Flask 100%, NestJS 96.8%, Gin 96.5%, Axum 100%, Rocket 93.8%, Vapor 100%, Laravel 92%, Rails 89.6%, React Router 100% — and the convention/reflection-heavy ones at their honest static-analysis ceiling: ASP.NET 83.9%, Spring 83.3%, Drupal 78.9%, Django 74.1%.
+Framework routing is validated the same way, on a canonical app per framework: Express 100%, FastAPI 98%, Flask 100%, NestJS 96.8%, Gin 96.5%, Axum 100%, Rocket 93.8%, Vapor 100%, Laravel 92%, Rails 89.6%, React Router 100% — and the convention/reflection-heavy ones at their honest static-analysis ceiling: ASP.NET 83.9%, Spring 83.3%, Drupal 78.9%, Play 76.3%, Django 74.1%. SvelteKit and Vue/Nuxt use file-based routing, so their page/endpoint coverage is the Svelte/SvelteKit (100%) and Vue/Nuxt (93.5%) figures in the table above.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Fills the gaps in the README's framework story so it lists every framework we ship — per the "fill the gaps" scope, **existing numbers untouched**.

## What was missing
- **Play** (Scala/Java) — absent from the Framework-aware Routes table *and* the routing-coverage line.
- **Vue Router / Nuxt** — recognized (file-based `pages/`, `server/api/`, middleware) but not in the routes table.
- **Scala** + **Vue** — missing from the "20+ Languages" highlight row.

## Play measurement (reproducible)
Metric = % of `route` nodes with an outgoing `references`/`calls` edge to a function/method/component/class handler — the routing analogue of the fair-coverage language metric.

| | |
|---|---|
| Canonical app | `playframework/play-samples` (the 31 sub-apps with traditional `conf/routes` verb lines) |
| Result | **106 / 139 routes resolved = 76.3%** |
| Residual | every miss is `GET /assets/*file` → Play's framework-provided `Assets` controller (vendored library code, not app source) |

That lands Play in the convention/reflection-heavy ceiling bucket, between Drupal (78.9%) and Django (74.1%).

## File-based routers
SvelteKit and Vue/Nuxt have no separate handler edge — the page *is* the handler — so their coverage is the fair-coverage language figure (Svelte/SvelteKit 100%, Vue/Nuxt 93.5%), now cited explicitly rather than implied.

The existing 15 framework numbers are left as-is: they were measured ad-hoc, and a fresh re-measure (with a slightly different metric — e.g. this metric scores the Express RealWorld app at 95%, not the documented 100%) would shift them. That full re-measure is out of scope for this gap-fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)