### PR TITLE
feat(resolution): index GoFrame g.Meta routes, link to controller methods (#747)

### DIFF
--- a/__tests__/frameworks.test.ts
+++ b/__tests__/frameworks.test.ts
@@ -942,6 +942,33 @@ describe('goResolver.extract', () => {
     const { references } = goResolver.extract!('routes.go', src);
     expect(references[0].referenceName).toBe('listUsers');
   });
+
+  it('extracts a GoFrame g.Meta route and links it to the controller method (#747)', () => {
+    // GoFrame binds reflectively: the route lives in a `g.Meta` struct tag on the
+    // request type, and the handler is the controller method named after that type
+    // (ChatReq -> Chat). No literal route string / call edge exists otherwise.
+    const src = `package v1
+type ChatReq struct {
+	g.Meta \`path:"/chat" method:"post"\`
+	Content string \`json:"content"\`
+}
+`;
+    const { nodes, references } = goResolver.extract!('api/chat/v1/chat.go', src);
+    expect(nodes[0].kind).toBe('route');
+    expect(nodes[0].name).toBe('POST /chat');
+    expect(references[0].referenceName).toBe('Chat');
+    expect(references[0].fromNodeId).toBe(nodes[0].id);
+  });
+
+  it('defaults a GoFrame g.Meta route with no method tag to ANY', () => {
+    const src = `type ListReq struct {
+	g.Meta \`path:"/list"\`
+}
+`;
+    const { nodes, references } = goResolver.extract!('api/v1/list.go', src);
+    expect(nodes[0].name).toBe('ANY /list');
+    expect(references[0].referenceName).toBe('List');
+  });
 });
 
 import { rustResolver } from '../src/resolution/frameworks/rust';

--- a/src/resolution/frameworks/go.ts
+++ b/src/resolution/frameworks/go.ts
@@ -131,6 +131,50 @@ export const goResolver: FrameworkResolver = {
       }
     }
 
+    // GoFrame binds routes reflectively: the path/method live in a `g.Meta`
+    // struct tag on the request type, so there is no literal route call to match
+    // above. Emit a route node from the tag and link it to the controller method,
+    // which GoFrame names after the request type with the `Req` suffix dropped
+    // (`ChatReq` -> `Chat`). Only the relative `path:` from the tag is captured;
+    // joining the `s.Group("/api", …)` prefix is left to a follow-up. (#747)
+    const goframeRegex = /\btype\s+(\w+)\s+struct\s*\{\s*g\.Meta\s+`([^`]*)`/g;
+    while ((match = goframeRegex.exec(safe)) !== null) {
+      const [, structName, tag] = match;
+      const routePath = /\bpath:"([^"]+)"/.exec(tag!)?.[1];
+      if (!routePath) continue; // a g.Meta without a path: tag is not a route
+      // Keep route node and its controller-method edge together: skip types that
+      // don't follow the `…Req` convention rather than emit an orphan route node.
+      if (!structName!.endsWith('Req')) continue;
+      const methodName = structName!.slice(0, -'Req'.length);
+      if (!methodName) continue;
+      const method = /\bmethod:"([^"]+)"/.exec(tag!)?.[1]?.toUpperCase() ?? 'ANY';
+      const line = safe.slice(0, match.index).split('\n').length;
+
+      const routeNode: Node = {
+        id: `route:${filePath}:${line}:${method}:${routePath}`,
+        kind: 'route',
+        name: `${method} ${routePath}`,
+        qualifiedName: `${filePath}::route:${routePath}`,
+        filePath,
+        startLine: line,
+        endLine: line,
+        startColumn: 0,
+        endColumn: match[0].length,
+        language: 'go',
+        updatedAt: now,
+      };
+      nodes.push(routeNode);
+      references.push({
+        fromNodeId: routeNode.id,
+        referenceName: methodName,
+        referenceKind: 'references',
+        line,
+        column: 0,
+        filePath,
+        language: 'go',
+      });
+    }
+
     return { nodes, references };
   },
 };


### PR DESCRIPTION
Follow-up to #720 (suggestion #3 — structural route coverage, distinct from the ranking fix). Closes #747.

## Why

GoFrame binds routes reflectively, so there's no literal `/chat` string and no call edge from path → controller method:

```go
// api/chat/v1/chat.go — the route lives in a struct tag on the request type
type ChatReq struct {
	g.Meta `path:"/chat" method:"post"`
	Content string `json:"content"`
}
// the handler is the controller method named after the request type (ChatReq -> Chat)
func (c *ControllerV1) Chat(ctx context.Context, req *v1.ChatReq) (*v1.ChatRes, error) { ... }
```

Today "where is this route registered / which method handles it" can only be answered lexically — route-registration symbols have nothing to win on.

## What

Extend `goResolver.extract` (`src/resolution/frameworks/go.ts`) with a GoFrame pass:

- read the `g.Meta` struct tag (`path:` + `method:`, defaulting to `ANY` when `method:` is absent) → a `route` node, identical in shape to the existing Gin/mux route nodes, and
- link that route to the controller method by GoFrame's naming convention (request type with the `Req` suffix dropped, `ChatReq` → `Chat`) via a `references` edge — same shape as the existing route→handler edges.

The route node and its method edge are emitted **together**: a `g.Meta` whose type doesn't follow the `…Req` convention (or has no `path:`) is skipped rather than left as an orphan route node, per the "partial coverage is worse than none" guidance.

## Scope / follow-ups (intentional)

- **Relative path only.** Only the `path:` from the tag is captured (`/chat`), not the `s.Group("/api", …)` prefix that GoFrame prepends. The route node + method edge are still complete and useful; joining the group prefix (cross-file) is a clean follow-up.
- **Method resolution.** The route→method `references` edge resolves through the same name-resolution path as the existing Gin/mux route handlers. There's no GoFrame-specific `resolve()` pattern, so a method name resolves like any PascalCase ref; a dedicated method-kind resolution pattern is possible follow-up hardening (same risk profile as today's route-handler refs).

## Tests

Two unit cases added to `goResolver.extract` in `__tests__/frameworks.test.ts` (mirroring the existing Gin/mux/Rust route-extraction tests): `g.Meta` with `method:"post"` → `POST /chat` + `Chat` edge; method-less `g.Meta` → `ANY /list` + `List` edge. Both assert the edge binds to the route node id.

## Validation

- `npm run build` — clean (tsc).
- `npx vitest run __tests__/frameworks.test.ts` — **96 passed**, no existing route tests broken.
- Verifiable with pure inline-Go string fixtures (the resolver is regex-over-source) — no Go toolchain needed; happy to also run the real small/medium/large GoFrame-repo validation from `codegraph/CLAUDE.md` if you want it in the PR.
