### PR TITLE
fix(graph): surface instantiates edges in callers/callees (#774)

### DIFF
--- a/__tests__/resolution.test.ts
+++ b/__tests__/resolution.test.ts
@@ -757,6 +757,47 @@ def bootstrap():
       expect(callsToUserService).toHaveLength(0);
     });
 
+    it('surfaces instantiation sites as callers/callees via the instantiates edge (#774)', async () => {
+      // Once a `Foo()` ref is promoted to `instantiates`, traversal must
+      // still surface it: `getCallers(Foo)` should list every instantiation
+      // site and `getCallees(site)` should list the class — otherwise
+      // `callers`/`impact` on a class miss where it is constructed (#774).
+      const srcDir = path.join(tempDir, 'src');
+      fs.mkdirSync(srcDir, { recursive: true });
+
+      fs.writeFileSync(
+        path.join(srcDir, 'app.py'),
+        `class UserService:
+    def __init__(self):
+        self.db = None
+
+def bootstrap():
+    return UserService()
+`
+      );
+
+      cg = await CodeGraph.init(tempDir, { index: true });
+      cg.resolveReferences();
+
+      const userService = cg
+        .getNodesByKind('class')
+        .find((n) => n.name === 'UserService');
+      expect(userService).toBeDefined();
+
+      const callers = cg.getCallers(userService!.id);
+      const fromBootstrap = callers.find((c) => c.node.name === 'bootstrap');
+      expect(fromBootstrap).toBeDefined();
+      expect(fromBootstrap!.edge.kind).toBe('instantiates');
+
+      const bootstrap = cg
+        .getNodesByKind('function')
+        .find((n) => n.name === 'bootstrap');
+      const callees = cg.getCallees(bootstrap!.id);
+      const toUserService = callees.find((c) => c.node.name === 'UserService');
+      expect(toUserService).toBeDefined();
+      expect(toUserService!.edge.kind).toBe('instantiates');
+    });
+
     it('resolves Go cross-package qualified calls via go.mod module path (#388)', async () => {
       // Pre-#388, every `pkga.FuncX(...)` call in a Go monorepo was flagged
       // external (isExternalImport returned true for any non-`/internal/`

--- a/src/graph/traversal.ts
+++ b/src/graph/traversal.ts
@@ -248,7 +248,9 @@ export class GraphTraverser {
     }
     visited.add(nodeId);
 
-    const incomingEdges = this.queries.getIncomingEdges(nodeId, ['calls', 'references', 'imports']);
+    // `instantiates` is a promoted `calls` (e.g. Python `Foo()`), so an
+    // instantiation site is a caller of the class — surface it here too (#774).
+    const incomingEdges = this.queries.getIncomingEdges(nodeId, ['calls', 'references', 'imports', 'instantiates']);
     if (incomingEdges.length === 0) return;
 
     // Batch-fetch all caller nodes in one round-trip instead of one
@@ -293,7 +295,9 @@ export class GraphTraverser {
     }
     visited.add(nodeId);
 
-    const outgoingEdges = this.queries.getOutgoingEdges(nodeId, ['calls', 'references', 'imports']);
+    // Symmetric with getCallers: a node that instantiates a class is calling
+    // into it, so the class is a callee of the instantiation site (#774).
+    const outgoingEdges = this.queries.getOutgoingEdges(nodeId, ['calls', 'references', 'imports', 'instantiates']);
     if (outgoingEdges.length === 0) return;
 
     // Batch-fetch callee nodes (was N+1 — see getCallersRecursive note).


### PR DESCRIPTION
Fixes #774.

## The actual gap (reframed)

#774 asks for class instantiation (`Foo()`) to count as a caller edge into the class. The **extraction/resolution half already ships**: `resolveReferences()` promotes a `calls` ref to an `instantiates` edge when the target resolves to a class (`src/resolution/index.ts`, covered by the existing test *"promotes calls→instantiates when target resolves to a class (Python)"*). And `impact` already surfaces it — `getImpactRecursive` walks every incoming edge except `contains`.

The residual bug is in **traversal**: `getCallersRecursive` and `getCalleesRecursive` whitelisted only `['calls', 'references', 'imports']`, omitting `instantiates`. So after promotion, the edge exists in the graph but:

- `callers <Class>` / `codegraph_callers` returns **"No callers found"** even though the class is instantiated, and
- `callees <site>` omits the class the site constructs.

`callers` was the one inconsistent traversal (impact already included instantiation sites).

## The fix

Add `'instantiates'` to the edge-kind whitelist in both `getCallersRecursive` (incoming) and `getCalleesRecursive` (outgoing), so an instantiation site is reported as a caller of the class and the class as a callee of the site — matching what `impact` already does.

```ts
// getCallersRecursive
getIncomingEdges(nodeId, ['calls', 'references', 'imports', 'instantiates'])
// getCalleesRecursive
getOutgoingEdges(nodeId, ['calls', 'references', 'imports', 'instantiates'])
```

## Test

Extends the existing `calls→instantiates` Python fixture (`UserService` + `bootstrap`) in `__tests__/resolution.test.ts` to assert the traversal: `getCallers(UserService)` now returns `bootstrap` via an `instantiates` edge, and `getCallees(bootstrap)` returns `UserService`. Red before the change, green after.

## Validation

- `npm run build` — clean.
- The new regression test: red on `main`, green on this branch.
- `npm test` — no new failures. Two pre-existing worker-exit flakes (in `resolution.test.ts`'s real-SQLite/wasm run) reproduce identically on clean `main`, so they're unrelated to this change; all callers/callees/impact suites (`foundation`, `explore-blast-radius`, `object-literal-methods`) pass.

The reporter's original evidence was against v0.9.5 (before the `calls→instantiates` promotion landed in #134), so the symptom they saw was broader; on current `main` this traversal whitelist is the remaining piece.
