### PR TITLE
fix(installer): instructions block conditional on .codegraph/ — safe in user-scope files

### DIFF
--- a/src/installer/instructions-template.ts
+++ b/src/installer/instructions-template.ts
@@ -29,12 +29,23 @@
 export const CODEGRAPH_SECTION_START = '<!-- CODEGRAPH_START -->';
 export const CODEGRAPH_SECTION_END = '<!-- CODEGRAPH_END -->';
 
-/** The full block, markers included, exactly as written to disk. */
+/**
+ * The full block, markers included, exactly as written to disk.
+ *
+ * The wording is deliberately CONDITIONAL ("in repositories indexed by…"):
+ * a global install writes this into a user-scope file (~/.claude/CLAUDE.md,
+ * ~/.codex/AGENTS.md) that applies to every project the user opens —
+ * including unindexed ones, where an unconditional "this repository is
+ * indexed" claim would send subagents into failing codegraph calls (the
+ * noise the unindexed-session policy exists to prevent).
+ */
 export const CODEGRAPH_INSTRUCTIONS_BLOCK = `${CODEGRAPH_SECTION_START}
 ## CodeGraph
 
-This repository is indexed by CodeGraph — a pre-built code knowledge graph. Reach for it BEFORE grep/find or reading files when you need to understand or locate code:
+In repositories indexed by CodeGraph (a \`.codegraph/\` directory exists at the repo root), reach for it BEFORE grep/find or reading files when you need to understand or locate code:
 
 - **MCP tools** (when available): \`codegraph_explore\` answers most code questions in one call — the relevant symbols' verbatim source plus the call paths between them. \`codegraph_node\` returns one symbol's source + callers, or reads a whole file with line numbers. If the tools are listed but deferred, load them by name via tool search.
 - **Shell** (always works): \`codegraph explore "<symbol names or question>"\` and \`codegraph node <symbol-or-file>\` print the same output.
+
+If there is no \`.codegraph/\` directory, skip CodeGraph entirely — indexing is the user's decision.
 ${CODEGRAPH_SECTION_END}`;


### PR DESCRIPTION
## Summary

Follow-up to #819. The instructions block opened with "This repository is indexed by CodeGraph" — true for project-local installs, **false when a global install writes it into user-scope files** (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.gemini/GEMINI.md`, `~/.config/opencode/AGENTS.md`), where it applies to every repo the user opens. In unindexed repos that claim would push subagents into failing `codegraph` calls — the exact noise the unindexed-session policy (#817) exists to prevent.

The block is now scope-neutral: "In repositories indexed by CodeGraph (a `.codegraph/` directory exists at the repo root) …", with an explicit "if there is no `.codegraph/`, skip CodeGraph entirely — indexing is the user's decision" closer, consistent with the stay-quiet policy everywhere else.

Same `[Unreleased]` feature as #819 — no separate changelog entry. Contract tests: 137/137 (substring assertions unaffected).

Residual risk, stated honestly: the delegation A/B validated the assertive project-scoped wording (4/4 subagent adoption); the conditional form keeps the same active ingredients. Fold a re-check into the next delegation A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)