### PR TITLE
fix(cli): codegraph node accepts Windows backslash paths in file mode

### DIFF
--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -968,12 +968,15 @@ program
 
       // A name with a path separator is a file read; otherwise a symbol
       // (use --file for basename-only file reads or to pin an overload).
+      // Both separators: Windows users type src\auth\session.ts. Symbols
+      // never contain either ('/' isn't an identifier char anywhere we
+      // index; C++ scope is '::', JS members '.').
       const args: Record<string, unknown> = {};
       if (options.file) {
         args.file = options.file;
         if (name && name !== options.file) args.symbol = name;
-      } else if (name.includes('/')) {
-        args.file = name;
+      } else if (name.includes('/') || name.includes('\\')) {
+        args.file = name.replace(/\\/g, '/');
       } else {
         args.symbol = name;
         args.includeCode = true;


### PR DESCRIPTION
The new `codegraph node` file-vs-symbol heuristic only matched `/` — on Windows, `codegraph node src\auth\session.ts` fell through to symbol mode and found nothing. Both separators now route to file mode, normalized to forward slashes (the form the index stores internally). Symbols never contain either separator in any indexed language (C++ scope is `::`, JS members `.`).

Cross-platform validation of the new CLI commands (`explore` + `node`, from #819):
- **macOS**: smoke pass — explore content, node symbol mode, node file mode, unindexed clean refusal (exit 1, stay-out wording)
- **Linux** (node:22-bookworm, `--init`): same smoke pass + full suite **1428 passed | 2 skipped** + installer/mcp-unindexed/allowlist suites 151/151
- **Windows**: queued — the Parallels guest is unreachable (VM reports running, 100% packet loss; restart commands are Pro-gated). Will run the smoke + suite there once the VM is manually started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)