### PR TITLE
fix(cli): explore/node not-indexed error stops agents from running init themselves

### DIFF
--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -915,7 +915,7 @@ program
 
     try {
       if (!isInitialized(projectPath)) {
-        error(`CodeGraph not initialized in ${projectPath} — run 'codegraph init' first.`);
+        error(`CodeGraph isn't available here — no .codegraph/ index exists in ${projectPath}. If you are an AI agent: continue with your usual tools; indexing is the user's decision, do not run it yourself. (The project owner can enable CodeGraph with 'codegraph init'.)`);
         process.exit(1);
       }
 
@@ -957,7 +957,7 @@ program
 
     try {
       if (!isInitialized(projectPath)) {
-        error(`CodeGraph not initialized in ${projectPath} — run 'codegraph init' first.`);
+        error(`CodeGraph isn't available here — no .codegraph/ index exists in ${projectPath}. If you are an AI agent: continue with your usual tools; indexing is the user's decision, do not run it yourself. (The project owner can enable CodeGraph with 'codegraph init'.)`);
         process.exit(1);
       }
 


### PR DESCRIPTION
Follow-up to #819/#820, closing the last gap in the unindexed-repo defense stack. The CLI's not-indexed error said "run 'codegraph init' first" — an instruction-shaped error inviting an agent (e.g. a subagent that followed the global instructions block into an unindexed repo) to index the project uninvited. Now matches the policy every other layer encodes: continue with your usual tools, indexing is the user's decision, don't run it yourself — with the human path ("the project owner can enable CodeGraph with `codegraph init`") kept in parentheses.

Defense stack for a globally-installed codegraph + unindexed repo, complete:
- MCP main agent: empty tool list + inactive instructions (#817)
- MCP subagent: empty tool list → nothing in the deferred registry to load
- Instructions block: conditional on `.codegraph/` existing + explicit skip line (#820)
- CLI: one clean failing call that tells the agent to stay out (this PR)

Full suite: 1428 passed | 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)