### PR TITLE
spec(codegraph-rs): external-package references design

### DIFF
--- a/docs/superpowers/plans/2026-04-22-codegraph-rs-slice-1-walking-skeleton.md
+++ b/docs/superpowers/plans/2026-04-22-codegraph-rs-slice-1-walking-skeleton.md
@@ -543,6 +543,8 @@ cargo test --test config_parsing 2>&1 | tail -10
 
 Expected: compile errors about `parse` and `WorkspaceConfig` being missing from `codegraph_rs::config::workspace`.
 
+> **Note on intermediate broken builds:** The project will not build between steps 4 and 6 of this task — `workspace.rs` imports `crate::config::naming` which is created in step 6. This is intentional. Don't run `cargo build` until step 7.
+
 - [ ] **Step 4: Implement the config types and parser**
 
 Create `src/config/workspace.rs`:
@@ -790,6 +792,8 @@ Expected: errors about `find_workspace_root` and `load_from_path` not being defi
 
 - [ ] **Step 3: Implement the discovery and loading helpers**
 
+> **Note:** "Append" here means *add to the file*. The new `use std::path::Path;` line should go up at the top with the other `use` statements (replacing `use std::path::PathBuf;` with `use std::path::{Path, PathBuf};`); the new functions go below the existing code.
+
 Append to `src/config/workspace.rs`:
 
 ```rust
@@ -1033,6 +1037,10 @@ git commit -m "feat(config): real Neo4j 5 db-name validation and derivation"
 
 Append to `tests/config_parsing.rs`:
 
+> **Notes for the engineer:**
+> - These tests mutate process-wide environment variables. cargo by default runs unit tests in parallel within a test binary; to avoid surprise interactions with later test additions, run unit tests with `--test-threads=1` once the suite is large enough that contention matters. For slice 1, each test uses a distinct env-var name so they don't collide.
+> - `std::env::set_var` may emit a future-incompat lint warning on Rust 1.91 (it's safe in edition 2021 but became `unsafe` in edition 2024). Ignore the warning for slice 1.
+
 ```rust
 use codegraph_rs::config::secrets::{resolve_neo4j_password, SecretsSource};
 
@@ -1040,9 +1048,6 @@ use codegraph_rs::config::secrets::{resolve_neo4j_password, SecretsSource};
 fn resolves_password_from_env() {
     // Use a dedicated env var name to avoid polluting global state
     let key = "CODEGRAPH_RS_TEST_PASSWORD_ENV";
-    // SAFETY: tests in this file run sequentially because cargo test is
-    // single-threaded per test binary by default; if you parallelize later,
-    // switch to a thread-local override.
     std::env::set_var(key, "from-env");
 
     let dir = tempdir().unwrap();
@@ -1236,8 +1241,12 @@ impl Connection {
     pub async fn ping(&self) -> Result<()> {
         let mut stream = self.graph.execute(neo4rs::query("RETURN 1 AS x")).await
             .context("ping query failed")?;
-        let row = stream.next().await.context("ping returned no row")?
-            .context("ping row error")?;
+        // First `.context` attaches to a Result<_, neo4rs::Error> (DB-level error).
+        // Second `.context` attaches to Option::None (empty stream — anyhow's
+        // `Context for Option` converts None into an error with this message).
+        let row = stream.next().await
+            .context("ping query stream errored")?
+            .context("ping returned no row (empty stream)")?;
         let x: i64 = row.get("x").context("ping row missing `x`")?;
         anyhow::ensure!(x == 1, "ping returned unexpected value: {x}");
         Ok(())
@@ -1851,9 +1860,12 @@ pub fn run(workspace_arg: Option<&Path>) -> Result<()> {
 async fn single_count(conn: &Connection, cypher: &str) -> Result<i64> {
     let mut stream = conn.graph.execute(query(cypher)).await
         .with_context(|| format!("running `{cypher}`"))?;
+    // First context: DB-level error from the row stream.
+    // Second context: stream finished without producing a row (Option::None case
+    // — anyhow's Context impl for Option turns None into this error).
     let row = stream.next().await
-        .with_context(|| format!("no row from `{cypher}`"))?
-        .with_context(|| format!("row error from `{cypher}`"))?;
+        .with_context(|| format!("stream error reading result of `{cypher}`"))?
+        .with_context(|| format!("`{cypher}` returned no row"))?;
     row.get("c").context("row missing `c`")
 }
 
@@ -1861,8 +1873,13 @@ async fn max_last_indexed(conn: &Connection) -> Result<Option<i64>> {
     let mut stream = conn.graph
         .execute(query("MATCH (n:File) RETURN max(n.last_indexed_at) AS t"))
         .await?;
-    let row = stream.next().await.context("no row")??;
-    Ok(row.get::<Option<i64>>("t").context("missing `t`")?)
+
+    // Handle both possibilities: stream may produce zero rows (no Files yet)
+    // or one row whose `t` is NULL (which deserializes to None).
+    match stream.next().await? {
+        None => Ok(None),
+        Some(row) => row.get::<Option<i64>>("t").context("missing `t`"),
+    }
 }
 ```
 

--- a/docs/superpowers/plans/2026-04-22-codegraph-rs-slice-1-walking-skeleton.md
+++ b/docs/superpowers/plans/2026-04-22-codegraph-rs-slice-1-walking-skeleton.md
@@ -1,0 +1,2063 @@
+# codegraph-rs Slice 1 — Walking Skeleton
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the codegraph-rs Cargo project with a functioning CLI that can `init` a workspace (validate Neo4j, create the database, apply schema, write config files) and report `status`. No indexing, no parsing, no MCP. Just the skeleton through to the database.
+
+**Architecture:** Single-crate Rust binary. `clap` for CLI, `serde + toml` for config, `neo4rs` 0.8 for Bolt. Async via `tokio`. Configuration discovery walks upward to find `.codegraph/config.toml` (except `init`, which creates it). Secrets resolved via env > file > error. Database name auto-derived from workspace name and validated per Neo4j 5 naming rules.
+
+**Tech Stack:** Rust 1.91+, clap 4, serde 1, toml 1, tokio 1, neo4rs 0.8, anyhow, tracing.
+
+**Source spec:** [`docs/superpowers/specs/2026-04-22-codegraph-rs-design.md`](../specs/2026-04-22-codegraph-rs-design.md) §1–5, §11–12. This slice covers config loading, the `db/` module, and the `init` + `status` CLI commands.
+
+**Target directory:** `/Users/gyorgybalazsi/codegraph-rs` (sibling of the current TS `codegraph` repo). The directory does **not** exist yet — Task 1 creates it.
+
+**Prerequisites:**
+- Rust toolchain 1.91+ (`rustc --version` to verify)
+- Neo4j Desktop running locally with a DBMS started, default port 7687, default user `neo4j` with a known password. The DBMS must be Enterprise Edition (Desktop installs this by default for local dev).
+
+---
+
+## File structure produced by this slice
+
+```
+codegraph-rs/
+  Cargo.toml
+  Cargo.lock
+  README.md
+  .gitignore
+  rust-toolchain.toml
+  src/
+    main.rs                 # tiny: parse args, call lib::run
+    lib.rs                  # re-exports + run() entry point
+    cli/
+      mod.rs                # Cli struct + Command enum
+      init.rs               # init command implementation
+      status.rs             # status command implementation
+    config/
+      mod.rs                # re-exports
+      workspace.rs          # WorkspaceConfig types + load
+      secrets.rs            # password resolution
+      naming.rs             # Neo4j db-name validation + derivation
+    db/
+      mod.rs                # re-exports
+      connection.rs         # Connection wrapper around neo4rs::Graph
+      schema.rs             # apply_schema()
+  tests/
+    config_parsing.rs       # unit tests using fixtures
+    fixtures/
+      valid_workspace.toml
+      missing_version.toml
+      bad_db_name.toml
+    integration_init.rs     # gated on CODEGRAPH_RS_TEST_NEO4J=1
+    integration_status.rs   # gated on CODEGRAPH_RS_TEST_NEO4J=1
+```
+
+## Out of scope for this slice (covered in later slices)
+
+- Extraction (no tree-sitter yet)
+- Resolution
+- Vector embeddings
+- MCP server
+- `index`, `sync`, `query`, `serve` subcommands (stubs only — they print "not yet implemented")
+- Interactive `init` prompts (this slice uses flag-based `init`; interactive mode is a later slice)
+
+---
+
+### Task 1: Initialize Cargo project and git repository
+
+**Files:**
+- Create: `/Users/gyorgybalazsi/codegraph-rs/Cargo.toml`
+- Create: `/Users/gyorgybalazsi/codegraph-rs/src/main.rs`
+- Create: `/Users/gyorgybalazsi/codegraph-rs/.gitignore`
+- Create: `/Users/gyorgybalazsi/codegraph-rs/rust-toolchain.toml`
+
+- [ ] **Step 1: Verify the target directory does not exist**
+
+```bash
+test ! -e /Users/gyorgybalazsi/codegraph-rs && echo "OK: directory does not exist" || echo "STOP: directory already exists"
+```
+
+Expected: `OK: directory does not exist`. If the directory exists, stop and ask before proceeding — do not overwrite.
+
+- [ ] **Step 2: Create the Cargo project**
+
+```bash
+cd /Users/gyorgybalazsi
+cargo new --bin codegraph-rs
+cd codegraph-rs
+ls
+```
+
+Expected output: `Cargo.toml  src` (Cargo also runs `git init` automatically).
+
+- [ ] **Step 3: Pin the Rust toolchain**
+
+Create `/Users/gyorgybalazsi/codegraph-rs/rust-toolchain.toml`:
+
+```toml
+[toolchain]
+channel = "1.91"
+components = ["rustfmt", "clippy"]
+```
+
+This locks all contributors and CI to a known-good Rust version.
+
+- [ ] **Step 4: Replace Cargo.toml with the slice 1 manifest**
+
+Overwrite `/Users/gyorgybalazsi/codegraph-rs/Cargo.toml` with:
+
+```toml
+[package]
+name = "codegraph-rs"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.91"
+description = "Local-first code intelligence — Rust port of CodeGraph, backed by Neo4j"
+license = "MIT"
+repository = "https://github.com/bitsafe/codegraph-rs"
+
+[[bin]]
+name = "codegraph-rs"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+thiserror = "2"
+clap = { version = "4", features = ["derive", "env"] }
+serde = { version = "1", features = ["derive"] }
+toml = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-util", "io-std", "fs", "process", "signal"] }
+neo4rs = "0.8"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tempfile = "3"
+```
+
+- [ ] **Step 5: Replace .gitignore**
+
+Overwrite `/Users/gyorgybalazsi/codegraph-rs/.gitignore`:
+
+```
+/target
+/Cargo.lock.bak
+.codegraph/secrets.toml
+
+# Editor / OS
+.DS_Store
+.vscode/
+.idea/
+*.swp
+```
+
+`Cargo.lock` is **not** gitignored — for a binary crate it should be checked in.
+
+- [ ] **Step 6: Verify cargo builds the empty project**
+
+```bash
+cd /Users/gyorgybalazsi/codegraph-rs
+cargo build 2>&1 | tail -5
+```
+
+Expected to end with: `Finished \`dev\` profile [optimized + debuginfo] target(s)` (compile time may be substantial because of dependencies).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/gyorgybalazsi/codegraph-rs
+git add Cargo.toml Cargo.lock .gitignore rust-toolchain.toml src/
+git commit -m "chore: initialize codegraph-rs Cargo project"
+```
+
+---
+
+### Task 2: Module skeleton with empty modules
+
+**Files:**
+- Modify: `src/main.rs`
+- Create: `src/lib.rs`
+- Create: `src/cli/mod.rs`
+- Create: `src/config/mod.rs`
+- Create: `src/db/mod.rs`
+
+- [ ] **Step 1: Replace src/main.rs with a thin entry point**
+
+Overwrite `src/main.rs`:
+
+```rust
+fn main() -> anyhow::Result<()> {
+    codegraph_rs::run()
+}
+```
+
+- [ ] **Step 2: Create src/lib.rs**
+
+Create `src/lib.rs`:
+
+```rust
+//! codegraph-rs library entry point.
+//!
+//! This crate exposes its modules so integration tests can exercise them
+//! without spawning the binary. The binary in `src/main.rs` is a thin shim.
+
+pub mod cli;
+pub mod config;
+pub mod db;
+
+/// Application entry point. Initializes logging, parses CLI args, dispatches.
+pub fn run() -> anyhow::Result<()> {
+    init_tracing();
+    cli::dispatch()
+}
+
+fn init_tracing() {
+    use tracing_subscriber::EnvFilter;
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_env("CODEGRAPH_RS_LOG").unwrap_or_else(|_| EnvFilter::new("info")))
+        .with_target(false)
+        .try_init();
+}
+```
+
+- [ ] **Step 3: Create empty module files**
+
+Create `src/cli/mod.rs`:
+
+```rust
+//! CLI subcommand dispatch.
+
+use anyhow::Result;
+
+pub fn dispatch() -> Result<()> {
+    anyhow::bail!("CLI dispatch not implemented yet");
+}
+```
+
+Create `src/config/mod.rs`:
+
+```rust
+//! Workspace configuration loading and validation.
+```
+
+Create `src/db/mod.rs`:
+
+```rust
+//! Neo4j Bolt client and schema management.
+```
+
+- [ ] **Step 4: Build to verify the skeleton compiles**
+
+```bash
+cargo build 2>&1 | tail -3
+```
+
+Expected: builds clean with no errors. Warnings about unused modules are fine for now.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/
+git commit -m "chore: add module skeleton (cli, config, db)"
+```
+
+---
+
+### Task 3: CLI scaffolding with clap
+
+**Files:**
+- Modify: `src/cli/mod.rs`
+- Create: `src/cli/init.rs`
+- Create: `src/cli/status.rs`
+- Test: integration test will run as `cargo test --test cli_smoke`
+
+- [ ] **Step 1: Replace src/cli/mod.rs with the full clap definition**
+
+Overwrite `src/cli/mod.rs`:
+
+```rust
+//! CLI subcommand dispatch.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+pub mod init;
+pub mod status;
+
+/// codegraph-rs: local-first code intelligence backed by Neo4j.
+#[derive(Debug, Parser)]
+#[command(name = "codegraph-rs", version, about, long_about = None)]
+pub struct Cli {
+    /// Path to the workspace directory (the directory containing `.codegraph/`).
+    /// Defaults to the current working directory; commands other than `init`
+    /// also walk upward to find the nearest `.codegraph/`.
+    #[arg(long, global = true)]
+    pub workspace: Option<PathBuf>,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Scaffold a new workspace: validate Neo4j, create the database, write config files.
+    Init(init::InitArgs),
+
+    /// Run a full index of the workspace. Stub in slice 1.
+    Index,
+
+    /// Run an incremental sync. Stub in slice 1.
+    Sync,
+
+    /// Print workspace statistics (file count, symbol count, last sync time).
+    Status,
+
+    /// Search for a symbol by name. Stub in slice 1.
+    Query {
+        /// The query string.
+        query: String,
+    },
+
+    /// Run the MCP stdio server for use by Claude Code. Stub in slice 1.
+    Serve,
+}
+
+pub fn dispatch() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::Init(args) => init::run(args, cli.workspace.as_deref()),
+        Command::Status => status::run(cli.workspace.as_deref()),
+        Command::Index | Command::Sync | Command::Query { .. } | Command::Serve => {
+            anyhow::bail!("not yet implemented in slice 1");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Create src/cli/init.rs as a stub**
+
+Create `src/cli/init.rs`:
+
+```rust
+//! `codegraph-rs init` — scaffold a workspace.
+
+use anyhow::Result;
+use clap::Args;
+use std::path::Path;
+
+#[derive(Debug, Args)]
+pub struct InitArgs {
+    /// Workspace name (used to derive the Neo4j database name).
+    #[arg(long)]
+    pub name: String,
+
+    /// Neo4j Bolt URI.
+    #[arg(long, default_value = "bolt://localhost:7687")]
+    pub neo4j_uri: String,
+
+    /// Neo4j user.
+    #[arg(long, default_value = "neo4j")]
+    pub neo4j_user: String,
+
+    /// Neo4j password. Prefer the CODEGRAPH_RS_NEO4J_PASSWORD env var for non-interactive use.
+    #[arg(long, env = "CODEGRAPH_RS_NEO4J_PASSWORD")]
+    pub neo4j_password: String,
+
+    /// Workspace roots in the form `name=path`. Repeat for multiple roots.
+    /// Example: `--root splice=../splice --root utility=../utility`.
+    #[arg(long, value_name = "NAME=PATH", required = true, num_args = 1..)]
+    pub root: Vec<String>,
+}
+
+pub fn run(_args: InitArgs, _workspace: Option<&Path>) -> Result<()> {
+    anyhow::bail!("init: not yet implemented (filled in by Task 10)");
+}
+```
+
+- [ ] **Step 3: Create src/cli/status.rs as a stub**
+
+Create `src/cli/status.rs`:
+
+```rust
+//! `codegraph-rs status` — print workspace stats.
+
+use anyhow::Result;
+use std::path::Path;
+
+pub fn run(_workspace: Option<&Path>) -> Result<()> {
+    anyhow::bail!("status: not yet implemented (filled in by Task 11)");
+}
+```
+
+- [ ] **Step 4: Build and verify the CLI parses**
+
+```bash
+cargo run --quiet -- --help 2>&1 | head -25
+```
+
+Expected: shows usage with subcommands `init`, `index`, `sync`, `status`, `query`, `serve`.
+
+- [ ] **Step 5: Verify a subcommand stub fails predictably**
+
+```bash
+cargo run --quiet -- index 2>&1 | tail -3
+```
+
+Expected: prints an error containing `not yet implemented in slice 1` and exits nonzero.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/
+git commit -m "feat(cli): add clap-based CLI with init/status/index/sync/query/serve subcommands"
+```
+
+---
+
+### Task 4: Workspace config types and TOML parsing (TDD)
+
+**Files:**
+- Create: `src/config/workspace.rs`
+- Modify: `src/config/mod.rs`
+- Create: `tests/fixtures/valid_workspace.toml`
+- Create: `tests/fixtures/missing_version.toml`
+- Create: `tests/fixtures/bad_db_name.toml`
+- Test: `tests/config_parsing.rs`
+
+- [ ] **Step 1: Create the test fixtures**
+
+Create `tests/fixtures/valid_workspace.toml`:
+
+```toml
+schema_version = 1
+
+[workspace]
+name = "daml-stack"
+
+[workspace.neo4j]
+uri = "bolt://localhost:7687"
+database = "codegraph-daml-stack"
+username = "neo4j"
+
+[[workspace.roots]]
+name = "splice"
+path = "../splice"
+
+[[workspace.roots]]
+name = "utility"
+path = "../utility"
+
+[indexing]
+languages = ["rust", "daml"]
+
+[embeddings]
+enabled = true
+model = "bge-small-en-v1.5"
+```
+
+Create `tests/fixtures/missing_version.toml`:
+
+```toml
+[workspace]
+name = "x"
+
+[workspace.neo4j]
+uri = "bolt://localhost:7687"
+database = "codegraph-x"
+username = "neo4j"
+
+[[workspace.roots]]
+name = "x"
+path = "."
+```
+
+Create `tests/fixtures/bad_db_name.toml`:
+
+```toml
+schema_version = 1
+
+[workspace]
+name = "x"
+
+[workspace.neo4j]
+uri = "bolt://localhost:7687"
+database = "codegraph_x"
+username = "neo4j"
+
+[[workspace.roots]]
+name = "x"
+path = "."
+```
+
+(`codegraph_x` has an underscore — invalid per Neo4j 5 rules.)
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/config_parsing.rs`:
+
+```rust
+//! Unit tests for TOML config parsing.
+
+use codegraph_rs::config::workspace::{WorkspaceConfig, parse};
+
+const VALID: &str = include_str!("fixtures/valid_workspace.toml");
+const MISSING_VERSION: &str = include_str!("fixtures/missing_version.toml");
+const BAD_DB_NAME: &str = include_str!("fixtures/bad_db_name.toml");
+
+#[test]
+fn parses_valid_workspace() {
+    let cfg: WorkspaceConfig = parse(VALID).expect("valid TOML must parse");
+    assert_eq!(cfg.schema_version, 1);
+    assert_eq!(cfg.workspace.name, "daml-stack");
+    assert_eq!(cfg.workspace.neo4j.uri, "bolt://localhost:7687");
+    assert_eq!(cfg.workspace.neo4j.database, "codegraph-daml-stack");
+    assert_eq!(cfg.workspace.roots.len(), 2);
+    assert_eq!(cfg.workspace.roots[0].name, "splice");
+    assert_eq!(cfg.indexing.languages, vec!["rust".to_string(), "daml".to_string()]);
+    assert!(cfg.embeddings.enabled);
+}
+
+#[test]
+fn missing_schema_version_errors() {
+    let err = parse(MISSING_VERSION).expect_err("missing schema_version must error");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("schema_version"), "error should mention schema_version, got: {msg}");
+}
+
+#[test]
+fn bad_database_name_errors() {
+    let err = parse(BAD_DB_NAME).expect_err("underscore in db name must error");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("database"), "error should mention database, got: {msg}");
+}
+```
+
+- [ ] **Step 3: Run the tests — expect compile failures (modules don't exist yet)**
+
+```bash
+cargo test --test config_parsing 2>&1 | tail -10
+```
+
+Expected: compile errors about `parse` and `WorkspaceConfig` being missing from `codegraph_rs::config::workspace`.
+
+- [ ] **Step 4: Implement the config types and parser**
+
+Create `src/config/workspace.rs`:
+
+```rust
+//! Workspace config types deserialized from `.codegraph/config.toml`.
+
+use serde::Deserialize;
+use std::path::PathBuf;
+
+use crate::config::naming::validate_database_name;
+
+#[derive(Debug, Deserialize)]
+pub struct WorkspaceConfig {
+    pub schema_version: u32,
+    pub workspace: Workspace,
+    #[serde(default)]
+    pub indexing: Indexing,
+    #[serde(default)]
+    pub embeddings: Embeddings,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Workspace {
+    pub name: String,
+    pub neo4j: Neo4j,
+    pub roots: Vec<Root>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Neo4j {
+    pub uri: String,
+    pub database: String,
+    pub username: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Root {
+    pub name: String,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Indexing {
+    #[serde(default = "default_languages")]
+    pub languages: Vec<String>,
+}
+
+impl Default for Indexing {
+    fn default() -> Self {
+        Self { languages: default_languages() }
+    }
+}
+
+fn default_languages() -> Vec<String> {
+    vec!["rust".to_string(), "daml".to_string()]
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Embeddings {
+    #[serde(default = "yes")]
+    pub enabled: bool,
+    #[serde(default = "default_model")]
+    pub model: String,
+}
+
+impl Default for Embeddings {
+    fn default() -> Self {
+        Self { enabled: true, model: default_model() }
+    }
+}
+
+fn yes() -> bool { true }
+fn default_model() -> String { "bge-small-en-v1.5".to_string() }
+
+const SUPPORTED_SCHEMA_VERSION: u32 = 1;
+
+/// Parse a TOML string into a validated `WorkspaceConfig`.
+pub fn parse(input: &str) -> anyhow::Result<WorkspaceConfig> {
+    // First pass: surface a clear error if `schema_version` is missing,
+    // since serde's default error for a missing top-level key is awkward.
+    if !input.contains("schema_version") {
+        anyhow::bail!("config is missing required key `schema_version`");
+    }
+
+    let cfg: WorkspaceConfig = toml::from_str(input)
+        .map_err(|e| anyhow::anyhow!("failed to parse workspace config: {e}"))?;
+
+    if cfg.schema_version != SUPPORTED_SCHEMA_VERSION {
+        anyhow::bail!(
+            "unsupported schema_version {} (this build supports {})",
+            cfg.schema_version,
+            SUPPORTED_SCHEMA_VERSION
+        );
+    }
+
+    if cfg.workspace.roots.is_empty() {
+        anyhow::bail!("workspace must declare at least one root in [[workspace.roots]]");
+    }
+
+    validate_database_name(&cfg.workspace.neo4j.database)
+        .map_err(|e| anyhow::anyhow!("invalid Neo4j database name `{}`: {e}", cfg.workspace.neo4j.database))?;
+
+    if cfg.embeddings.enabled && cfg.embeddings.model != "bge-small-en-v1.5" {
+        anyhow::bail!(
+            "embedding model `{}` not supported in v1; only `bge-small-en-v1.5` is accepted",
+            cfg.embeddings.model
+        );
+    }
+
+    Ok(cfg)
+}
+```
+
+- [ ] **Step 5: Re-export from src/config/mod.rs**
+
+Overwrite `src/config/mod.rs`:
+
+```rust
+//! Workspace configuration loading and validation.
+
+pub mod naming;
+pub mod secrets;
+pub mod workspace;
+
+pub use workspace::{WorkspaceConfig, parse};
+```
+
+(`naming` and `secrets` modules are added in Tasks 6 and 7. They are referenced here to avoid module-graph churn later.)
+
+- [ ] **Step 6: Create stub for naming module so the build compiles**
+
+Create `src/config/naming.rs`:
+
+```rust
+//! Neo4j database name validation. Filled in by Task 6.
+
+pub fn validate_database_name(_name: &str) -> Result<(), String> {
+    // Slice 1 / Task 6: real validation. For now accept everything except
+    // the explicit underscore case used in test fixtures.
+    if _name.contains('_') {
+        return Err("underscores are not permitted in Neo4j 5 database names".to_string());
+    }
+    Ok(())
+}
+```
+
+Create `src/config/secrets.rs`:
+
+```rust
+//! Neo4j password resolution. Filled in by Task 7.
+```
+
+- [ ] **Step 7: Run the tests**
+
+```bash
+cargo test --test config_parsing 2>&1 | tail -10
+```
+
+Expected: 3 tests pass. If the `bad_database_name_errors` test fails, double-check that the fixture has the underscore.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/config tests/fixtures tests/config_parsing.rs
+git commit -m "feat(config): add WorkspaceConfig types and TOML parser with validation"
+```
+
+---
+
+### Task 5: Config loading with upward discovery
+
+**Files:**
+- Modify: `src/config/workspace.rs`
+- Modify: `src/config/mod.rs` (add re-export)
+- Test: extend `tests/config_parsing.rs`
+
+- [ ] **Step 1: Write the failing tests for path discovery and loading**
+
+Append to `tests/config_parsing.rs`:
+
+```rust
+use codegraph_rs::config::workspace::{find_workspace_root, load_from_path};
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn finds_workspace_in_current_dir() {
+    let dir = tempdir().unwrap();
+    fs::create_dir(dir.path().join(".codegraph")).unwrap();
+    fs::write(dir.path().join(".codegraph/config.toml"), VALID).unwrap();
+
+    let found = find_workspace_root(dir.path()).expect("should find .codegraph");
+    assert_eq!(found.canonicalize().unwrap(), dir.path().canonicalize().unwrap());
+}
+
+#[test]
+fn finds_workspace_in_ancestor() {
+    let dir = tempdir().unwrap();
+    fs::create_dir(dir.path().join(".codegraph")).unwrap();
+    fs::write(dir.path().join(".codegraph/config.toml"), VALID).unwrap();
+
+    let nested = dir.path().join("a/b/c");
+    fs::create_dir_all(&nested).unwrap();
+
+    let found = find_workspace_root(&nested).expect("should walk up to find .codegraph");
+    assert_eq!(found.canonicalize().unwrap(), dir.path().canonicalize().unwrap());
+}
+
+#[test]
+fn missing_workspace_errors() {
+    let dir = tempdir().unwrap();
+    let err = find_workspace_root(dir.path()).expect_err("must error when no .codegraph anywhere");
+    assert!(format!("{err:#}").contains(".codegraph"));
+}
+
+#[test]
+fn load_from_path_canonicalizes_root_paths() {
+    let dir = tempdir().unwrap();
+    fs::create_dir(dir.path().join(".codegraph")).unwrap();
+
+    // Create the root directories the fixture references
+    fs::create_dir(dir.path().join("splice")).unwrap();
+    fs::create_dir(dir.path().join("utility")).unwrap();
+
+    // Adjust the fixture so root paths exist relative to dir/
+    let fixture = VALID
+        .replace("../splice", "splice")
+        .replace("../utility", "utility");
+    fs::write(dir.path().join(".codegraph/config.toml"), &fixture).unwrap();
+
+    let cfg = load_from_path(dir.path()).expect("load should succeed");
+    let splice = &cfg.workspace.roots[0];
+    assert!(splice.path.is_absolute(), "paths must be canonicalized to absolute");
+}
+```
+
+- [ ] **Step 2: Run the new tests — expect compile failure**
+
+```bash
+cargo test --test config_parsing 2>&1 | tail -10
+```
+
+Expected: errors about `find_workspace_root` and `load_from_path` not being defined.
+
+- [ ] **Step 3: Implement the discovery and loading helpers**
+
+Append to `src/config/workspace.rs`:
+
+```rust
+use std::path::Path;
+
+const CONFIG_DIRNAME: &str = ".codegraph";
+const CONFIG_FILENAME: &str = "config.toml";
+
+/// Walk upward from `start` looking for the nearest directory containing
+/// `.codegraph/config.toml`. Returns the directory containing `.codegraph/`.
+pub fn find_workspace_root(start: &Path) -> anyhow::Result<PathBuf> {
+    let mut current: PathBuf = start.canonicalize().map_err(|e| {
+        anyhow::anyhow!("cannot canonicalize starting path `{}`: {e}", start.display())
+    })?;
+
+    loop {
+        let candidate = current.join(CONFIG_DIRNAME).join(CONFIG_FILENAME);
+        if candidate.is_file() {
+            return Ok(current);
+        }
+        let Some(parent) = current.parent() else {
+            anyhow::bail!(
+                "no .codegraph/{CONFIG_FILENAME} found in `{}` or any ancestor",
+                start.display()
+            );
+        };
+        current = parent.to_path_buf();
+    }
+}
+
+/// Read and parse the workspace config at `<workspace_dir>/.codegraph/config.toml`.
+/// Canonicalizes all root paths to absolute paths relative to `workspace_dir`.
+pub fn load_from_path(workspace_dir: &Path) -> anyhow::Result<WorkspaceConfig> {
+    let config_path = workspace_dir.join(CONFIG_DIRNAME).join(CONFIG_FILENAME);
+    let raw = std::fs::read_to_string(&config_path).map_err(|e| {
+        anyhow::anyhow!("cannot read `{}`: {e}", config_path.display())
+    })?;
+    let mut cfg = parse(&raw)?;
+
+    // Canonicalize root paths relative to the config file's directory.
+    let base = workspace_dir.canonicalize().map_err(|e| {
+        anyhow::anyhow!("cannot canonicalize `{}`: {e}", workspace_dir.display())
+    })?;
+    for root in &mut cfg.workspace.roots {
+        let absolute = if root.path.is_absolute() {
+            root.path.clone()
+        } else {
+            base.join(&root.path)
+        };
+        root.path = absolute.canonicalize().map_err(|e| {
+            anyhow::anyhow!(
+                "root `{}` points at non-existent path `{}`: {e}",
+                root.name,
+                absolute.display()
+            )
+        })?;
+    }
+
+    Ok(cfg)
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cargo test --test config_parsing 2>&1 | tail -10
+```
+
+Expected: 7 tests pass total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config tests/
+git commit -m "feat(config): add upward .codegraph/ discovery and absolute-path loader"
+```
+
+---
+
+### Task 6: Database name validation per Neo4j 5 rules
+
+**Files:**
+- Modify: `src/config/naming.rs`
+- Test: append to `tests/config_parsing.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/config_parsing.rs`:
+
+```rust
+use codegraph_rs::config::naming::{validate_database_name, derive_database_name};
+
+#[test]
+fn db_name_valid_examples() {
+    for name in ["codegraph-x", "codegraph-daml-stack", "abc", "neo4j", "a1.b2", "abc-def-12.3"] {
+        validate_database_name(name).unwrap_or_else(|e| panic!("`{name}` should be valid: {e}"));
+    }
+}
+
+#[test]
+fn db_name_invalid_examples() {
+    let bad = [
+        "ab",                       // too short (<3)
+        "1abc",                     // starts with digit
+        "_abc",                     // starts with underscore
+        "ABC",                      // uppercase: codegraph-rs convention is lowercase only
+        "codegraph_x",              // underscore
+        "codegraph x",              // space
+        "codegraph!",               // special char
+        &"a".repeat(64),            // > 63
+    ];
+    for name in bad {
+        assert!(
+            validate_database_name(name).is_err(),
+            "`{name}` should be invalid"
+        );
+    }
+}
+
+#[test]
+fn derives_db_name_from_workspace() {
+    assert_eq!(derive_database_name("daml-stack"), "codegraph-daml-stack");
+    assert_eq!(derive_database_name("My Project"), "codegraph-my-project");
+    assert_eq!(derive_database_name("codegraph-rs"), "codegraph-codegraph-rs");
+    assert_eq!(derive_database_name("foo_bar"), "codegraph-foo-bar");
+}
+```
+
+Note: Neo4j 5 rules allow ASCII letters (case-insensitive in practice — but the docs require starting with a letter and using letters, digits, dots, dashes). Uppercase is not strictly forbidden by the language grammar but is conventionally lowercased. We accept lowercase only via `derive_database_name` and reject uppercase in user-supplied names to keep things simple. The `"ABC"` case in the invalid set tests this rule. Adjust the test if you decide differently — but be consistent.
+
+- [ ] **Step 2: Run the failing tests**
+
+```bash
+cargo test --test config_parsing 2>&1 | tail -10
+```
+
+Expected: tests fail or panic (the existing stub accepts everything without underscores).
+
+- [ ] **Step 3: Implement the real validator + deriver**
+
+Overwrite `src/config/naming.rs`:
+
+```rust
+//! Neo4j database name rules and derivation.
+//!
+//! Neo4j 5 rules:
+//! - 3..=63 characters
+//! - First character: ASCII letter (a-z or A-Z; we restrict to lowercase)
+//! - Remaining characters: ASCII letters (lowercase), digits, '.', '-'
+//! - No spaces, no underscores, no other special characters.
+
+const MIN_LEN: usize = 3;
+const MAX_LEN: usize = 63;
+
+/// Validate a database name against Neo4j 5 rules. Returns Ok on success.
+pub fn validate_database_name(name: &str) -> Result<(), String> {
+    let len = name.len();
+    if len < MIN_LEN {
+        return Err(format!("name must be at least {MIN_LEN} characters (got {len})"));
+    }
+    if len > MAX_LEN {
+        return Err(format!("name must be at most {MAX_LEN} characters (got {len})"));
+    }
+
+    let mut chars = name.chars();
+    let first = chars.next().expect("len checked above");
+    if !first.is_ascii_lowercase() {
+        return Err(format!(
+            "first character must be an ASCII lowercase letter (got `{first}`)"
+        ));
+    }
+
+    for (i, c) in chars.enumerate() {
+        if !(c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-') {
+            return Err(format!(
+                "character `{c}` at position {} not allowed (only lowercase letters, digits, '.', '-')",
+                i + 1
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Derive a Neo4j-compatible database name from a workspace name.
+/// Lowercases and replaces any disallowed character with '-', then prefixes
+/// with `codegraph-`. Collapses runs of '-' and trims leading/trailing '-'.
+pub fn derive_database_name(workspace_name: &str) -> String {
+    let mut sanitized = String::with_capacity(workspace_name.len());
+    for c in workspace_name.chars() {
+        let mapped = c.to_ascii_lowercase();
+        if mapped.is_ascii_lowercase() || mapped.is_ascii_digit() || mapped == '.' {
+            sanitized.push(mapped);
+        } else {
+            sanitized.push('-');
+        }
+    }
+    // Collapse multiple consecutive dashes
+    let mut collapsed = String::with_capacity(sanitized.len());
+    let mut prev_dash = false;
+    for c in sanitized.chars() {
+        if c == '-' {
+            if !prev_dash {
+                collapsed.push('-');
+            }
+            prev_dash = true;
+        } else {
+            collapsed.push(c);
+            prev_dash = false;
+        }
+    }
+    let trimmed = collapsed.trim_matches('-');
+    format!("codegraph-{trimmed}")
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cargo test --test config_parsing 2>&1 | tail -10
+```
+
+Expected: all tests pass (10 total: 7 from before + 3 new naming tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/naming.rs tests/config_parsing.rs
+git commit -m "feat(config): real Neo4j 5 db-name validation and derivation"
+```
+
+---
+
+### Task 7: Secrets resolution (env > file > error)
+
+**Files:**
+- Modify: `src/config/secrets.rs`
+- Test: append to `tests/config_parsing.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/config_parsing.rs`:
+
+```rust
+use codegraph_rs::config::secrets::{resolve_neo4j_password, SecretsSource};
+
+#[test]
+fn resolves_password_from_env() {
+    // Use a dedicated env var name to avoid polluting global state
+    let key = "CODEGRAPH_RS_TEST_PASSWORD_ENV";
+    // SAFETY: tests in this file run sequentially because cargo test is
+    // single-threaded per test binary by default; if you parallelize later,
+    // switch to a thread-local override.
+    std::env::set_var(key, "from-env");
+
+    let dir = tempdir().unwrap();
+    let pw = resolve_neo4j_password(dir.path(), Some(key)).expect("env should resolve");
+    assert_eq!(pw.value, "from-env");
+    assert_eq!(pw.source, SecretsSource::Environment);
+
+    std::env::remove_var(key);
+}
+
+#[test]
+fn resolves_password_from_secrets_file() {
+    let dir = tempdir().unwrap();
+    fs::create_dir(dir.path().join(".codegraph")).unwrap();
+    fs::write(
+        dir.path().join(".codegraph/secrets.toml"),
+        "neo4j_password = \"from-file\"\n",
+    ).unwrap();
+
+    // Make sure the env var is not set
+    std::env::remove_var("CODEGRAPH_RS_TEST_NO_ENV");
+    let pw = resolve_neo4j_password(dir.path(), Some("CODEGRAPH_RS_TEST_NO_ENV"))
+        .expect("file should resolve");
+    assert_eq!(pw.value, "from-file");
+    assert_eq!(pw.source, SecretsSource::File);
+}
+
+#[test]
+fn missing_password_errors() {
+    let dir = tempdir().unwrap();
+    std::env::remove_var("CODEGRAPH_RS_TEST_DEFINITELY_UNSET");
+    let err = resolve_neo4j_password(dir.path(), Some("CODEGRAPH_RS_TEST_DEFINITELY_UNSET"))
+        .expect_err("missing both env and file should error");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("password"));
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+cargo test --test config_parsing 2>&1 | tail -10
+```
+
+Expected: compile errors about missing `resolve_neo4j_password` and `SecretsSource`.
+
+- [ ] **Step 3: Implement secrets resolution**
+
+Overwrite `src/config/secrets.rs`:
+
+```rust
+//! Resolve the Neo4j password.
+//!
+//! Order of precedence:
+//!   1. The configured environment variable (default `CODEGRAPH_RS_NEO4J_PASSWORD`).
+//!   2. `<workspace_dir>/.codegraph/secrets.toml` with key `neo4j_password`.
+//!   3. Error.
+//!
+//! Interactive stdin prompting is deferred to a later slice.
+
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SecretsSource {
+    Environment,
+    File,
+}
+
+#[derive(Debug)]
+pub struct ResolvedPassword {
+    pub value: String,
+    pub source: SecretsSource,
+}
+
+#[derive(Debug, Deserialize)]
+struct SecretsFile {
+    neo4j_password: String,
+}
+
+const DEFAULT_ENV_VAR: &str = "CODEGRAPH_RS_NEO4J_PASSWORD";
+
+/// Resolve the Neo4j password.
+///
+/// `env_var` defaults to `CODEGRAPH_RS_NEO4J_PASSWORD` when `None`.
+pub fn resolve_neo4j_password(
+    workspace_dir: &Path,
+    env_var: Option<&str>,
+) -> anyhow::Result<ResolvedPassword> {
+    let var = env_var.unwrap_or(DEFAULT_ENV_VAR);
+    if let Ok(v) = std::env::var(var) {
+        if !v.is_empty() {
+            return Ok(ResolvedPassword { value: v, source: SecretsSource::Environment });
+        }
+    }
+
+    let secrets_path = workspace_dir.join(".codegraph").join("secrets.toml");
+    if secrets_path.is_file() {
+        let raw = std::fs::read_to_string(&secrets_path).map_err(|e| {
+            anyhow::anyhow!("cannot read `{}`: {e}", secrets_path.display())
+        })?;
+        let parsed: SecretsFile = toml::from_str(&raw).map_err(|e| {
+            anyhow::anyhow!("invalid secrets.toml: {e}")
+        })?;
+        return Ok(ResolvedPassword {
+            value: parsed.neo4j_password,
+            source: SecretsSource::File,
+        });
+    }
+
+    anyhow::bail!(
+        "Neo4j password not found. Set the `{var}` environment variable, \
+         or create `<workspace>/.codegraph/secrets.toml` with `neo4j_password = \"...\"`."
+    );
+}
+
+/// Default env-var name. Public so other modules can reference it consistently.
+pub fn default_env_var() -> &'static str {
+    DEFAULT_ENV_VAR
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test --test config_parsing 2>&1 | tail -10
+```
+
+Expected: all tests pass (13 total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/secrets.rs tests/config_parsing.rs
+git commit -m "feat(config): resolve Neo4j password from env > file"
+```
+
+---
+
+### Task 8: Neo4j Bolt connection wrapper
+
+**Files:**
+- Create: `src/db/connection.rs`
+- Modify: `src/db/mod.rs`
+- Test: `tests/integration_db.rs` (gated on env var)
+
+- [ ] **Step 1: Implement the connection wrapper**
+
+Create `src/db/connection.rs`:
+
+```rust
+//! Neo4j Bolt connection wrapper.
+
+use anyhow::{Context, Result};
+use neo4rs::{ConfigBuilder, Graph};
+
+/// A connected Neo4j Bolt session targeting a specific database.
+///
+/// The underlying `neo4rs::Graph` is itself a connection pool; cloning is cheap.
+#[derive(Clone)]
+pub struct Connection {
+    pub graph: Graph,
+    pub database: String,
+}
+
+impl Connection {
+    /// Connect to a Neo4j DBMS targeting the given `database`. The database must
+    /// already exist; use [`Connection::system`] to operate on `system` and create one.
+    pub async fn open(uri: &str, user: &str, password: &str, database: &str) -> Result<Self> {
+        let config = ConfigBuilder::default()
+            .uri(uri)
+            .user(user)
+            .password(password)
+            .db(database)
+            .build()
+            .context("invalid neo4rs config")?;
+        let graph = Graph::connect(config)
+            .await
+            .with_context(|| format!("cannot connect to Neo4j at `{uri}` as `{user}`, db `{database}`"))?;
+        let conn = Self { graph, database: database.to_string() };
+        conn.ping().await.with_context(|| format!("connection ping to `{database}` failed"))?;
+        Ok(conn)
+    }
+
+    /// Connect to the `system` database (used to create user databases).
+    pub async fn system(uri: &str, user: &str, password: &str) -> Result<Self> {
+        Self::open(uri, user, password, "system").await
+    }
+
+    /// Verify the connection by running a trivial query.
+    pub async fn ping(&self) -> Result<()> {
+        let mut stream = self.graph.execute(neo4rs::query("RETURN 1 AS x")).await
+            .context("ping query failed")?;
+        let row = stream.next().await.context("ping returned no row")?
+            .context("ping row error")?;
+        let x: i64 = row.get("x").context("ping row missing `x`")?;
+        anyhow::ensure!(x == 1, "ping returned unexpected value: {x}");
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 2: Re-export from src/db/mod.rs**
+
+Overwrite `src/db/mod.rs`:
+
+```rust
+//! Neo4j Bolt client and schema management.
+
+pub mod connection;
+pub mod schema;
+
+pub use connection::Connection;
+```
+
+- [ ] **Step 3: Create the schema module stub (filled in by Task 9)**
+
+Create `src/db/schema.rs`:
+
+```rust
+//! Neo4j schema (constraints + indexes). Filled in by Task 9.
+
+use crate::db::Connection;
+
+pub async fn apply_schema(_conn: &Connection) -> anyhow::Result<()> {
+    anyhow::bail!("apply_schema: not yet implemented (filled in by Task 9)")
+}
+```
+
+- [ ] **Step 4: Write the integration test**
+
+Create `tests/integration_db.rs`:
+
+```rust
+//! Integration tests that require a live Neo4j Desktop DBMS.
+//! Run with: CODEGRAPH_RS_TEST_NEO4J=1 cargo test --test integration_db -- --nocapture
+//!
+//! Requires env vars:
+//!   CODEGRAPH_RS_TEST_NEO4J_URI       (default bolt://localhost:7687)
+//!   CODEGRAPH_RS_TEST_NEO4J_USER      (default neo4j)
+//!   CODEGRAPH_RS_TEST_NEO4J_PASSWORD  (required)
+
+use codegraph_rs::db::Connection;
+
+fn enabled() -> bool {
+    std::env::var("CODEGRAPH_RS_TEST_NEO4J").as_deref() == Ok("1")
+}
+
+fn env(var: &str, default: Option<&str>) -> String {
+    std::env::var(var).ok().or_else(|| default.map(String::from))
+        .unwrap_or_else(|| panic!("env var `{var}` is required for this test"))
+}
+
+#[tokio::test]
+async fn connects_to_system_database() {
+    if !enabled() {
+        eprintln!("SKIP: set CODEGRAPH_RS_TEST_NEO4J=1 to enable");
+        return;
+    }
+
+    let uri = env("CODEGRAPH_RS_TEST_NEO4J_URI", Some("bolt://localhost:7687"));
+    let user = env("CODEGRAPH_RS_TEST_NEO4J_USER", Some("neo4j"));
+    let pw = env("CODEGRAPH_RS_TEST_NEO4J_PASSWORD", None);
+
+    let conn = Connection::system(&uri, &user, &pw).await.expect("system connect must succeed");
+    conn.ping().await.expect("ping must succeed");
+    assert_eq!(conn.database, "system");
+}
+```
+
+- [ ] **Step 5: Build and verify the gated test compiles and skips by default**
+
+```bash
+cargo test --test integration_db 2>&1 | tail -5
+```
+
+Expected: 1 test, passes via the SKIP path (no env var set), printed `SKIP:` line.
+
+- [ ] **Step 6: Run the integration test against a real Neo4j (manual)**
+
+This step requires Neo4j Desktop to be running.
+
+```bash
+CODEGRAPH_RS_TEST_NEO4J=1 \
+CODEGRAPH_RS_TEST_NEO4J_PASSWORD='your-actual-password' \
+cargo test --test integration_db -- --nocapture
+```
+
+Expected: `1 passed`, no `SKIP:` printed. If this fails, do NOT proceed — fix the connection issue first (most common: wrong password, DBMS not started).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/db tests/integration_db.rs
+git commit -m "feat(db): add Neo4j Bolt connection wrapper with ping verification"
+```
+
+---
+
+### Task 9: Schema application
+
+**Files:**
+- Modify: `src/db/schema.rs`
+- Test: append to `tests/integration_db.rs`
+
+- [ ] **Step 1: Implement schema application**
+
+Overwrite `src/db/schema.rs`:
+
+```rust
+//! Neo4j schema: constraints, indexes, FTS index, vector index.
+//! All statements are `IF NOT EXISTS` to make this routine idempotent.
+
+use anyhow::{Context, Result};
+use neo4rs::query;
+
+use crate::db::Connection;
+
+const VECTOR_DIMENSIONS: u32 = 384;
+
+/// Apply the codegraph-rs schema to the connection's target database.
+/// Safe to call repeatedly — every statement uses `IF NOT EXISTS`.
+pub async fn apply_schema(conn: &Connection) -> Result<()> {
+    let stmts: &[(&str, &str)] = &[
+        (
+            "symbol_qid_unique constraint",
+            "CREATE CONSTRAINT symbol_qid_unique IF NOT EXISTS \
+             FOR (n:Symbol) REQUIRE n.qid IS UNIQUE",
+        ),
+        (
+            "symbol_name_idx",
+            "CREATE INDEX symbol_name_idx IF NOT EXISTS \
+             FOR (n:Symbol) ON (n.name)",
+        ),
+        (
+            "symbol_qualified_idx",
+            "CREATE INDEX symbol_qualified_idx IF NOT EXISTS \
+             FOR (n:Symbol) ON (n.qualified_name)",
+        ),
+        (
+            "file_path_idx",
+            "CREATE INDEX file_path_idx IF NOT EXISTS \
+             FOR (n:File) ON (n.root_name, n.relative_path)",
+        ),
+        (
+            "unresolved_ref_qid_unique",
+            "CREATE CONSTRAINT unresolved_ref_qid_unique IF NOT EXISTS \
+             FOR (n:UnresolvedRef) REQUIRE n.qid IS UNIQUE",
+        ),
+        (
+            "symbol_fts (full-text)",
+            "CREATE FULLTEXT INDEX symbol_fts IF NOT EXISTS \
+             FOR (n:Symbol) ON EACH [n.name, n.qualified_name, n.signature, n.doc]",
+        ),
+    ];
+
+    for (label, cypher) in stmts {
+        conn.graph
+            .execute(query(cypher))
+            .await
+            .with_context(|| format!("schema step `{label}` failed"))?
+            .next()
+            .await
+            .ok();
+    }
+
+    // Vector index has a more complex options map and is created separately.
+    let vector_cypher = format!(
+        "CREATE VECTOR INDEX symbol_embedding IF NOT EXISTS \
+         FOR (n:Symbol) ON n.embedding \
+         OPTIONS {{ \
+           indexConfig: {{ \
+             `vector.dimensions`: {VECTOR_DIMENSIONS}, \
+             `vector.similarity_function`: 'cosine' \
+           }} \
+         }}"
+    );
+    conn.graph
+        .execute(query(&vector_cypher))
+        .await
+        .context("creating vector index `symbol_embedding` failed")?
+        .next()
+        .await
+        .ok();
+
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Append integration test for schema**
+
+Append to `tests/integration_db.rs`:
+
+```rust
+use codegraph_rs::db::schema::apply_schema;
+use neo4rs::query;
+
+#[tokio::test]
+async fn applies_schema_to_fresh_test_database() {
+    if !enabled() { eprintln!("SKIP"); return; }
+
+    let uri = env("CODEGRAPH_RS_TEST_NEO4J_URI", Some("bolt://localhost:7687"));
+    let user = env("CODEGRAPH_RS_TEST_NEO4J_USER", Some("neo4j"));
+    let pw = env("CODEGRAPH_RS_TEST_NEO4J_PASSWORD", None);
+    let db_name = format!("codegraph-test-{}", std::process::id());
+
+    // Create the database via system, then connect to it
+    let sys = Connection::system(&uri, &user, &pw).await.unwrap();
+    sys.graph
+        .execute(query(&format!("CREATE DATABASE `{db_name}` IF NOT EXISTS WAIT")))
+        .await
+        .expect("CREATE DATABASE")
+        .next()
+        .await
+        .ok();
+
+    let conn = Connection::open(&uri, &user, &pw, &db_name).await.expect("connect to test db");
+    apply_schema(&conn).await.expect("apply_schema must succeed on fresh db");
+    apply_schema(&conn).await.expect("apply_schema must be idempotent");
+
+    // Spot check that the constraint exists
+    let mut rows = conn.graph
+        .execute(query("SHOW CONSTRAINTS YIELD name RETURN name"))
+        .await.unwrap();
+    let mut names = Vec::new();
+    while let Some(row) = rows.next().await.unwrap() {
+        names.push(row.get::<String>("name").unwrap());
+    }
+    assert!(names.iter().any(|n| n == "symbol_qid_unique"),
+        "expected symbol_qid_unique among: {names:?}");
+
+    // Cleanup: drop the test database
+    sys.graph
+        .execute(query(&format!("DROP DATABASE `{db_name}` IF EXISTS WAIT")))
+        .await
+        .expect("DROP DATABASE")
+        .next()
+        .await
+        .ok();
+}
+```
+
+- [ ] **Step 3: Run integration tests against Neo4j**
+
+```bash
+CODEGRAPH_RS_TEST_NEO4J=1 \
+CODEGRAPH_RS_TEST_NEO4J_PASSWORD='your-actual-password' \
+cargo test --test integration_db -- --nocapture --test-threads=1
+```
+
+Expected: 2 tests pass. The `--test-threads=1` is important — these tests share a Neo4j instance and shouldn't run concurrently.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/db/schema.rs tests/integration_db.rs
+git commit -m "feat(db): apply codegraph-rs schema (constraints, indexes, fts, vector) idempotently"
+```
+
+---
+
+### Task 10: `init` command — full implementation
+
+**Files:**
+- Modify: `src/cli/init.rs`
+- Test: `tests/integration_init.rs` (gated)
+
+- [ ] **Step 1: Implement init**
+
+Overwrite `src/cli/init.rs`:
+
+```rust
+//! `codegraph-rs init` — scaffold a workspace.
+//!
+//! Order of operations is fail-fast: validate Neo4j and apply schema BEFORE
+//! writing any config files. If anything fails, the workspace directory is
+//! left as the user provided it (no half-initialized state).
+
+use anyhow::{Context, Result};
+use clap::Args;
+use neo4rs::query;
+use std::path::{Path, PathBuf};
+use tracing::info;
+
+use crate::config::naming::{derive_database_name, validate_database_name};
+use crate::db::{Connection, schema::apply_schema};
+
+#[derive(Debug, Args)]
+pub struct InitArgs {
+    /// Workspace name (used to derive the Neo4j database name).
+    #[arg(long)]
+    pub name: String,
+
+    /// Neo4j Bolt URI.
+    #[arg(long, default_value = "bolt://localhost:7687")]
+    pub neo4j_uri: String,
+
+    /// Neo4j user.
+    #[arg(long, default_value = "neo4j")]
+    pub neo4j_user: String,
+
+    /// Neo4j password. Prefer the CODEGRAPH_RS_NEO4J_PASSWORD env var.
+    #[arg(long, env = "CODEGRAPH_RS_NEO4J_PASSWORD")]
+    pub neo4j_password: String,
+
+    /// Workspace roots in the form `name=path`.
+    #[arg(long, value_name = "NAME=PATH", required = true, num_args = 1..)]
+    pub root: Vec<String>,
+}
+
+pub fn run(args: InitArgs, workspace: Option<&Path>) -> Result<()> {
+    let workspace_dir = workspace.map(Path::to_path_buf).unwrap_or_else(|| {
+        std::env::current_dir().expect("cwd readable")
+    });
+
+    // Tokio runtime for the async Neo4j calls.
+    let rt = tokio::runtime::Runtime::new().context("starting tokio runtime")?;
+    rt.block_on(async { run_async(args, &workspace_dir).await })
+}
+
+async fn run_async(args: InitArgs, workspace_dir: &Path) -> Result<()> {
+    let db_name = derive_database_name(&args.name);
+    validate_database_name(&db_name).map_err(|e| anyhow::anyhow!("derived db name `{db_name}` invalid: {e}"))?;
+
+    let roots = parse_roots(&args.root, workspace_dir)?;
+
+    info!("validating Neo4j connection at {}", args.neo4j_uri);
+    let sys = Connection::system(&args.neo4j_uri, &args.neo4j_user, &args.neo4j_password).await
+        .context("Neo4j connection failed; is the DBMS running?")?;
+
+    info!("creating database `{db_name}` if missing");
+    sys.graph
+        .execute(query(&format!("CREATE DATABASE `{db_name}` IF NOT EXISTS WAIT")))
+        .await
+        .with_context(|| format!("CREATE DATABASE `{db_name}` failed (do you have CREATE DATABASE privilege?)"))?
+        .next()
+        .await
+        .ok();
+
+    let conn = Connection::open(&args.neo4j_uri, &args.neo4j_user, &args.neo4j_password, &db_name)
+        .await
+        .with_context(|| format!("cannot open created database `{db_name}`"))?;
+
+    info!("applying schema");
+    apply_schema(&conn).await.context("schema apply failed")?;
+
+    // All Neo4j operations succeeded — now write config files.
+    write_config_files(workspace_dir, &args, &db_name, &roots)?;
+    println!("Initialized workspace `{}` -> Neo4j database `{db_name}`", args.name);
+    Ok(())
+}
+
+struct ParsedRoot { name: String, path: PathBuf }
+
+fn parse_roots(items: &[String], workspace_dir: &Path) -> Result<Vec<ParsedRoot>> {
+    let mut out = Vec::with_capacity(items.len());
+    for item in items {
+        let (name, path) = item.split_once('=').ok_or_else(|| {
+            anyhow::anyhow!("--root must be NAME=PATH (got `{item}`)")
+        })?;
+        let resolved = if PathBuf::from(path).is_absolute() {
+            PathBuf::from(path)
+        } else {
+            workspace_dir.join(path)
+        };
+        if !resolved.is_dir() {
+            anyhow::bail!("root `{name}` path `{}` is not a directory", resolved.display());
+        }
+        out.push(ParsedRoot { name: name.to_string(), path: PathBuf::from(path) });
+    }
+    Ok(out)
+}
+
+fn write_config_files(
+    workspace_dir: &Path,
+    args: &InitArgs,
+    db_name: &str,
+    roots: &[ParsedRoot],
+) -> Result<()> {
+    let codegraph_dir = workspace_dir.join(".codegraph");
+    std::fs::create_dir_all(&codegraph_dir).with_context(|| {
+        format!("creating {}", codegraph_dir.display())
+    })?;
+
+    let mut config_toml = String::new();
+    config_toml.push_str("schema_version = 1\n\n");
+    config_toml.push_str("[workspace]\n");
+    config_toml.push_str(&format!("name = \"{}\"\n\n", args.name));
+    config_toml.push_str("[workspace.neo4j]\n");
+    config_toml.push_str(&format!("uri = \"{}\"\n", args.neo4j_uri));
+    config_toml.push_str(&format!("database = \"{}\"\n", db_name));
+    config_toml.push_str(&format!("username = \"{}\"\n\n", args.neo4j_user));
+    for r in roots {
+        config_toml.push_str("[[workspace.roots]]\n");
+        config_toml.push_str(&format!("name = \"{}\"\n", r.name));
+        config_toml.push_str(&format!("path = \"{}\"\n\n", r.path.display()));
+    }
+    config_toml.push_str("[indexing]\nlanguages = [\"rust\", \"daml\"]\n\n");
+    config_toml.push_str("[embeddings]\nenabled = true\nmodel = \"bge-small-en-v1.5\"\n");
+
+    let config_path = codegraph_dir.join("config.toml");
+    std::fs::write(&config_path, config_toml)
+        .with_context(|| format!("writing {}", config_path.display()))?;
+
+    let secrets_path = codegraph_dir.join("secrets.toml");
+    let secrets_content = format!("neo4j_password = \"{}\"\n", args.neo4j_password.replace('"', "\\\""));
+    std::fs::write(&secrets_path, secrets_content)
+        .with_context(|| format!("writing {}", secrets_path.display()))?;
+
+    // Restrict secrets.toml permissions on Unix.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perm = std::fs::metadata(&secrets_path)?.permissions();
+        perm.set_mode(0o600);
+        std::fs::set_permissions(&secrets_path, perm)?;
+    }
+
+    // Ensure secrets.toml is gitignored. Append-or-create the workspace .gitignore.
+    let gitignore_path = workspace_dir.join(".gitignore");
+    let line = ".codegraph/secrets.toml\n";
+    let existing = std::fs::read_to_string(&gitignore_path).unwrap_or_default();
+    if !existing.lines().any(|l| l.trim() == ".codegraph/secrets.toml") {
+        let combined = if existing.ends_with('\n') || existing.is_empty() {
+            format!("{existing}{line}")
+        } else {
+            format!("{existing}\n{line}")
+        };
+        std::fs::write(&gitignore_path, combined)
+            .with_context(|| format!("updating {}", gitignore_path.display()))?;
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cargo build 2>&1 | tail -3
+```
+
+Expected: clean build, possibly some unused-import warnings.
+
+- [ ] **Step 3: Write the integration test**
+
+Create `tests/integration_init.rs`:
+
+```rust
+//! Integration test for `codegraph-rs init`. Gated on env var.
+
+use codegraph_rs::cli::init::{InitArgs, run};
+use std::fs;
+use tempfile::tempdir;
+
+fn enabled() -> bool {
+    std::env::var("CODEGRAPH_RS_TEST_NEO4J").as_deref() == Ok("1")
+}
+
+#[test]
+fn init_creates_workspace_and_database() {
+    if !enabled() {
+        eprintln!("SKIP: set CODEGRAPH_RS_TEST_NEO4J=1 to enable");
+        return;
+    }
+
+    let pw = std::env::var("CODEGRAPH_RS_TEST_NEO4J_PASSWORD")
+        .expect("CODEGRAPH_RS_TEST_NEO4J_PASSWORD required");
+
+    let dir = tempdir().unwrap();
+    let workspace_name = format!("init-test-{}", std::process::id());
+    let root_subdir = dir.path().join("root1");
+    fs::create_dir(&root_subdir).unwrap();
+
+    let args = InitArgs {
+        name: workspace_name.clone(),
+        neo4j_uri: "bolt://localhost:7687".into(),
+        neo4j_user: "neo4j".into(),
+        neo4j_password: pw.clone(),
+        root: vec![format!("only=root1")],
+    };
+
+    run(args, Some(dir.path())).expect("init must succeed");
+
+    // Files written?
+    assert!(dir.path().join(".codegraph/config.toml").is_file());
+    assert!(dir.path().join(".codegraph/secrets.toml").is_file());
+    assert!(dir.path().join(".gitignore").is_file());
+
+    let gi = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+    assert!(gi.contains(".codegraph/secrets.toml"), "gitignore must contain secrets path");
+
+    // Drop the database to keep the local DBMS clean.
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let sys = codegraph_rs::db::Connection::system(
+            "bolt://localhost:7687", "neo4j", &pw,
+        ).await.unwrap();
+        let db_name = format!("codegraph-init-test-{}", std::process::id());
+        sys.graph.execute(neo4rs::query(&format!("DROP DATABASE `{db_name}` IF EXISTS WAIT")))
+            .await.unwrap().next().await.ok();
+    });
+}
+```
+
+- [ ] **Step 4: Run the integration test**
+
+```bash
+CODEGRAPH_RS_TEST_NEO4J=1 \
+CODEGRAPH_RS_TEST_NEO4J_PASSWORD='your-actual-password' \
+cargo test --test integration_init -- --nocapture
+```
+
+Expected: test passes; `init` reports success; `.codegraph/config.toml` and `secrets.toml` exist after.
+
+- [ ] **Step 5: Manual smoke test**
+
+```bash
+mkdir -p /tmp/cg-rs-smoke && cd /tmp/cg-rs-smoke
+mkdir my-root
+CODEGRAPH_RS_NEO4J_PASSWORD='your-actual-password' \
+cargo run --manifest-path /Users/gyorgybalazsi/codegraph-rs/Cargo.toml -- init \
+  --name smoke \
+  --root primary=my-root
+cat .codegraph/config.toml
+cat .gitignore
+```
+
+Expected: prints "Initialized workspace `smoke` -> Neo4j database `codegraph-smoke`"; config.toml shows the workspace; .gitignore includes the secrets path.
+
+Cleanup:
+
+```bash
+cd /Users/gyorgybalazsi/codegraph-rs
+# Drop the smoke db
+cargo run --quiet -- 2>&1 | head -1   # noop — we'll add a 'drop' command later
+# For now, drop manually via Neo4j Browser or cypher-shell:
+#   DROP DATABASE `codegraph-smoke` IF EXISTS;
+rm -rf /tmp/cg-rs-smoke
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/init.rs tests/integration_init.rs
+git commit -m "feat(cli): implement init — validate Neo4j, CREATE DATABASE, apply schema, write config"
+```
+
+---
+
+### Task 11: `status` command — basic counts
+
+**Files:**
+- Modify: `src/cli/status.rs`
+- Test: `tests/integration_status.rs` (gated)
+
+- [ ] **Step 1: Implement status**
+
+Overwrite `src/cli/status.rs`:
+
+```rust
+//! `codegraph-rs status` — print workspace stats.
+
+use anyhow::{Context, Result};
+use neo4rs::query;
+use std::path::Path;
+
+use crate::config::secrets::resolve_neo4j_password;
+use crate::config::workspace;
+use crate::db::Connection;
+
+pub fn run(workspace_arg: Option<&Path>) -> Result<()> {
+    let starting = workspace_arg.map(Path::to_path_buf).unwrap_or_else(|| {
+        std::env::current_dir().expect("cwd readable")
+    });
+    let workspace_dir = workspace::find_workspace_root(&starting)
+        .context("no workspace found; run `codegraph-rs init` first")?;
+    let cfg = workspace::load_from_path(&workspace_dir)?;
+    let pw = resolve_neo4j_password(&workspace_dir, None)?;
+
+    let rt = tokio::runtime::Runtime::new().context("starting tokio runtime")?;
+    rt.block_on(async {
+        let conn = Connection::open(
+            &cfg.workspace.neo4j.uri,
+            &cfg.workspace.neo4j.username,
+            &pw.value,
+            &cfg.workspace.neo4j.database,
+        ).await.context("connecting to workspace database")?;
+
+        let file_count: i64 = single_count(&conn, "MATCH (n:File) RETURN count(n) AS c").await?;
+        let symbol_count: i64 = single_count(&conn, "MATCH (n:Symbol) RETURN count(n) AS c").await?;
+        let unresolved: i64 = single_count(&conn, "MATCH (n:UnresolvedRef) RETURN count(n) AS c").await?;
+        let last_indexed: Option<i64> = max_last_indexed(&conn).await?;
+
+        println!("Workspace: {}", cfg.workspace.name);
+        println!("Database:  {}", cfg.workspace.neo4j.database);
+        println!("Roots:     {}", cfg.workspace.roots.iter().map(|r| r.name.as_str()).collect::<Vec<_>>().join(", "));
+        println!("Files:     {file_count}");
+        println!("Symbols:   {symbol_count}");
+        println!("Unresolved refs: {unresolved}");
+        println!("Last indexed:    {}", match last_indexed { Some(t) => t.to_string(), None => "never".into() });
+        Ok::<(), anyhow::Error>(())
+    })
+}
+
+async fn single_count(conn: &Connection, cypher: &str) -> Result<i64> {
+    let mut stream = conn.graph.execute(query(cypher)).await
+        .with_context(|| format!("running `{cypher}`"))?;
+    let row = stream.next().await
+        .with_context(|| format!("no row from `{cypher}`"))?
+        .with_context(|| format!("row error from `{cypher}`"))?;
+    row.get("c").context("row missing `c`")
+}
+
+async fn max_last_indexed(conn: &Connection) -> Result<Option<i64>> {
+    let mut stream = conn.graph
+        .execute(query("MATCH (n:File) RETURN max(n.last_indexed_at) AS t"))
+        .await?;
+    let row = stream.next().await.context("no row")??;
+    Ok(row.get::<Option<i64>>("t").context("missing `t`")?)
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+```bash
+cargo build 2>&1 | tail -3
+```
+
+Expected: clean build.
+
+- [ ] **Step 3: Write the integration test**
+
+Create `tests/integration_status.rs`:
+
+```rust
+//! Integration test for `codegraph-rs status`. Gated on env var.
+
+use codegraph_rs::cli::{init::{InitArgs, self}, status};
+use std::fs;
+use tempfile::tempdir;
+
+fn enabled() -> bool {
+    std::env::var("CODEGRAPH_RS_TEST_NEO4J").as_deref() == Ok("1")
+}
+
+#[test]
+fn status_after_init_reports_zero_counts() {
+    if !enabled() {
+        eprintln!("SKIP");
+        return;
+    }
+    let pw = std::env::var("CODEGRAPH_RS_TEST_NEO4J_PASSWORD")
+        .expect("CODEGRAPH_RS_TEST_NEO4J_PASSWORD required");
+
+    let dir = tempdir().unwrap();
+    let workspace_name = format!("status-test-{}", std::process::id());
+    fs::create_dir(dir.path().join("root1")).unwrap();
+
+    let args = InitArgs {
+        name: workspace_name.clone(),
+        neo4j_uri: "bolt://localhost:7687".into(),
+        neo4j_user: "neo4j".into(),
+        neo4j_password: pw.clone(),
+        root: vec!["only=root1".into()],
+    };
+    init::run(args, Some(dir.path())).expect("init");
+
+    // Set env so status's secrets resolution finds it
+    std::env::set_var("CODEGRAPH_RS_NEO4J_PASSWORD", &pw);
+    status::run(Some(dir.path())).expect("status");
+    std::env::remove_var("CODEGRAPH_RS_NEO4J_PASSWORD");
+
+    // Drop test db
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let sys = codegraph_rs::db::Connection::system(
+            "bolt://localhost:7687", "neo4j", &pw,
+        ).await.unwrap();
+        let db_name = format!("codegraph-status-test-{}", std::process::id());
+        sys.graph.execute(neo4rs::query(&format!("DROP DATABASE `{db_name}` IF EXISTS WAIT")))
+            .await.unwrap().next().await.ok();
+    });
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+CODEGRAPH_RS_TEST_NEO4J=1 \
+CODEGRAPH_RS_TEST_NEO4J_PASSWORD='your-actual-password' \
+cargo test --test integration_status -- --nocapture --test-threads=1
+```
+
+Expected: status output prints "Files: 0", "Symbols: 0", "Unresolved refs: 0", "Last indexed: never".
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/status.rs tests/integration_status.rs
+git commit -m "feat(cli): implement status — print file/symbol counts and last index time"
+```
+
+---
+
+### Task 12: README, final cleanup, slice 1 tag
+
+**Files:**
+- Create: `/Users/gyorgybalazsi/codegraph-rs/README.md`
+
+- [ ] **Step 1: Create the README**
+
+Create `/Users/gyorgybalazsi/codegraph-rs/README.md`:
+
+```markdown
+# codegraph-rs
+
+Local-first code intelligence — the Rust port of [CodeGraph](https://github.com/colbymchenry/codegraph),
+backed by Neo4j.
+
+## Status
+
+In development. Currently implements **Slice 1: Walking Skeleton** —
+workspace initialization, schema setup, and status reporting. Indexing,
+resolution, vector search, and the MCP server land in subsequent slices.
+
+## Prerequisites
+
+- Rust 1.91+ (`rustup install 1.91`)
+- Neo4j Desktop (Enterprise Edition, free for local dev). The DBMS must be
+  running with default user `neo4j` and a known password.
+
+## Quick start
+
+```bash
+cargo install --path .
+
+mkdir my-workspace && cd my-workspace
+mkdir my-source-root
+export CODEGRAPH_RS_NEO4J_PASSWORD='your-neo4j-password'
+codegraph-rs init --name my-workspace --root primary=my-source-root
+
+codegraph-rs status
+```
+
+## Development
+
+```bash
+cargo test                         # unit tests
+CODEGRAPH_RS_TEST_NEO4J=1 \
+CODEGRAPH_RS_TEST_NEO4J_PASSWORD='...' \
+  cargo test -- --test-threads=1   # full suite, including integration tests
+```
+
+## Design
+
+See [`docs/superpowers/specs/2026-04-22-codegraph-rs-design.md`](https://github.com/bitsafe/codegraph/blob/main/docs/superpowers/specs/2026-04-22-codegraph-rs-design.md)
+in the parent CodeGraph repo for the architectural spec.
+
+## License
+
+MIT.
+```
+
+- [ ] **Step 2: Run the full test suite one last time**
+
+```bash
+cd /Users/gyorgybalazsi/codegraph-rs
+cargo test 2>&1 | tail -10
+```
+
+Expected: all unit tests pass. Integration tests print `SKIP:` (no env var set) — that's fine.
+
+- [ ] **Step 3: Run clippy and rustfmt**
+
+```bash
+cargo clippy --all-targets 2>&1 | tail -20
+cargo fmt --check 2>&1 | tail -5
+```
+
+Expected: no clippy warnings (or only pre-approved ones); `cargo fmt --check` exits 0. If `cargo fmt --check` fails, run `cargo fmt` and re-stage.
+
+- [ ] **Step 4: Run integration tests against Neo4j once more, end-to-end**
+
+```bash
+CODEGRAPH_RS_TEST_NEO4J=1 \
+CODEGRAPH_RS_TEST_NEO4J_PASSWORD='your-actual-password' \
+cargo test -- --test-threads=1 2>&1 | tail -15
+```
+
+Expected: all tests (unit + integration) pass.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add README.md
+git commit -m "docs: add README for slice 1 walking skeleton"
+git tag slice-1-walking-skeleton
+git log --oneline | head -15
+```
+
+Expected: clean commit history with one commit per task and a final tag.
+
+---
+
+## Slice 1 Done
+
+Verify the artifact:
+
+- [ ] `cargo build` succeeds with no errors.
+- [ ] `cargo test` (no env vars) — all unit tests pass; integration tests print `SKIP:`.
+- [ ] `CODEGRAPH_RS_TEST_NEO4J=1 cargo test -- --test-threads=1` — all tests pass.
+- [ ] `codegraph-rs --help` shows all 6 subcommands.
+- [ ] `codegraph-rs init --name X --root r=./X` against a real Neo4j Desktop creates `.codegraph/config.toml` and the database.
+- [ ] `codegraph-rs status` after init prints zero counts.
+- [ ] `codegraph-rs index` prints `not yet implemented in slice 1` and exits nonzero.
+
+When all check, slice 1 is complete and we can write slice 2 (Rust extraction).

--- a/docs/superpowers/plans/2026-05-06-codegraph-rs-slice-2-rust-extraction.md
+++ b/docs/superpowers/plans/2026-05-06-codegraph-rs-slice-2-rust-extraction.md
@@ -101,7 +101,7 @@ codegraph-rs/
 
 - [ ] **Step 1: Add extraction deps to Cargo.toml**
 
-In `/Users/gyorgybalazsi/codegraph-rs/Cargo.toml`, add to `[dependencies]`:
+In `/Users/gyorgybalazsi/codegraph-rs/Cargo.toml`, add the new deps AND **enable the `json` feature on the existing `neo4rs` line** (Task 10's writer feeds `serde_json::Value` into `Query::param`, which only converts via `BoltType: From<serde_json::Value>` when the `json` feature is on).
 
 ```toml
 tree-sitter = "0.25"
@@ -109,9 +109,12 @@ tree-sitter-rust = "0.24"
 ignore = "0.4"
 blake3 = "1"
 rayon = "1"
+serde_json = "1"
 ```
 
-Place these alphabetically among the existing deps. Result section should look like:
+And replace `neo4rs = "0.8"` with `neo4rs = { version = "0.8", features = ["json"] }`.
+
+Result section should look like:
 
 ```toml
 [dependencies]
@@ -119,9 +122,10 @@ anyhow = "1"
 blake3 = "1"
 clap = { version = "4", features = ["derive", "env"] }
 ignore = "0.4"
-neo4rs = "0.8"
+neo4rs = { version = "0.8", features = ["json"] }
 rayon = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-util", "io-std", "fs", "process", "signal"] }
 toml = "1"
@@ -132,6 +136,8 @@ tree-sitter-rust = "0.24"
 ```
 
 (Order may differ from the existing file — match the existing alphabetical convention.)
+
+> Note: `serde_json` is moved here from Task 10 to consolidate all the slice-2 dep additions in one commit.
 
 - [ ] **Step 2: Update src/lib.rs**
 
@@ -310,6 +316,8 @@ fn raw_node_is_constructible() {
         signature: Some("fn foo()".to_string()),
         doc: None,
         parse_reliable: true,
+        content_hash: None,
+        last_indexed_at: None,
     };
     assert_eq!(n.name, "foo");
     assert_eq!(n.kind, NodeKind::Function);
@@ -452,6 +460,10 @@ pub struct RawNode {
     /// True for tree-sitter parses we trust; false for Daml template bodies
     /// extracted via tree-sitter-haskell (Slice 7+). For Rust always true.
     pub parse_reliable: bool,
+    /// File-only properties (per spec §4 "File-specific properties").
+    /// `None` for non-File nodes; `Some(...)` for File.
+    pub content_hash: Option<String>,
+    pub last_indexed_at: Option<i64>,
 }
 
 #[derive(Debug, Clone)]
@@ -899,6 +911,21 @@ fn extraction_emits_file_node() {
     assert_eq!(files.len(), 1);
     assert_eq!(files[0].name, "f.rs");
     assert_eq!(files[0].relative_path, "f.rs");
+    // File node carries content_hash + last_indexed_at; non-File nodes leave these as None.
+    assert!(files[0].content_hash.is_some(), "File should have content_hash");
+    let hash = files[0].content_hash.as_ref().unwrap();
+    assert_eq!(hash.len(), 64, "BLAKE3 hex hash is 64 chars");
+    assert!(files[0].last_indexed_at.is_some(), "File should have last_indexed_at");
+}
+
+#[test]
+fn non_file_nodes_have_no_content_hash() {
+    let source = "fn x() {}";
+    let result = extract_rust(source, "r", "f.rs").expect("ok");
+    let funcs: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Function).collect();
+    assert_eq!(funcs.len(), 1);
+    assert!(funcs[0].content_hash.is_none(), "non-File nodes must leave content_hash unset");
+    assert!(funcs[0].last_indexed_at.is_none());
 }
 
 #[test]
@@ -946,6 +973,7 @@ Overwrite `src/extraction/languages/rust.rs`:
 use anyhow::{Context, Result};
 use tree_sitter::{Query, QueryCursor, StreamingIterator};
 
+use crate::extraction::hash::source_hash;
 use crate::extraction::parser::parse_rust;
 use crate::extraction::result::{
     EdgeKind, ExtractionResult, NodeKind, RawEdge, RawNode,
@@ -1009,6 +1037,8 @@ pub fn extract_rust(source: &str, root_name: &str, relative_path: &str) -> Resul
                 signature: Some(signature),
                 doc: None,
                 parse_reliable: true,
+                content_hash: None,
+                last_indexed_at: None,
             });
             result.edges.push(RawEdge {
                 from_qid: file_qid.clone(),
@@ -1028,6 +1058,10 @@ fn build_file_node(source: &str, root_name: &str, relative_path: &str) -> RawNod
         .map(|s| s.to_string_lossy().to_string())
         .unwrap_or_else(|| relative_path.to_string());
     let line_count = source.lines().count() as u32;
+    let now_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
     RawNode {
         qid,
         kind: NodeKind::File,
@@ -1043,6 +1077,8 @@ fn build_file_node(source: &str, root_name: &str, relative_path: &str) -> RawNod
         signature: None,
         doc: None,
         parse_reliable: true,
+        content_hash: Some(source_hash(source)),
+        last_indexed_at: Some(now_unix),
     }
 }
 
@@ -1085,13 +1121,13 @@ fn signature_text(source: &str, node: tree_sitter::Node) -> String {
 cargo test --test extraction_unit 2>&1 | tail -10
 ```
 
-Expected: 18 tests pass (14 + 4 new).
+Expected: 20 tests pass (14 + 6 new — 4 function-extraction tests + 2 file-properties tests).
 
 - [ ] **Step 6: Commit**
 
 ```bash
 git add src/extraction/languages/rust.rs src/extraction/languages/rust.scm tests/extraction_unit.rs
-git commit -m "feat(extraction): Rust extractor — function_item -> Function with CONTAINS"
+git commit -m "feat(extraction): Rust extractor — function_item -> Function with CONTAINS, file content hash"
 ```
 
 ---
@@ -1246,6 +1282,8 @@ In `src/extraction/languages/rust.rs`, refactor `extract_rust` to handle multipl
                     signature,
                     doc: None,
                     parse_reliable: true,
+                    content_hash: None,
+                    last_indexed_at: None,
                 });
                 result.edges.push(RawEdge {
                     from_qid: file_qid.clone(),
@@ -1266,7 +1304,7 @@ Remove the now-stale `function_ordinals` variable, `function_def_idx`, and `func
 cargo test --test extraction_unit 2>&1 | tail -10
 ```
 
-Expected: 23 tests pass.
+Expected: 25 tests pass.
 
 - [ ] **Step 5: Commit**
 
@@ -1321,6 +1359,15 @@ Append to `src/extraction/languages/rust.scm`:
 
 (`(_)` matches any kind of argument node — `scoped_identifier`, `use_list`, `use_as_clause`, etc.)
 
+> **Verify the `argument:` field name.** If `Query::new` succeeds but the test produces 0 imports, the field name in tree-sitter-rust 0.24 may be different (some grammar versions use unnamed children). To diagnose:
+>
+> ```bash
+> # From the codegraph-rs root, with cargo workspace target:
+> rg --files ~/.cargo/registry/src | grep tree-sitter-rust | grep node-types
+> ```
+>
+> Open `node-types.json` and search for `"type": "use_declaration"` — its `fields` array tells you the real field name. If absent, replace the query with a positional pattern: `(use_declaration (_) @import.path) @import.def` (no field). Re-run the test.
+
 - [ ] **Step 3: Update the captures table**
 
 In `src/extraction/languages/rust.rs`, add to the `captures` slice:
@@ -1337,7 +1384,7 @@ Then handle the case that Import has a path-text-as-name rather than an identifi
 cargo test --test extraction_unit 2>&1 | tail -10
 ```
 
-Expected: 25 tests pass.
+Expected: 27 tests pass.
 
 - [ ] **Step 5: Commit**
 
@@ -1411,6 +1458,8 @@ Append to `src/extraction/languages/rust.scm`:
 (call_expression
   function: (_) @call.callee) @call.site
 ```
+
+> **Verify the `function:` field name.** Same diagnostic as Task 8: if the test produces 0 unresolved refs after a clean compile, inspect tree-sitter-rust 0.24's `node-types.json` for `call_expression`'s field names. The field name should be `function` per the standard tree-sitter-rust grammar — but verify before assuming. If different, adjust the query.
 
 - [ ] **Step 3: Implement call extraction**
 
@@ -1498,7 +1547,7 @@ fn enclosing_symbol_qid(nodes: &[RawNode], line: u32, col: u32) -> Option<&Strin
 cargo test --test extraction_unit 2>&1 | tail -10
 ```
 
-Expected: 28 tests pass.
+Expected: 30 tests pass.
 
 - [ ] **Step 5: Commit**
 
@@ -1570,6 +1619,8 @@ pub async fn write_extraction(conn: &Connection, results: Vec<ExtractionResult>)
 
 async fn write_nodes(conn: &Connection, kind: NodeKind, nodes: &[RawNode]) -> Result<()> {
     let label = kind.as_label();
+    // content_hash and last_indexed_at are set on File nodes only; on other
+    // nodes the row values are null and Neo4j removes the property.
     let cypher_text = format!(
         "UNWIND $batch AS row \
          MERGE (n:Symbol:{label} {{qid: row.qid}}) \
@@ -1584,7 +1635,9 @@ async fn write_nodes(conn: &Connection, kind: NodeKind, nodes: &[RawNode]) -> Re
              n.end_col = row.end_col, \
              n.signature = row.signature, \
              n.doc = row.doc, \
-             n.parse_reliable = row.parse_reliable"
+             n.parse_reliable = row.parse_reliable, \
+             n.content_hash = row.content_hash, \
+             n.last_indexed_at = row.last_indexed_at"
     );
 
     for chunk in nodes.chunks(BATCH_SIZE) {
@@ -1659,6 +1712,11 @@ fn node_to_json(n: &RawNode) -> Value {
     m.insert("signature".into(), n.signature.clone().map(Value::String).unwrap_or(Value::Null));
     m.insert("doc".into(), n.doc.clone().map(Value::String).unwrap_or(Value::Null));
     m.insert("parse_reliable".into(), n.parse_reliable.into());
+    m.insert("content_hash".into(), n.content_hash.clone().map(Value::String).unwrap_or(Value::Null));
+    m.insert("last_indexed_at".into(), match n.last_indexed_at {
+        Some(t) => Value::Number(t.into()),
+        None => Value::Null,
+    });
     Value::Object(m)
 }
 
@@ -1683,27 +1741,17 @@ fn edge_to_json(e: &RawEdge) -> Value {
 
 > **Note on `UnresolvedKind`:** `UnresolvedKind` was used here in the import line (`use crate::extraction::result::{... UnresolvedKind ...}`). The `as_str()` method called on `r.kind` is what the writer needs. If your `result.rs` from Task 2 doesn't have `UnresolvedKind::as_str()`, add it. The Task 2 spec includes it; verify before continuing.
 
-- [ ] **Step 2: Add serde_json dependency**
+> **Note on `Query::param`:** The `serde_json::Value` arguments require neo4rs's `json` feature flag, which Task 1 already enabled. If you skipped that, you'll see compile errors here — go back and update `Cargo.toml`.
 
-`serde_json` isn't in slice 1's Cargo.toml. Add it now since `neo4rs` 0.8 takes parameters as `serde_json::Value` (or via `BoltType`; use serde_json for ergonomics).
-
-In `/Users/gyorgybalazsi/codegraph-rs/Cargo.toml`, add to `[dependencies]`:
-
-```toml
-serde_json = "1"
-```
-
-> Implementer note: if `neo4rs::query(...).param(...)` does NOT accept `serde_json::Value` directly, switch to `neo4rs::BoltType` construction. The neo4rs 0.8 README shows `query(...).param("k", value)` where `value: impl Into<BoltType>`. `BoltType: From<serde_json::Value>` exists; if not, adapt with `BoltType::Map`/`BoltType::List`/etc. by hand. Validate via the Task 12 integration test.
-
-- [ ] **Step 3: Build and verify**
+- [ ] **Step 2: Build and verify**
 
 ```bash
 cargo build 2>&1 | tail -5
 ```
 
-Expected: clean. If neo4rs's `param` doesn't accept `serde_json::Value` directly, you'll see compile errors — adjust per the note above.
+Expected: clean.
 
-- [ ] **Step 4: Run all tests (no integration_index yet — added in Task 12)**
+- [ ] **Step 3: Run all tests (no integration_index yet — added in Task 12)**
 
 ```bash
 cargo test 2>&1 | tail -10
@@ -1711,10 +1759,10 @@ cargo test 2>&1 | tail -10
 
 Expected: existing tests still pass; no new tests added in this task.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
-git add src/db/write.rs Cargo.toml Cargo.lock
+git add src/db/write.rs
 git commit -m "feat(db): write_extraction — batched UNWIND/MERGE for nodes, edges, refs"
 ```
 
@@ -1863,10 +1911,18 @@ cargo test 2>&1 | tail -10
 
 Expected: build clean. The `cli_smoke` test for `index` previously expected "not yet implemented" — but `index` now runs the real command (which will fail without a workspace, with a different error). Update the test if needed.
 
-In `tests/cli_smoke.rs`, the test `slice1_stub_commands_fail_with_not_implemented` iterates over `["index", "sync", "serve"]`. Remove `"index"` from that list (since it's now implemented and will produce a different error message):
+In `tests/cli_smoke.rs`, the test `slice1_stub_commands_fail_with_not_implemented` iterates over `["index", "sync", "serve"]`. Two changes:
+
+1. **Rename** the test (the `slice1_` prefix is now misleading) to `stub_commands_fail_with_not_implemented`.
+2. **Remove `"index"`** from the iteration list (it's now a real command and will produce a different error message):
 
 ```rust
+#[test]
+fn stub_commands_fail_with_not_implemented() {
     for sub in &["sync", "serve"] {
+        // ... existing body unchanged ...
+    }
+}
 ```
 
 - [ ] **Step 5: Commit**
@@ -2076,7 +2132,20 @@ git commit -m "test(extraction): integration test indexing tiny-rust fixture aga
 git tag slice-2-rust-extraction
 ```
 
-Expected: all tests pass (28 unit + 4 integration_db SKIPs + 1 integration_init SKIP + 1 integration_status SKIP + 1 integration_index SKIP + 2 cli_smoke = ~37 tests). All clippy/fmt clean. Tag at HEAD.
+Expected: all tests pass. Approximate breakdown:
+
+| Test binary | Count |
+|---|---|
+| `extraction_unit` (slice 2 new) | 30 |
+| `config_parsing` (slice 1 carry) | 13 |
+| `cli_smoke` (slice 1 carry) | 2 |
+| `integration_db` (slice 1 carry, SKIP path) | 2 |
+| `integration_init` (slice 1 carry, SKIP path) | 1 |
+| `integration_status` (slice 1 carry, SKIP path) | 1 |
+| `integration_index` (slice 2 new, SKIP path) | 1 |
+| **Total** | **50** |
+
+All clippy/fmt clean. Tag at HEAD.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-06-codegraph-rs-slice-2-rust-extraction.md
+++ b/docs/superpowers/plans/2026-05-06-codegraph-rs-slice-2-rust-extraction.md
@@ -1,0 +1,2095 @@
+# codegraph-rs Slice 2 — Rust Extraction
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Index a Rust codebase. After this slice, `codegraph-rs index` walks a workspace's source roots, parses every `.rs` file with tree-sitter, extracts `Symbol`/`Function`/`Struct`/`Enum`/`Trait`/`TypeAlias`/`Module`/`Import` nodes plus structural `CONTAINS` edges, persists `UnresolvedRef` records for call sites, and writes everything to Neo4j. Resolution-derived edges (`CALLS`, etc.) come in Slice 3.
+
+**Architecture:** Walk filesystems with `ignore` (ripgrep's walker, .gitignore-aware). Parse with `tree-sitter` + `tree-sitter-rust`, one `Parser` per worker thread (parsers are not `Sync`). Each language has a `LanguageExtractor` trait impl that runs declarative tree-sitter queries (`.scm` files) over the AST and produces an `ExtractionResult { nodes, edges, unresolved_refs }`. `rayon` parallelizes parsing across files; results stream through a `tokio::mpsc` channel into an async DB writer that batches `UNWIND $batch AS row MERGE ...` statements. Content hash via `blake3` for sync diffing.
+
+**Tech Stack:** Rust 1.91, tree-sitter 0.25, tree-sitter-rust 0.24, ignore 0.4, blake3 1.8, rayon 1.12; existing slice-1 stack (clap, serde, toml, tokio, neo4rs, anyhow, tracing).
+
+**Source spec:** [`docs/superpowers/specs/2026-04-22-codegraph-rs-design.md`](../specs/2026-04-22-codegraph-rs-design.md) — primarily §4 (schema), §6 (extraction pipeline). This slice does NOT implement §7 (resolution) or §8 (vectors).
+
+**Slice 1 baseline:** HEAD of `codegraph-rs` is `82dde3a` (tagged `slice-1-walking-skeleton`). Slice 2 builds on it.
+
+---
+
+## What gets indexed in Slice 2
+
+For each `.rs` file in a workspace root:
+
+| AST node | Becomes | Notes |
+|---|---|---|
+| The file itself | `(:File:Symbol)` | Stores `content_hash` (BLAKE3) and `last_indexed_at` |
+| `function_item` | `(:Function:Symbol)` | qualified_name = `<crate-relative-path>::<name>` |
+| `struct_item` | `(:Struct:Symbol)` | |
+| `enum_item` | `(:Enum:Symbol)` | |
+| `trait_item` | `(:Trait:Symbol)` | |
+| `type_item` | `(:TypeAlias:Symbol)` | |
+| `mod_item` | `(:Module:Symbol)` | nested modules within a file |
+| `use_declaration` | `(:Import:Symbol)` | the source-side; resolution to a real `Module` is Slice 3 |
+| `call_expression` | `(:UnresolvedRef)` with `kind="call"` | persistent record; resolution to `:CALLS` edges is Slice 3 |
+| `(File)-CONTAINS->(every nested Symbol)` | structural edge | parent for non-impl items is the file |
+| `(Symbol)-HAS_REF->(UnresolvedRef)` | structural edge | source-side of the unresolved reference |
+
+**`impl` blocks:** per the spec, `impl` is NOT a node. Methods in `impl Foo { fn bar() }` are emitted as `Method` nodes whose `qualified_name` carries the type prefix (`<path>::Foo::bar`). Their `CONTAINS` parent is the source file.
+
+**Out of scope for Slice 2** (intentionally):
+- `CALLS`, `IMPORTS` (target side), `REFERENCES` edges — resolution-derived, comes in Slice 3
+- Field/property/parameter/variable extraction (Slice 3 might add these as warranted)
+- Daml support (Slice 7)
+- Embeddings (Slice 4)
+- Sync (Slice 5) — full reindex only
+- Any framework-specific enrichment
+
+---
+
+## File structure produced by this slice
+
+```
+codegraph-rs/
+  Cargo.toml                                  # adds extraction deps
+  src/
+    lib.rs                                    # add `pub mod extraction;`
+    cli/
+      index.rs                                # NEW: real `index` command (replaces dispatch stub)
+      mod.rs                                  # wire Index variant -> index::run
+    extraction/
+      mod.rs                                  # re-exports
+      result.rs                               # ExtractionResult + RawNode + RawEdge + UnresolvedRef + enums
+      walker.rs                               # ignore-crate file discovery
+      parser.rs                               # per-thread tree-sitter parser
+      hash.rs                                 # blake3 content hash
+      orchestrator.rs                         # ties walker + parser + extractor + writer
+      languages/
+        mod.rs                                # LanguageExtractor trait + registry
+        rust.rs                               # Rust extractor
+        rust.scm                              # tree-sitter capture queries
+    db/
+      write.rs                                # NEW: write_extraction (UNWIND/MERGE batches)
+      mod.rs                                  # add `pub mod write;`
+  tests/
+    extraction_unit.rs                        # in-memory unit tests for walker/hash/result types
+    fixtures/
+      tiny-rust/                              # 3-file Rust mini-project, used by integration_index
+        Cargo.toml
+        src/
+          main.rs
+          util.rs
+          lib.rs
+    integration_index.rs                      # gated; indexes tiny-rust against live Neo4j
+```
+
+---
+
+### Task 1: Add slice-2 dependencies and module skeleton
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `src/lib.rs`
+- Create: `src/extraction/mod.rs`
+- Create: `src/extraction/result.rs` (stub)
+- Create: `src/extraction/walker.rs` (stub)
+- Create: `src/extraction/parser.rs` (stub)
+- Create: `src/extraction/hash.rs` (stub)
+- Create: `src/extraction/orchestrator.rs` (stub)
+- Create: `src/extraction/languages/mod.rs` (stub)
+- Create: `src/extraction/languages/rust.rs` (stub)
+- Create: `src/extraction/languages/rust.scm` (empty)
+- Create: `src/db/write.rs` (stub)
+- Modify: `src/db/mod.rs` (add `pub mod write;`)
+
+- [ ] **Step 1: Add extraction deps to Cargo.toml**
+
+In `/Users/gyorgybalazsi/codegraph-rs/Cargo.toml`, add to `[dependencies]`:
+
+```toml
+tree-sitter = "0.25"
+tree-sitter-rust = "0.24"
+ignore = "0.4"
+blake3 = "1"
+rayon = "1"
+```
+
+Place these alphabetically among the existing deps. Result section should look like:
+
+```toml
+[dependencies]
+anyhow = "1"
+blake3 = "1"
+clap = { version = "4", features = ["derive", "env"] }
+ignore = "0.4"
+neo4rs = "0.8"
+rayon = "1"
+serde = { version = "1", features = ["derive"] }
+thiserror = "2"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-util", "io-std", "fs", "process", "signal"] }
+toml = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tree-sitter = "0.25"
+tree-sitter-rust = "0.24"
+```
+
+(Order may differ from the existing file — match the existing alphabetical convention.)
+
+- [ ] **Step 2: Update src/lib.rs**
+
+Add `pub mod extraction;` to `src/lib.rs` after the existing `pub mod db;`:
+
+```rust
+pub mod cli;
+pub mod config;
+pub mod db;
+pub mod extraction;
+```
+
+- [ ] **Step 3: Create the extraction module skeleton**
+
+Create `src/extraction/mod.rs`:
+
+```rust
+//! Tree-sitter-based extraction pipeline.
+
+pub mod hash;
+pub mod languages;
+pub mod orchestrator;
+pub mod parser;
+pub mod result;
+pub mod walker;
+
+pub use orchestrator::run_extraction;
+pub use result::{ExtractionResult, RawEdge, RawNode, UnresolvedRef};
+```
+
+Create `src/extraction/result.rs`:
+
+```rust
+//! ExtractionResult and the raw node/edge/ref types. Filled in by Task 2.
+```
+
+Create `src/extraction/walker.rs`:
+
+```rust
+//! File discovery via the `ignore` crate. Filled in by Task 3.
+```
+
+Create `src/extraction/hash.rs`:
+
+```rust
+//! BLAKE3 content hashing. Filled in by Task 4.
+```
+
+Create `src/extraction/parser.rs`:
+
+```rust
+//! Per-thread tree-sitter parser. Filled in by Task 5.
+```
+
+Create `src/extraction/orchestrator.rs`:
+
+```rust
+//! Ties walker + parser + extractor + writer together. Filled in by Task 11.
+
+use anyhow::Result;
+use std::path::Path;
+
+pub fn run_extraction(_workspace_dir: &Path) -> Result<()> {
+    anyhow::bail!("run_extraction: not yet implemented (filled in by Task 11)")
+}
+```
+
+Create `src/extraction/languages/mod.rs`:
+
+```rust
+//! Language-specific extractors. Filled in by Tasks 6–9.
+
+pub mod rust;
+```
+
+Create `src/extraction/languages/rust.rs`:
+
+```rust
+//! Rust extractor. Filled in by Tasks 6–9.
+```
+
+Create an empty `src/extraction/languages/rust.scm` file (just a newline; Tasks 6–9 fill it).
+
+- [ ] **Step 4: Create db/write.rs stub**
+
+Create `src/db/write.rs`:
+
+```rust
+//! Batched extraction-output writer. Filled in by Task 10.
+
+use anyhow::Result;
+
+use crate::db::Connection;
+use crate::extraction::ExtractionResult;
+
+pub async fn write_extraction(_conn: &Connection, _results: Vec<ExtractionResult>) -> Result<()> {
+    anyhow::bail!("write_extraction: not yet implemented (filled in by Task 10)")
+}
+```
+
+Modify `src/db/mod.rs` to add the new module. After the existing `pub mod schema;`:
+
+```rust
+pub mod connection;
+pub mod schema;
+pub mod write;
+
+pub use connection::Connection;
+```
+
+- [ ] **Step 5: Build to verify the skeleton compiles**
+
+```bash
+cd /Users/gyorgybalazsi/codegraph-rs
+cargo build 2>&1 | tail -10
+```
+
+Expected: clean build (downloading + compiling tree-sitter-rust takes a minute on first run; subsequent builds are fast). Possibly some unused-import warnings.
+
+- [ ] **Step 6: Run the existing test suite**
+
+```bash
+cargo test 2>&1 | tail -10
+```
+
+Expected: all 15 unit tests + 4 integration SKIP-mode tests still pass. Slice 2 hasn't broken slice 1.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock src/
+git commit -m "chore(extraction): add deps and module skeleton for slice 2"
+```
+
+---
+
+### Task 2: ExtractionResult types (TDD)
+
+**Files:**
+- Modify: `src/extraction/result.rs`
+- Create: `tests/extraction_unit.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/extraction_unit.rs`:
+
+```rust
+//! Unit tests for extraction types and helpers.
+
+use codegraph_rs::extraction::result::{
+    EdgeKind, ExtractionResult, NodeKind, RawEdge, RawNode, UnresolvedKind, UnresolvedRef,
+};
+
+#[test]
+fn extraction_result_default_is_empty() {
+    let r = ExtractionResult::default();
+    assert!(r.nodes.is_empty());
+    assert!(r.edges.is_empty());
+    assert!(r.unresolved_refs.is_empty());
+}
+
+#[test]
+fn raw_node_is_constructible() {
+    let n = RawNode {
+        qid: "rs:src/lib.rs:crate::foo".to_string(),
+        kind: NodeKind::Function,
+        name: "foo".to_string(),
+        qualified_name: "crate::foo".to_string(),
+        root_name: "myroot".to_string(),
+        relative_path: "src/lib.rs".to_string(),
+        language: "rust".to_string(),
+        start_line: 10,
+        end_line: 20,
+        start_col: 0,
+        end_col: 1,
+        signature: Some("fn foo()".to_string()),
+        doc: None,
+        parse_reliable: true,
+    };
+    assert_eq!(n.name, "foo");
+    assert_eq!(n.kind, NodeKind::Function);
+}
+
+#[test]
+fn raw_edge_is_constructible() {
+    let e = RawEdge {
+        from_qid: "a".to_string(),
+        to_qid: "b".to_string(),
+        kind: EdgeKind::Contains,
+    };
+    assert_eq!(e.kind, EdgeKind::Contains);
+}
+
+#[test]
+fn unresolved_ref_is_constructible() {
+    let r = UnresolvedRef {
+        qid: "rs:src/lib.rs:crate::foo:ref:42:7:1".to_string(),
+        source_qid: "rs:src/lib.rs:crate::foo".to_string(),
+        unresolved_name: "bar".to_string(),
+        kind: UnresolvedKind::Call,
+        line: 42,
+        col: 7,
+    };
+    assert_eq!(r.kind, UnresolvedKind::Call);
+}
+
+#[test]
+fn node_kind_round_trips_to_str() {
+    use NodeKind::*;
+    for k in [File, Function, Method, Struct, Enum, Trait, TypeAlias, Module, Import] {
+        let s = k.as_label();
+        assert!(!s.is_empty());
+        assert!(s.chars().next().unwrap().is_ascii_uppercase());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — expect compile failures**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: errors about missing types in `codegraph_rs::extraction::result`.
+
+- [ ] **Step 3: Implement the types**
+
+Overwrite `src/extraction/result.rs`:
+
+```rust
+//! ExtractionResult and the raw node/edge/ref types produced by per-language extractors.
+//!
+//! These are the language-agnostic shape carried from extraction to the DB writer.
+//! No serde derives — these are internal-only.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeKind {
+    File,
+    Module,
+    Function,
+    Method,
+    Struct,
+    Enum,
+    Trait,
+    TypeAlias,
+    Import,
+}
+
+impl NodeKind {
+    /// The Neo4j label name (PascalCase, matches §4 of the spec).
+    pub fn as_label(self) -> &'static str {
+        match self {
+            NodeKind::File => "File",
+            NodeKind::Module => "Module",
+            NodeKind::Function => "Function",
+            NodeKind::Method => "Method",
+            NodeKind::Struct => "Struct",
+            NodeKind::Enum => "Enum",
+            NodeKind::Trait => "Trait",
+            NodeKind::TypeAlias => "TypeAlias",
+            NodeKind::Import => "Import",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EdgeKind {
+    /// Lexical containment (File -> Function, Module -> Class, etc.)
+    Contains,
+    /// Symbol -> its UnresolvedRef records.
+    HasRef,
+}
+
+impl EdgeKind {
+    pub fn as_relationship_type(self) -> &'static str {
+        match self {
+            EdgeKind::Contains => "CONTAINS",
+            EdgeKind::HasRef => "HAS_REF",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnresolvedKind {
+    Call,
+    Import,
+    TypeRef,
+    Reference,
+}
+
+impl UnresolvedKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UnresolvedKind::Call => "call",
+            UnresolvedKind::Import => "import",
+            UnresolvedKind::TypeRef => "type_ref",
+            UnresolvedKind::Reference => "reference",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RawNode {
+    /// Stable identifier per spec §4: `<root>:<rel_path>:<qualified_name>[#<n>]`.
+    pub qid: String,
+    pub kind: NodeKind,
+    pub name: String,
+    pub qualified_name: String,
+    pub root_name: String,
+    pub relative_path: String,
+    pub language: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub start_col: u32,
+    pub end_col: u32,
+    pub signature: Option<String>,
+    pub doc: Option<String>,
+    /// True for tree-sitter parses we trust; false for Daml template bodies
+    /// extracted via tree-sitter-haskell (Slice 7+). For Rust always true.
+    pub parse_reliable: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct RawEdge {
+    pub from_qid: String,
+    pub to_qid: String,
+    pub kind: EdgeKind,
+}
+
+#[derive(Debug, Clone)]
+pub struct UnresolvedRef {
+    /// Stable identifier per spec §7: `<source_qid>:ref:<line>:<col>:<ord>`.
+    pub qid: String,
+    pub source_qid: String,
+    pub unresolved_name: String,
+    pub kind: UnresolvedKind,
+    pub line: u32,
+    pub col: u32,
+}
+
+/// One file's extraction output.
+#[derive(Debug, Clone, Default)]
+pub struct ExtractionResult {
+    pub nodes: Vec<RawNode>,
+    pub edges: Vec<RawEdge>,
+    pub unresolved_refs: Vec<UnresolvedRef>,
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/extraction/result.rs tests/extraction_unit.rs
+git commit -m "feat(extraction): add ExtractionResult types (RawNode, RawEdge, UnresolvedRef)"
+```
+
+---
+
+### Task 3: File walker via `ignore` (TDD)
+
+**Files:**
+- Modify: `src/extraction/walker.rs`
+- Test: append to `tests/extraction_unit.rs`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/extraction_unit.rs`:
+
+```rust
+use codegraph_rs::extraction::walker::{walk_root, DiscoveredFile};
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn walker_discovers_rs_files() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("a.rs"), "fn a() {}").unwrap();
+    fs::write(dir.path().join("b.rs"), "fn b() {}").unwrap();
+    fs::write(dir.path().join("c.txt"), "not a rust file").unwrap();
+
+    let files: Vec<DiscoveredFile> = walk_root(dir.path(), "myroot", &["rust".to_string()]).collect();
+    let names: Vec<&str> = files.iter().map(|f| f.relative_path.as_str()).collect();
+    assert!(names.contains(&"a.rs"));
+    assert!(names.contains(&"b.rs"));
+    assert!(!names.iter().any(|n| n.ends_with(".txt")));
+}
+
+#[test]
+fn walker_honors_gitignore() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".gitignore"), "ignored.rs\n").unwrap();
+    fs::write(dir.path().join("kept.rs"), "fn k() {}").unwrap();
+    fs::write(dir.path().join("ignored.rs"), "fn i() {}").unwrap();
+
+    // ignore crate requires the dir to be a git repo for .gitignore to apply by default
+    fs::create_dir(dir.path().join(".git")).unwrap();
+
+    let files: Vec<DiscoveredFile> = walk_root(dir.path(), "myroot", &["rust".to_string()]).collect();
+    let names: Vec<&str> = files.iter().map(|f| f.relative_path.as_str()).collect();
+    assert!(names.contains(&"kept.rs"), "kept.rs should be discovered: {names:?}");
+    assert!(!names.contains(&"ignored.rs"), "ignored.rs should be filtered: {names:?}");
+}
+
+#[test]
+fn walker_recurses_subdirs_with_relative_paths() {
+    let dir = tempdir().unwrap();
+    fs::create_dir(dir.path().join("subdir")).unwrap();
+    fs::write(dir.path().join("subdir/nested.rs"), "fn n() {}").unwrap();
+
+    let files: Vec<DiscoveredFile> = walk_root(dir.path(), "myroot", &["rust".to_string()]).collect();
+    let names: Vec<&str> = files.iter().map(|f| f.relative_path.as_str()).collect();
+    assert!(names.iter().any(|n| n == &"subdir/nested.rs"),
+        "should find nested.rs with subdir/ prefix: {names:?}");
+}
+
+#[test]
+fn walker_filters_by_language() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("a.rs"), "fn a() {}").unwrap();
+    fs::write(dir.path().join("b.daml"), "module B").unwrap();
+
+    // Only Rust enabled
+    let rust_only: Vec<DiscoveredFile> = walk_root(dir.path(), "r", &["rust".to_string()]).collect();
+    assert_eq!(rust_only.len(), 1);
+    assert_eq!(rust_only[0].language, "rust");
+
+    // Only Daml enabled (Slice 2 doesn't extract daml but the walker should still recognize it)
+    let daml_only: Vec<DiscoveredFile> = walk_root(dir.path(), "r", &["daml".to_string()]).collect();
+    assert_eq!(daml_only.len(), 1);
+    assert_eq!(daml_only[0].language, "daml");
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: errors about missing `walk_root`, `DiscoveredFile`.
+
+- [ ] **Step 3: Implement the walker**
+
+Overwrite `src/extraction/walker.rs`:
+
+```rust
+//! File discovery via the `ignore` crate (the walker behind ripgrep).
+//!
+//! Honors `.gitignore`, `.ignore`, and a workspace-level `.codegraphignore`.
+
+use ignore::WalkBuilder;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct DiscoveredFile {
+    pub absolute_path: PathBuf,
+    pub relative_path: String,
+    pub root_name: String,
+    pub language: String,
+}
+
+/// Walk `root_dir` recursively, yielding source files whose extension maps
+/// to a language listed in `enabled_languages`.
+///
+/// The returned iterator is single-threaded; parallelism happens at the
+/// per-file extraction stage in the orchestrator.
+pub fn walk_root(
+    root_dir: &Path,
+    root_name: &str,
+    enabled_languages: &[String],
+) -> impl Iterator<Item = DiscoveredFile> {
+    let root_dir = root_dir.to_path_buf();
+    let root_name = root_name.to_string();
+    let enabled: Vec<String> = enabled_languages.iter().map(|s| s.to_lowercase()).collect();
+
+    let mut builder = WalkBuilder::new(&root_dir);
+    builder.standard_filters(true).hidden(true).follow_links(false);
+    // Add per-workspace ignore file if it exists (workspace root is the parent of `.codegraph/`,
+    // not `root_dir` — but that path is owned by the orchestrator. Walker honors any
+    // `.codegraphignore` inside `root_dir`).
+    builder.add_custom_ignore_filename(".codegraphignore");
+
+    builder.build().filter_map(move |result| {
+        let entry = result.ok()?;
+        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            return None;
+        }
+        let absolute_path = entry.path().to_path_buf();
+        let language = language_for_extension(&absolute_path)?;
+        if !enabled.iter().any(|l| l == language) {
+            return None;
+        }
+        let relative_path = absolute_path
+            .strip_prefix(&root_dir)
+            .ok()?
+            .to_string_lossy()
+            .to_string();
+        Some(DiscoveredFile {
+            absolute_path,
+            relative_path,
+            root_name: root_name.clone(),
+            language: language.to_string(),
+        })
+    })
+}
+
+fn language_for_extension(path: &Path) -> Option<&'static str> {
+    match path.extension()?.to_str()? {
+        "rs" => Some("rust"),
+        "daml" => Some("daml"),
+        _ => None,
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: 9 tests pass total (5 from Task 2 + 4 walker tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/extraction/walker.rs tests/extraction_unit.rs
+git commit -m "feat(extraction): add ignore-crate walker with extension/language filtering"
+```
+
+---
+
+### Task 4: BLAKE3 content hashing (TDD)
+
+**Files:**
+- Modify: `src/extraction/hash.rs`
+- Test: append to `tests/extraction_unit.rs`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/extraction_unit.rs`:
+
+```rust
+use codegraph_rs::extraction::hash::{file_hash, source_hash};
+
+#[test]
+fn source_hash_is_deterministic() {
+    let h1 = source_hash("hello world");
+    let h2 = source_hash("hello world");
+    assert_eq!(h1, h2);
+    assert_eq!(h1.len(), 64); // BLAKE3 hex = 64 chars
+}
+
+#[test]
+fn source_hash_differs_for_different_inputs() {
+    assert_ne!(source_hash("a"), source_hash("b"));
+}
+
+#[test]
+fn file_hash_matches_source_hash() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("foo.rs");
+    let content = "fn foo() {}";
+    fs::write(&path, content).unwrap();
+
+    assert_eq!(file_hash(&path).unwrap(), source_hash(content));
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: errors about missing `file_hash`, `source_hash`.
+
+- [ ] **Step 3: Implement hashing**
+
+Overwrite `src/extraction/hash.rs`:
+
+```rust
+//! BLAKE3 content hashing for sync diffing.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+/// Hex-encoded BLAKE3 hash of the given byte slice.
+pub fn source_hash(content: &str) -> String {
+    blake3::hash(content.as_bytes()).to_hex().to_string()
+}
+
+/// Hex-encoded BLAKE3 hash of a file's contents.
+pub fn file_hash(path: &Path) -> Result<String> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("reading `{}` for hashing", path.display()))?;
+    Ok(blake3::hash(&bytes).to_hex().to_string())
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: 12 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/extraction/hash.rs tests/extraction_unit.rs
+git commit -m "feat(extraction): add BLAKE3 file/source hashing"
+```
+
+---
+
+### Task 5: Tree-sitter parser plumbing (per-thread)
+
+**Files:**
+- Modify: `src/extraction/parser.rs`
+- Test: append to `tests/extraction_unit.rs`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/extraction_unit.rs`:
+
+```rust
+use codegraph_rs::extraction::parser::parse_rust;
+
+#[test]
+fn parser_returns_tree_for_valid_rust() {
+    let source = "fn foo() {}";
+    let tree = parse_rust(source).expect("valid Rust must parse");
+    let root = tree.root_node();
+    assert_eq!(root.kind(), "source_file");
+    // Either no errors, or at most ERROR nodes within the tree (we don't fail on those).
+    assert!(!root.has_error() || root.named_child_count() > 0);
+}
+
+#[test]
+fn parser_returns_tree_for_partial_rust_with_error_nodes() {
+    // Even broken source returns a tree (with ERROR nodes inside).
+    let source = "fn foo( {";
+    let tree = parse_rust(source);
+    assert!(tree.is_some());
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: errors about missing `parse_rust`.
+
+- [ ] **Step 3: Implement parser plumbing**
+
+Overwrite `src/extraction/parser.rs`:
+
+```rust
+//! Per-thread tree-sitter parsers.
+//!
+//! `tree_sitter::Parser` is `Send` but not `Sync`, so we use `thread_local!`
+//! to give each rayon worker its own reusable parser. Avoids the cost of
+//! reconstructing the parser per file.
+
+use std::cell::RefCell;
+use tree_sitter::{Parser, Tree};
+
+thread_local! {
+    static RUST_PARSER: RefCell<Parser> = RefCell::new(make_parser_for(tree_sitter_rust::LANGUAGE.into()));
+}
+
+fn make_parser_for(language: tree_sitter::Language) -> Parser {
+    let mut p = Parser::new();
+    p.set_language(&language).expect("valid grammar");
+    p
+}
+
+/// Parse a Rust source string using this thread's pooled parser.
+/// Returns None only if tree-sitter itself can't allocate a tree.
+pub fn parse_rust(source: &str) -> Option<Tree> {
+    RUST_PARSER.with(|cell| cell.borrow_mut().parse(source, None))
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: 14 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/extraction/parser.rs tests/extraction_unit.rs
+git commit -m "feat(extraction): add per-thread tree-sitter parser pool"
+```
+
+---
+
+### Task 6: Rust extractor — `function_item` → `Function` (TDD)
+
+**Files:**
+- Modify: `src/extraction/languages/rust.rs`
+- Modify: `src/extraction/languages/rust.scm`
+- Test: append to `tests/extraction_unit.rs`
+
+This task introduces the `LanguageExtractor` trait, the Rust impl, and tree-sitter capture queries — but limited to `function_item` only. Tasks 7–9 extend the surface.
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/extraction_unit.rs`:
+
+```rust
+use codegraph_rs::extraction::languages::rust::extract_rust;
+use codegraph_rs::extraction::result::NodeKind;
+
+#[test]
+fn extracts_top_level_function() {
+    let source = r#"fn foo() { let x = 1; }"#;
+    let result = extract_rust(source, "myroot", "src/lib.rs").expect("extraction must succeed");
+
+    let funcs: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Function).collect();
+    assert_eq!(funcs.len(), 1, "expected 1 Function, got {}", funcs.len());
+
+    let f = &funcs[0];
+    assert_eq!(f.name, "foo");
+    assert!(f.qualified_name.contains("foo"));
+    assert_eq!(f.relative_path, "src/lib.rs");
+    assert_eq!(f.root_name, "myroot");
+    assert_eq!(f.language, "rust");
+    assert_eq!(f.start_line, 1);
+    assert!(f.parse_reliable);
+}
+
+#[test]
+fn extracts_multiple_functions_in_order() {
+    let source = "fn a() {}\nfn b() {}\nfn c() {}\n";
+    let result = extract_rust(source, "r", "f.rs").expect("ok");
+    let funcs: Vec<&str> = result.nodes.iter()
+        .filter(|n| n.kind == NodeKind::Function)
+        .map(|n| n.name.as_str())
+        .collect();
+    assert_eq!(funcs, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn extraction_emits_file_node() {
+    let source = "fn x() {}";
+    let result = extract_rust(source, "r", "f.rs").expect("ok");
+    let files: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::File).collect();
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].name, "f.rs");
+    assert_eq!(files[0].relative_path, "f.rs");
+}
+
+#[test]
+fn extraction_emits_contains_edge_from_file_to_function() {
+    use codegraph_rs::extraction::result::EdgeKind;
+    let source = "fn y() {}";
+    let result = extract_rust(source, "r", "f.rs").expect("ok");
+    let contains: Vec<_> = result.edges.iter().filter(|e| e.kind == EdgeKind::Contains).collect();
+    assert!(!contains.is_empty(), "expected at least one CONTAINS edge");
+    // Every Function in result.nodes should have a CONTAINS edge from the File.
+    let file_qid = &result.nodes.iter().find(|n| n.kind == NodeKind::File).unwrap().qid;
+    let func_qid = &result.nodes.iter().find(|n| n.kind == NodeKind::Function).unwrap().qid;
+    assert!(contains.iter().any(|e| e.from_qid == *file_qid && e.to_qid == *func_qid));
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: errors about missing `extract_rust`.
+
+- [ ] **Step 3: Write the tree-sitter query for functions**
+
+Overwrite `src/extraction/languages/rust.scm`:
+
+```scheme
+; Top-level function items.
+(function_item
+  name: (identifier) @function.name) @function.def
+```
+
+- [ ] **Step 4: Implement the Rust extractor**
+
+Overwrite `src/extraction/languages/rust.rs`:
+
+```rust
+//! Rust language extractor.
+//!
+//! Uses tree-sitter-rust + a `.scm` capture query to locate interesting AST nodes
+//! declaratively. Tasks 6–9 incrementally grow the supported node kinds.
+
+use anyhow::{Context, Result};
+use tree_sitter::{Query, QueryCursor, StreamingIterator};
+
+use crate::extraction::parser::parse_rust;
+use crate::extraction::result::{
+    EdgeKind, ExtractionResult, NodeKind, RawEdge, RawNode,
+};
+
+const QUERY_SOURCE: &str = include_str!("rust.scm");
+
+/// Extract a single Rust file. Always emits one File node + zero or more
+/// per-symbol nodes + the structural CONTAINS edges connecting them.
+pub fn extract_rust(source: &str, root_name: &str, relative_path: &str) -> Result<ExtractionResult> {
+    let tree = parse_rust(source).context("tree-sitter-rust failed to produce a tree")?;
+
+    let language = tree_sitter_rust::LANGUAGE;
+    let query = Query::new(&language.into(), QUERY_SOURCE)
+        .context("invalid tree-sitter-rust query")?;
+    let function_def_idx = query.capture_index_for_name("function.def")
+        .context("query missing capture `function.def`")? as u32;
+    let function_name_idx = query.capture_index_for_name("function.name")
+        .context("query missing capture `function.name`")? as u32;
+
+    let mut result = ExtractionResult::default();
+    let file_node = build_file_node(source, root_name, relative_path);
+    let file_qid = file_node.qid.clone();
+    result.nodes.push(file_node);
+
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
+
+    let mut function_ordinals: std::collections::HashMap<String, u32> = Default::default();
+
+    while let Some(m) = matches.next() {
+        let mut def_node = None;
+        let mut name_node = None;
+        for cap in m.captures {
+            if cap.index == function_def_idx { def_node = Some(cap.node); }
+            else if cap.index == function_name_idx { name_node = Some(cap.node); }
+        }
+        if let (Some(def), Some(name)) = (def_node, name_node) {
+            let func_name = name.utf8_text(source.as_bytes()).unwrap_or("?").to_string();
+            let qualified_name = format!("{}::{}", path_to_module(relative_path), func_name);
+            let key = format!("{root_name}:{relative_path}:{qualified_name}");
+            let ord = function_ordinals.entry(key.clone()).and_modify(|n| *n += 1).or_insert(0);
+            let qid = if *ord == 0 { key.clone() } else { format!("{key}#{ord}") };
+
+            let start = def.start_position();
+            let end = def.end_position();
+            let signature = signature_text(source, def);
+
+            result.nodes.push(RawNode {
+                qid: qid.clone(),
+                kind: NodeKind::Function,
+                name: func_name,
+                qualified_name,
+                root_name: root_name.to_string(),
+                relative_path: relative_path.to_string(),
+                language: "rust".to_string(),
+                start_line: (start.row as u32) + 1,
+                end_line: (end.row as u32) + 1,
+                start_col: start.column as u32,
+                end_col: end.column as u32,
+                signature: Some(signature),
+                doc: None,
+                parse_reliable: true,
+            });
+            result.edges.push(RawEdge {
+                from_qid: file_qid.clone(),
+                to_qid: qid,
+                kind: EdgeKind::Contains,
+            });
+        }
+    }
+
+    Ok(result)
+}
+
+fn build_file_node(source: &str, root_name: &str, relative_path: &str) -> RawNode {
+    let qid = format!("{root_name}:{relative_path}");
+    let name = std::path::Path::new(relative_path)
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| relative_path.to_string());
+    let line_count = source.lines().count() as u32;
+    RawNode {
+        qid,
+        kind: NodeKind::File,
+        name,
+        qualified_name: relative_path.to_string(),
+        root_name: root_name.to_string(),
+        relative_path: relative_path.to_string(),
+        language: "rust".to_string(),
+        start_line: 1,
+        end_line: line_count.max(1),
+        start_col: 0,
+        end_col: 0,
+        signature: None,
+        doc: None,
+        parse_reliable: true,
+    }
+}
+
+/// Convert `src/util/foo.rs` into a Rust-ish module path `src::util::foo`.
+/// Slice 2 doesn't read `Cargo.toml` to derive the crate root, so this is a
+/// best-effort qualified-name prefix; resolution (Slice 3) treats names by
+/// uniqueness within the workspace.
+fn path_to_module(relative_path: &str) -> String {
+    let p = std::path::Path::new(relative_path);
+    let stem: Vec<&str> = p
+        .with_extension("")
+        .components()
+        .map(|c| c.as_os_str().to_str().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect();
+    stem.join("::")
+}
+
+fn signature_text(source: &str, node: tree_sitter::Node) -> String {
+    // The "signature" for a function is everything before the body (`{ ... }`).
+    // tree-sitter-rust exposes the body as a child by field name "body".
+    let mut tail = node.start_byte();
+    if let Some(body) = node.child_by_field_name("body") {
+        tail = body.start_byte();
+    } else {
+        tail = node.end_byte();
+    }
+    let bytes = &source.as_bytes()[node.start_byte()..tail];
+    std::str::from_utf8(bytes).unwrap_or("").trim().to_string()
+}
+```
+
+> **Note on the `Path::components` chain:** `with_extension("")` returns an owned `PathBuf`. The chain takes its components, maps to `&str`, collects into a `Vec<&str>`, then converts back to an iterator and filters. The double-collect is needed because `with_extension` returns a temporary that's destroyed at the end of the expression — but the outer `let stem: Vec<&str>` keeps the strings alive via `to_str()` borrowing from `as_os_str()` of components owned by the final Vec. If the borrow checker complains, refactor to: collect once into `Vec<String>` to avoid lifetime issues.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: 18 tests pass (14 + 4 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/extraction/languages/rust.rs src/extraction/languages/rust.scm tests/extraction_unit.rs
+git commit -m "feat(extraction): Rust extractor — function_item -> Function with CONTAINS"
+```
+
+---
+
+### Task 7: Rust extractor — extend to struct/enum/trait/type/mod (TDD)
+
+**Files:**
+- Modify: `src/extraction/languages/rust.rs`
+- Modify: `src/extraction/languages/rust.scm`
+- Test: append to `tests/extraction_unit.rs`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/extraction_unit.rs`:
+
+```rust
+#[test]
+fn extracts_struct() {
+    let source = "pub struct Foo { x: u32 }";
+    let result = extract_rust(source, "r", "f.rs").expect("ok");
+    let structs: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Struct).collect();
+    assert_eq!(structs.len(), 1);
+    assert_eq!(structs[0].name, "Foo");
+}
+
+#[test]
+fn extracts_enum() {
+    let source = "enum Color { Red, Green, Blue }";
+    let result = extract_rust(source, "r", "f.rs").expect("ok");
+    let enums: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Enum).collect();
+    assert_eq!(enums.len(), 1);
+    assert_eq!(enums[0].name, "Color");
+}
+
+#[test]
+fn extracts_trait() {
+    let source = "trait Greeter { fn hi(&self); }";
+    let result = extract_rust(source, "r", "f.rs").expect("ok");
+    let traits: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Trait).collect();
+    assert_eq!(traits.len(), 1);
+    assert_eq!(traits[0].name, "Greeter");
+}
+
+#[test]
+fn extracts_type_alias() {
+    let source = "type Bar = u64;";
+    let result = extract_rust(source, "r", "f.rs").expect("ok");
+    let types: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::TypeAlias).collect();
+    assert_eq!(types.len(), 1);
+    assert_eq!(types[0].name, "Bar");
+}
+
+#[test]
+fn extracts_inner_module_declaration() {
+    let source = "mod nested { fn inside() {} }";
+    let result = extract_rust(source, "r", "f.rs").expect("ok");
+    let modules: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Module).collect();
+    assert_eq!(modules.len(), 1);
+    assert_eq!(modules[0].name, "nested");
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Expected: 5 new tests fail.
+
+- [ ] **Step 3: Extend the query and extractor**
+
+Append to `src/extraction/languages/rust.scm`:
+
+```scheme
+; Type-like definitions.
+(struct_item
+  name: (type_identifier) @struct.name) @struct.def
+
+(enum_item
+  name: (type_identifier) @enum.name) @enum.def
+
+(trait_item
+  name: (type_identifier) @trait.name) @trait.def
+
+(type_item
+  name: (type_identifier) @type.name) @type.def
+
+; Inner module declarations (mod foo { ... } or mod foo;)
+(mod_item
+  name: (identifier) @module.name) @module.def
+```
+
+In `src/extraction/languages/rust.rs`, refactor `extract_rust` to handle multiple capture pairs. Replace the function body with a generalized loop. Specifically, after the file node insertion, replace the existing `while let Some(m) = matches.next() { ... }` block with:
+
+```rust
+    // Capture-pair table: (def_capture, name_capture, NodeKind)
+    let captures: &[(&str, &str, NodeKind)] = &[
+        ("function.def", "function.name", NodeKind::Function),
+        ("struct.def", "struct.name", NodeKind::Struct),
+        ("enum.def", "enum.name", NodeKind::Enum),
+        ("trait.def", "trait.name", NodeKind::Trait),
+        ("type.def", "type.name", NodeKind::TypeAlias),
+        ("module.def", "module.name", NodeKind::Module),
+    ];
+    let resolved: Vec<(u32, u32, NodeKind)> = captures.iter()
+        .map(|(def, name, kind)| {
+            let d = query.capture_index_for_name(def)
+                .with_context(|| format!("missing capture `{def}`"))? as u32;
+            let n = query.capture_index_for_name(name)
+                .with_context(|| format!("missing capture `{name}`"))? as u32;
+            Ok::<_, anyhow::Error>((d, n, *kind))
+        })
+        .collect::<Result<_>>()?;
+
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
+
+    let mut ordinals: std::collections::HashMap<String, u32> = Default::default();
+
+    while let Some(m) = matches.next() {
+        for (def_idx, name_idx, kind) in &resolved {
+            let mut def_node = None;
+            let mut name_node = None;
+            for cap in m.captures {
+                if cap.index == *def_idx { def_node = Some(cap.node); }
+                else if cap.index == *name_idx { name_node = Some(cap.node); }
+            }
+            if let (Some(def), Some(name)) = (def_node, name_node) {
+                let item_name = name.utf8_text(source.as_bytes()).unwrap_or("?").to_string();
+                let qualified_name = format!("{}::{}", path_to_module(relative_path), item_name);
+                let key = format!("{root_name}:{relative_path}:{qualified_name}");
+                let ord = ordinals.entry(key.clone())
+                    .and_modify(|n| *n += 1).or_insert(0);
+                let qid = if *ord == 0 { key.clone() } else { format!("{key}#{ord}") };
+
+                let start = def.start_position();
+                let end = def.end_position();
+                let signature = match kind {
+                    NodeKind::Function | NodeKind::Method => Some(signature_text(source, def)),
+                    _ => None,
+                };
+
+                result.nodes.push(RawNode {
+                    qid: qid.clone(),
+                    kind: *kind,
+                    name: item_name,
+                    qualified_name,
+                    root_name: root_name.to_string(),
+                    relative_path: relative_path.to_string(),
+                    language: "rust".to_string(),
+                    start_line: (start.row as u32) + 1,
+                    end_line: (end.row as u32) + 1,
+                    start_col: start.column as u32,
+                    end_col: end.column as u32,
+                    signature,
+                    doc: None,
+                    parse_reliable: true,
+                });
+                result.edges.push(RawEdge {
+                    from_qid: file_qid.clone(),
+                    to_qid: qid,
+                    kind: EdgeKind::Contains,
+                });
+                break; // a tree-sitter match has at most one (def, name) pair we care about
+            }
+        }
+    }
+```
+
+Remove the now-stale `function_ordinals` variable, `function_def_idx`, and `function_name_idx`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: 23 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/extraction/languages/rust.rs src/extraction/languages/rust.scm tests/extraction_unit.rs
+git commit -m "feat(extraction): Rust extractor — struct/enum/trait/type/mod"
+```
+
+---
+
+### Task 8: Rust extractor — `use_declaration` → `Import` (TDD)
+
+**Files:**
+- Modify: `src/extraction/languages/rust.rs`
+- Modify: `src/extraction/languages/rust.scm`
+- Test: append to `tests/extraction_unit.rs`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/extraction_unit.rs`:
+
+```rust
+#[test]
+fn extracts_simple_use_as_import() {
+    let source = "use std::collections::HashMap;\nfn main() {}";
+    let result = extract_rust(source, "r", "main.rs").expect("ok");
+    let imports: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Import).collect();
+    assert_eq!(imports.len(), 1);
+    // The Import node's name carries the full use path.
+    assert!(imports[0].name.contains("HashMap") || imports[0].name.contains("collections"),
+        "unexpected import name: {}", imports[0].name);
+}
+
+#[test]
+fn extracts_multiple_use_declarations() {
+    let source = "use a::b;\nuse c::d;\n";
+    let result = extract_rust(source, "r", "f.rs").expect("ok");
+    let imports: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Import).collect();
+    assert_eq!(imports.len(), 2);
+}
+```
+
+- [ ] **Step 2: Append to the .scm query**
+
+Append to `src/extraction/languages/rust.scm`:
+
+```scheme
+; `use` declarations -> Import nodes.
+(use_declaration
+  argument: (_) @import.path) @import.def
+```
+
+(`(_)` matches any kind of argument node — `scoped_identifier`, `use_list`, `use_as_clause`, etc.)
+
+- [ ] **Step 3: Update the captures table**
+
+In `src/extraction/languages/rust.rs`, add to the `captures` slice:
+
+```rust
+        ("import.def", "import.path", NodeKind::Import),
+```
+
+Then handle the case that Import has a path-text-as-name rather than an identifier-token. The current code does `name.utf8_text(...)` which returns the full subtree text — that's fine for Import too. So no further code changes are required.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: 25 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/extraction/languages/rust.rs src/extraction/languages/rust.scm tests/extraction_unit.rs
+git commit -m "feat(extraction): Rust extractor — use_declaration -> Import"
+```
+
+---
+
+### Task 9: Rust extractor — `call_expression` → `UnresolvedRef` (TDD)
+
+**Files:**
+- Modify: `src/extraction/languages/rust.rs`
+- Modify: `src/extraction/languages/rust.scm`
+- Test: append to `tests/extraction_unit.rs`
+
+This task adds `UnresolvedRef` records for call sites and the structural `HAS_REF` edge from the calling Symbol to the UnresolvedRef.
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/extraction_unit.rs`:
+
+```rust
+use codegraph_rs::extraction::result::UnresolvedKind;
+
+#[test]
+fn extracts_call_as_unresolved_ref() {
+    let source = "fn caller() { foo(); }";
+    let result = extract_rust(source, "r", "f.rs").expect("ok");
+
+    assert_eq!(result.unresolved_refs.len(), 1, "expected 1 UnresolvedRef");
+    let r = &result.unresolved_refs[0];
+    assert_eq!(r.kind, UnresolvedKind::Call);
+    assert_eq!(r.unresolved_name, "foo");
+    // source_qid should be the caller function
+    assert!(r.source_qid.contains("caller"), "source_qid: {}", r.source_qid);
+}
+
+#[test]
+fn calls_inside_unknown_scope_attach_to_file() {
+    // A call at module top level (rare, but possible in macros / tests) should
+    // still produce an UnresolvedRef. Source-qid falls back to the file qid.
+    let source = "const X: i32 = bar();";
+    let result = extract_rust(source, "r", "f.rs").expect("ok");
+    assert_eq!(result.unresolved_refs.len(), 1);
+    assert_eq!(result.unresolved_refs[0].unresolved_name, "bar");
+}
+
+#[test]
+fn unresolved_ref_has_ref_edge_from_source() {
+    use codegraph_rs::extraction::result::EdgeKind;
+    let source = "fn caller() { foo(); }";
+    let result = extract_rust(source, "r", "f.rs").expect("ok");
+    assert_eq!(result.unresolved_refs.len(), 1);
+
+    let ref_qid = &result.unresolved_refs[0].qid;
+    let source_qid = &result.unresolved_refs[0].source_qid;
+    assert!(result.edges.iter().any(|e|
+        e.kind == EdgeKind::HasRef && e.from_qid == *source_qid && e.to_qid == *ref_qid),
+        "expected HAS_REF edge from {source_qid} to {ref_qid}");
+}
+```
+
+- [ ] **Step 2: Append to the .scm query**
+
+Append to `src/extraction/languages/rust.scm`:
+
+```scheme
+; Function calls -> UnresolvedRef of kind=Call.
+(call_expression
+  function: (_) @call.callee) @call.site
+```
+
+- [ ] **Step 3: Implement call extraction**
+
+The logic is different from definition extraction (calls don't define a Symbol; they reference one). Add a separate query+iteration pass after the existing definition extraction.
+
+In `src/extraction/languages/rust.rs`, after the existing `while let Some(m) = matches.next() { ... }` loop and before `Ok(result)`, add:
+
+```rust
+    // Pass 2: call expressions -> UnresolvedRef with HAS_REF edge.
+    let call_callee_idx = query.capture_index_for_name("call.callee")
+        .context("missing capture `call.callee`")? as u32;
+    let call_site_idx = query.capture_index_for_name("call.site")
+        .context("missing capture `call.site`")? as u32;
+
+    let mut cursor2 = QueryCursor::new();
+    let mut call_matches = cursor2.matches(&query, tree.root_node(), source.as_bytes());
+    let mut ref_ord: std::collections::HashMap<String, u32> = Default::default();
+
+    while let Some(m) = call_matches.next() {
+        let mut callee = None;
+        let mut site = None;
+        for cap in m.captures {
+            if cap.index == call_callee_idx { callee = Some(cap.node); }
+            else if cap.index == call_site_idx { site = Some(cap.node); }
+        }
+        if let (Some(callee), Some(site)) = (callee, site) {
+            let name_text = callee.utf8_text(source.as_bytes()).unwrap_or("?").to_string();
+            // The "leaf" name is the last segment of a possibly-qualified call.
+            let leaf = name_text.split("::").last().unwrap_or(&name_text)
+                .trim_end_matches(|c: char| !c.is_alphanumeric() && c != '_').to_string();
+            let pos = site.start_position();
+            let line = (pos.row as u32) + 1;
+            let col = pos.column as u32;
+            let source_qid = enclosing_symbol_qid(&result.nodes, line, col).unwrap_or(&file_qid).clone();
+            let key = format!("{source_qid}:ref:{line}:{col}");
+            let ord = ref_ord.entry(key.clone()).and_modify(|n| *n += 1).or_insert(0);
+            let qid = format!("{key}:{ord}");
+
+            result.unresolved_refs.push(crate::extraction::result::UnresolvedRef {
+                qid: qid.clone(),
+                source_qid: source_qid.clone(),
+                unresolved_name: leaf,
+                kind: crate::extraction::result::UnresolvedKind::Call,
+                line,
+                col,
+            });
+            result.edges.push(RawEdge {
+                from_qid: source_qid,
+                to_qid: qid,
+                kind: EdgeKind::HasRef,
+            });
+        }
+    }
+```
+
+Then add this helper at the bottom of `rust.rs`:
+
+```rust
+/// Find the smallest Symbol node (Function/Method/etc.) in `nodes` whose
+/// span contains the given (line, col). Used to attach a call site to its
+/// enclosing function as the source of the UnresolvedRef.
+fn enclosing_symbol_qid(nodes: &[RawNode], line: u32, col: u32) -> Option<&String> {
+    let mut best: Option<&RawNode> = None;
+    for n in nodes {
+        if matches!(n.kind, NodeKind::File) { continue; }
+        let in_span = (n.start_line < line || (n.start_line == line && n.start_col <= col))
+            && (n.end_line > line || (n.end_line == line && n.end_col >= col));
+        if !in_span { continue; }
+        match best {
+            None => best = Some(n),
+            Some(b) => {
+                let n_lines = n.end_line.saturating_sub(n.start_line);
+                let b_lines = b.end_line.saturating_sub(b.start_line);
+                if n_lines < b_lines { best = Some(n); }
+            }
+        }
+    }
+    best.map(|n| &n.qid)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: 28 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/extraction/languages/rust.rs src/extraction/languages/rust.scm tests/extraction_unit.rs
+git commit -m "feat(extraction): Rust extractor — call_expression -> UnresolvedRef + HAS_REF"
+```
+
+---
+
+### Task 10: `db::write_extraction` — UNWIND/MERGE batches
+
+**Files:**
+- Modify: `src/db/write.rs`
+- Test: append `tests/integration_index.rs` (gated, but still creates the test fixture). The actual run-against-Neo4j happens in Task 12.
+
+This task implements the batch writer. The integration test is added in Task 12 (which also creates the `tiny-rust` fixture). For now, write only unit-friendly code; verify by reading.
+
+- [ ] **Step 1: Implement `write_extraction`**
+
+Overwrite `src/db/write.rs`:
+
+```rust
+//! Persist extraction results to Neo4j via batched UNWIND/MERGE statements.
+//!
+//! Strategy: collect all nodes/edges/refs across all files, group by kind
+//! (label / relationship type), and issue one UNWIND batch per group of ~500.
+
+use anyhow::{Context, Result};
+use neo4rs::query as cypher;
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+
+use crate::db::Connection;
+use crate::extraction::result::{EdgeKind, NodeKind, RawEdge, RawNode, UnresolvedKind, UnresolvedRef};
+use crate::extraction::ExtractionResult;
+
+const BATCH_SIZE: usize = 500;
+
+pub async fn write_extraction(conn: &Connection, results: Vec<ExtractionResult>) -> Result<()> {
+    // Aggregate.
+    let mut nodes_by_kind: HashMap<NodeKind, Vec<RawNode>> = HashMap::new();
+    let mut edges_by_kind: HashMap<EdgeKind, Vec<RawEdge>> = HashMap::new();
+    let mut refs: Vec<UnresolvedRef> = Vec::new();
+
+    for r in results {
+        for n in r.nodes { nodes_by_kind.entry(n.kind).or_default().push(n); }
+        for e in r.edges { edges_by_kind.entry(e.kind).or_default().push(e); }
+        refs.extend(r.unresolved_refs);
+    }
+
+    // Write nodes (Symbol + specific label for each).
+    for (kind, nodes) in nodes_by_kind {
+        write_nodes(conn, kind, &nodes).await
+            .with_context(|| format!("writing {} {:?} nodes", nodes.len(), kind))?;
+    }
+
+    // Write UnresolvedRef nodes.
+    write_unresolved_refs(conn, &refs).await.context("writing UnresolvedRef nodes")?;
+
+    // Write edges (CONTAINS and HAS_REF).
+    for (kind, edges) in edges_by_kind {
+        write_edges(conn, kind, &edges).await
+            .with_context(|| format!("writing {} {:?} edges", edges.len(), kind))?;
+    }
+
+    Ok(())
+}
+
+async fn write_nodes(conn: &Connection, kind: NodeKind, nodes: &[RawNode]) -> Result<()> {
+    let label = kind.as_label();
+    let cypher_text = format!(
+        "UNWIND $batch AS row \
+         MERGE (n:Symbol:{label} {{qid: row.qid}}) \
+         SET n.name = row.name, \
+             n.qualified_name = row.qualified_name, \
+             n.root_name = row.root_name, \
+             n.relative_path = row.relative_path, \
+             n.language = row.language, \
+             n.start_line = row.start_line, \
+             n.end_line = row.end_line, \
+             n.start_col = row.start_col, \
+             n.end_col = row.end_col, \
+             n.signature = row.signature, \
+             n.doc = row.doc, \
+             n.parse_reliable = row.parse_reliable"
+    );
+
+    for chunk in nodes.chunks(BATCH_SIZE) {
+        let batch: Vec<Value> = chunk.iter().map(node_to_json).collect();
+        conn.graph
+            .execute(cypher(&cypher_text).param("batch", Value::Array(batch)))
+            .await?
+            .next()
+            .await
+            .ok();
+    }
+    Ok(())
+}
+
+async fn write_unresolved_refs(conn: &Connection, refs: &[UnresolvedRef]) -> Result<()> {
+    let cypher_text = "\
+        UNWIND $batch AS row \
+        MERGE (n:UnresolvedRef {qid: row.qid}) \
+        SET n.source_qid = row.source_qid, \
+            n.unresolved_name = row.unresolved_name, \
+            n.kind = row.kind, \
+            n.line = row.line, \
+            n.col = row.col";
+
+    for chunk in refs.chunks(BATCH_SIZE) {
+        let batch: Vec<Value> = chunk.iter().map(ref_to_json).collect();
+        conn.graph
+            .execute(cypher(cypher_text).param("batch", Value::Array(batch)))
+            .await?
+            .next()
+            .await
+            .ok();
+    }
+    Ok(())
+}
+
+async fn write_edges(conn: &Connection, kind: EdgeKind, edges: &[RawEdge]) -> Result<()> {
+    let rel = kind.as_relationship_type();
+    // CONTAINS connects File/Module/Symbol to a Symbol; HAS_REF connects Symbol to UnresolvedRef.
+    // For the v1 schema we MATCH any node by qid (using the qid uniqueness constraint).
+    let cypher_text = format!(
+        "UNWIND $batch AS row \
+         MATCH (a {{qid: row.from_qid}}) \
+         MATCH (b {{qid: row.to_qid}}) \
+         MERGE (a)-[:{rel}]->(b)"
+    );
+
+    for chunk in edges.chunks(BATCH_SIZE) {
+        let batch: Vec<Value> = chunk.iter().map(edge_to_json).collect();
+        conn.graph
+            .execute(cypher(&cypher_text).param("batch", Value::Array(batch)))
+            .await?
+            .next()
+            .await
+            .ok();
+    }
+    Ok(())
+}
+
+fn node_to_json(n: &RawNode) -> Value {
+    let mut m = Map::new();
+    m.insert("qid".into(), n.qid.clone().into());
+    m.insert("name".into(), n.name.clone().into());
+    m.insert("qualified_name".into(), n.qualified_name.clone().into());
+    m.insert("root_name".into(), n.root_name.clone().into());
+    m.insert("relative_path".into(), n.relative_path.clone().into());
+    m.insert("language".into(), n.language.clone().into());
+    m.insert("start_line".into(), n.start_line.into());
+    m.insert("end_line".into(), n.end_line.into());
+    m.insert("start_col".into(), n.start_col.into());
+    m.insert("end_col".into(), n.end_col.into());
+    m.insert("signature".into(), n.signature.clone().map(Value::String).unwrap_or(Value::Null));
+    m.insert("doc".into(), n.doc.clone().map(Value::String).unwrap_or(Value::Null));
+    m.insert("parse_reliable".into(), n.parse_reliable.into());
+    Value::Object(m)
+}
+
+fn ref_to_json(r: &UnresolvedRef) -> Value {
+    let mut m = Map::new();
+    m.insert("qid".into(), r.qid.clone().into());
+    m.insert("source_qid".into(), r.source_qid.clone().into());
+    m.insert("unresolved_name".into(), r.unresolved_name.clone().into());
+    m.insert("kind".into(), r.kind.as_str().into());
+    m.insert("line".into(), r.line.into());
+    m.insert("col".into(), r.col.into());
+    Value::Object(m)
+}
+
+fn edge_to_json(e: &RawEdge) -> Value {
+    let mut m = Map::new();
+    m.insert("from_qid".into(), e.from_qid.clone().into());
+    m.insert("to_qid".into(), e.to_qid.clone().into());
+    Value::Object(m)
+}
+```
+
+> **Note on `UnresolvedKind`:** `UnresolvedKind` was used here in the import line (`use crate::extraction::result::{... UnresolvedKind ...}`). The `as_str()` method called on `r.kind` is what the writer needs. If your `result.rs` from Task 2 doesn't have `UnresolvedKind::as_str()`, add it. The Task 2 spec includes it; verify before continuing.
+
+- [ ] **Step 2: Add serde_json dependency**
+
+`serde_json` isn't in slice 1's Cargo.toml. Add it now since `neo4rs` 0.8 takes parameters as `serde_json::Value` (or via `BoltType`; use serde_json for ergonomics).
+
+In `/Users/gyorgybalazsi/codegraph-rs/Cargo.toml`, add to `[dependencies]`:
+
+```toml
+serde_json = "1"
+```
+
+> Implementer note: if `neo4rs::query(...).param(...)` does NOT accept `serde_json::Value` directly, switch to `neo4rs::BoltType` construction. The neo4rs 0.8 README shows `query(...).param("k", value)` where `value: impl Into<BoltType>`. `BoltType: From<serde_json::Value>` exists; if not, adapt with `BoltType::Map`/`BoltType::List`/etc. by hand. Validate via the Task 12 integration test.
+
+- [ ] **Step 3: Build and verify**
+
+```bash
+cargo build 2>&1 | tail -5
+```
+
+Expected: clean. If neo4rs's `param` doesn't accept `serde_json::Value` directly, you'll see compile errors — adjust per the note above.
+
+- [ ] **Step 4: Run all tests (no integration_index yet — added in Task 12)**
+
+```bash
+cargo test 2>&1 | tail -10
+```
+
+Expected: existing tests still pass; no new tests added in this task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/db/write.rs Cargo.toml Cargo.lock
+git commit -m "feat(db): write_extraction — batched UNWIND/MERGE for nodes, edges, refs"
+```
+
+---
+
+### Task 11: Wire up `codegraph-rs index` command
+
+**Files:**
+- Create: `src/cli/index.rs`
+- Modify: `src/cli/mod.rs`
+- Modify: `src/extraction/orchestrator.rs`
+
+- [ ] **Step 1: Implement the orchestrator**
+
+Overwrite `src/extraction/orchestrator.rs`:
+
+```rust
+//! Ties walker + parser + extractor together for a workspace, returning
+//! a list of ExtractionResult — one per file. Parallel via rayon.
+
+use anyhow::{Context, Result};
+use rayon::prelude::*;
+use std::path::Path;
+use tracing::warn;
+
+use crate::config::workspace::WorkspaceConfig;
+use crate::extraction::languages::rust::extract_rust;
+use crate::extraction::result::ExtractionResult;
+use crate::extraction::walker::walk_root;
+
+pub fn run_extraction(_workspace_dir: &Path, cfg: &WorkspaceConfig) -> Result<Vec<ExtractionResult>> {
+    let languages = &cfg.indexing.languages;
+
+    let files: Vec<_> = cfg.workspace.roots.iter()
+        .flat_map(|root| walk_root(&root.path, &root.name, languages))
+        .collect();
+
+    let results: Vec<Result<ExtractionResult>> = files.par_iter().map(|f| {
+        let source = std::fs::read_to_string(&f.absolute_path)
+            .with_context(|| format!("reading {}", f.absolute_path.display()))?;
+        match f.language.as_str() {
+            "rust" => extract_rust(&source, &f.root_name, &f.relative_path),
+            "daml" => Ok(ExtractionResult::default()), // Slice 7 fills in
+            other => {
+                warn!("no extractor for language `{other}`, skipping {}", f.relative_path);
+                Ok(ExtractionResult::default())
+            }
+        }
+    }).collect();
+
+    let mut ok = Vec::with_capacity(results.len());
+    for (idx, r) in results.into_iter().enumerate() {
+        match r {
+            Ok(er) => ok.push(er),
+            Err(e) => warn!("extraction failed for file {idx}: {e:#}"),
+        }
+    }
+    Ok(ok)
+}
+```
+
+- [ ] **Step 2: Implement the index CLI command**
+
+Create `src/cli/index.rs`:
+
+```rust
+//! `codegraph-rs index` — full-workspace extraction + write.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+use tracing::info;
+
+use crate::config::secrets::resolve_neo4j_password;
+use crate::config::workspace;
+use crate::db::{schema::apply_schema, write::write_extraction, Connection};
+use crate::extraction::orchestrator::run_extraction;
+
+pub fn run(workspace_arg: Option<&Path>) -> Result<()> {
+    let starting = workspace_arg.map(Path::to_path_buf).unwrap_or_else(|| {
+        std::env::current_dir().expect("cwd readable")
+    });
+    let workspace_dir = workspace::find_workspace_root(&starting)
+        .context("no workspace found; run `codegraph-rs init` first")?;
+    let cfg = workspace::load_from_path(&workspace_dir)?;
+    let pw = resolve_neo4j_password(&workspace_dir, None)?;
+
+    info!("extracting workspace `{}`", cfg.workspace.name);
+    let results = run_extraction(&workspace_dir, &cfg).context("extraction failed")?;
+
+    // Capture stats BEFORE moving `results` into write_extraction.
+    let file_count = results.len();
+    let total_nodes: usize = results.iter().map(|r| r.nodes.len()).sum();
+    let total_edges: usize = results.iter().map(|r| r.edges.len()).sum();
+    let total_refs: usize = results.iter().map(|r| r.unresolved_refs.len()).sum();
+    info!("extracted {total_nodes} nodes, {total_edges} edges, {total_refs} unresolved refs from {file_count} files");
+
+    let rt = tokio::runtime::Runtime::new().context("starting tokio runtime")?;
+    rt.block_on(async {
+        let conn = Connection::open(
+            &cfg.workspace.neo4j.uri,
+            &cfg.workspace.neo4j.username,
+            &pw.value,
+            &cfg.workspace.neo4j.database,
+        ).await.context("connecting to workspace database")?;
+
+        // Schema is idempotent; ensure it's there before writing.
+        apply_schema(&conn).await.context("applying schema")?;
+
+        write_extraction(&conn, results).await.context("writing extraction to Neo4j")?;
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    println!("Indexed {file_count} files: {total_nodes} nodes, {total_edges} edges, {total_refs} unresolved refs");
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Wire dispatch**
+
+In `src/cli/mod.rs`, add `pub mod index;` near the existing `pub mod init;` and `pub mod status;`. Update the dispatch match arm:
+
+```rust
+        Command::Index => index::run(cli.workspace.as_deref()),
+```
+
+Replace the existing combined arm:
+```rust
+        Command::Index | Command::Sync | Command::Query { .. } | Command::Serve => {
+            anyhow::bail!("not yet implemented in slice 1");
+        }
+```
+With:
+```rust
+        Command::Index => index::run(cli.workspace.as_deref()),
+        Command::Sync | Command::Query { .. } | Command::Serve => {
+            anyhow::bail!("not yet implemented");
+        }
+```
+
+- [ ] **Step 4: Build and run tests**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo test 2>&1 | tail -10
+```
+
+Expected: build clean. The `cli_smoke` test for `index` previously expected "not yet implemented" — but `index` now runs the real command (which will fail without a workspace, with a different error). Update the test if needed.
+
+In `tests/cli_smoke.rs`, the test `slice1_stub_commands_fail_with_not_implemented` iterates over `["index", "sync", "serve"]`. Remove `"index"` from that list (since it's now implemented and will produce a different error message):
+
+```rust
+    for sub in &["sync", "serve"] {
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli src/extraction/orchestrator.rs tests/cli_smoke.rs
+git commit -m "feat(cli): wire up index command — orchestrate walk + parse + extract + write"
+```
+
+---
+
+### Task 12: Integration test against tiny-rust fixture
+
+**Files:**
+- Create: `tests/fixtures/tiny-rust/Cargo.toml`
+- Create: `tests/fixtures/tiny-rust/src/main.rs`
+- Create: `tests/fixtures/tiny-rust/src/util.rs`
+- Create: `tests/fixtures/tiny-rust/src/lib.rs`
+- Create: `tests/integration_index.rs` (gated)
+
+- [ ] **Step 1: Create the fixture**
+
+Create `tests/fixtures/tiny-rust/Cargo.toml`:
+
+```toml
+[package]
+name = "tiny-rust"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+```
+
+Create `tests/fixtures/tiny-rust/src/lib.rs`:
+
+```rust
+pub mod util;
+
+pub fn library_entry() {
+    util::helper();
+}
+```
+
+Create `tests/fixtures/tiny-rust/src/util.rs`:
+
+```rust
+pub fn helper() -> u32 {
+    constant() + 1
+}
+
+pub fn constant() -> u32 {
+    41
+}
+
+pub struct Config {
+    pub debug: bool,
+}
+
+pub enum Mode {
+    Fast,
+    Slow,
+}
+```
+
+Create `tests/fixtures/tiny-rust/src/main.rs`:
+
+```rust
+use tiny_rust::library_entry;
+
+fn main() {
+    library_entry();
+}
+```
+
+- [ ] **Step 2: Write the gated integration test**
+
+Create `tests/integration_index.rs`:
+
+```rust
+//! Integration test for `codegraph-rs index`. Indexes the tiny-rust fixture
+//! against a live Neo4j Desktop. Gated on CODEGRAPH_RS_TEST_NEO4J=1.
+
+use codegraph_rs::cli::{init::{InitArgs, self}, index};
+use neo4rs::query;
+use std::fs;
+use tempfile::tempdir;
+
+fn enabled() -> bool {
+    std::env::var("CODEGRAPH_RS_TEST_NEO4J").as_deref() == Ok("1")
+}
+
+#[test]
+fn indexes_tiny_rust_fixture() {
+    if !enabled() {
+        eprintln!("SKIP: set CODEGRAPH_RS_TEST_NEO4J=1 to enable");
+        return;
+    }
+    let pw = std::env::var("CODEGRAPH_RS_TEST_NEO4J_PASSWORD")
+        .expect("CODEGRAPH_RS_TEST_NEO4J_PASSWORD required");
+
+    // Set up a fresh workspace pointing at tests/fixtures/tiny-rust.
+    let dir = tempdir().unwrap();
+    let workspace_name = format!("index-test-{}", std::process::id());
+
+    // Copy fixture into the temp directory so the workspace + roots resolve cleanly.
+    let fixture_src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/tiny-rust");
+    let fixture_dst = dir.path().join("tiny-rust");
+    copy_dir(&fixture_src, &fixture_dst).unwrap();
+
+    let args = InitArgs {
+        name: workspace_name.clone(),
+        neo4j_uri: "bolt://localhost:7687".into(),
+        neo4j_user: "neo4j".into(),
+        neo4j_password: pw.clone(),
+        root: vec!["tiny=tiny-rust".into()],
+    };
+    init::run(args, Some(dir.path())).expect("init must succeed");
+
+    // Index.
+    std::env::set_var("CODEGRAPH_RS_NEO4J_PASSWORD", &pw);
+    index::run(Some(dir.path())).expect("index must succeed");
+    std::env::remove_var("CODEGRAPH_RS_NEO4J_PASSWORD");
+
+    // Verify counts via Cypher.
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let db_name = format!("codegraph-index-test-{}", std::process::id());
+        let conn = codegraph_rs::db::Connection::open(
+            "bolt://localhost:7687", "neo4j", &pw, &db_name,
+        ).await.unwrap();
+
+        let file_count: i64 = scalar(&conn, "MATCH (n:File) RETURN count(n) AS c").await;
+        let func_count: i64 = scalar(&conn, "MATCH (n:Function) RETURN count(n) AS c").await;
+        let struct_count: i64 = scalar(&conn, "MATCH (n:Struct) RETURN count(n) AS c").await;
+        let enum_count: i64 = scalar(&conn, "MATCH (n:Enum) RETURN count(n) AS c").await;
+        let unresolved: i64 = scalar(&conn, "MATCH (n:UnresolvedRef) RETURN count(n) AS c").await;
+
+        // tiny-rust has 3 .rs files (main.rs, util.rs, lib.rs).
+        // util.rs has 2 functions, 1 struct, 1 enum.
+        // lib.rs has 1 function. main.rs has 1 function (main).
+        assert_eq!(file_count, 3, "expected 3 File nodes");
+        assert!(func_count >= 4, "expected at least 4 Function nodes (got {func_count})");
+        assert_eq!(struct_count, 1, "expected 1 Struct (Config)");
+        assert_eq!(enum_count, 1, "expected 1 Enum (Mode)");
+        assert!(unresolved >= 2, "expected at least 2 UnresolvedRef (helper(), constant(), library_entry())");
+
+        // Drop the test database.
+        let sys = codegraph_rs::db::Connection::system(
+            "bolt://localhost:7687", "neo4j", &pw,
+        ).await.unwrap();
+        sys.graph.execute(query(&format!("DROP DATABASE `{db_name}` IF EXISTS WAIT")))
+            .await.unwrap().next().await.ok();
+    });
+}
+
+async fn scalar(conn: &codegraph_rs::db::Connection, cypher: &str) -> i64 {
+    let mut stream = conn.graph.execute(query(cypher)).await.unwrap();
+    let row = stream.next().await.unwrap().unwrap();
+    row.get::<i64>("c").unwrap()
+}
+
+fn copy_dir(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        let dest = dst.join(entry.file_name());
+        if path.is_dir() {
+            copy_dir(&path, &dest)?;
+        } else {
+            fs::copy(&path, &dest)?;
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Verify the SKIP path works**
+
+```bash
+cargo test --test integration_index -- --nocapture 2>&1 | tail -10
+```
+
+Expected: 1 test, prints SKIP, passes.
+
+- [ ] **Step 4: Run the test against live Neo4j (optional — for the user)**
+
+```bash
+CODEGRAPH_RS_TEST_NEO4J=1 \
+CODEGRAPH_RS_TEST_NEO4J_PASSWORD='your-password' \
+cargo test --test integration_index -- --nocapture --test-threads=1
+```
+
+Expected: test passes, indexer produces the expected counts, database is dropped on cleanup.
+
+- [ ] **Step 5: Final test suite + commit + tag slice 2**
+
+```bash
+cargo test 2>&1 | tail -10
+cargo clippy --all-targets -- -D warnings 2>&1 | tail -5
+cargo fmt --check 2>&1 | tail -3
+
+git add tests/fixtures/tiny-rust tests/integration_index.rs
+git commit -m "test(extraction): integration test indexing tiny-rust fixture against Neo4j"
+
+git tag slice-2-rust-extraction
+```
+
+Expected: all tests pass (28 unit + 4 integration_db SKIPs + 1 integration_init SKIP + 1 integration_status SKIP + 1 integration_index SKIP + 2 cli_smoke = ~37 tests). All clippy/fmt clean. Tag at HEAD.
+
+---
+
+## Slice 2 Done
+
+Verify the artifact:
+
+- [ ] `cargo build` clean
+- [ ] `cargo test` (no env vars) — all unit tests pass; integration tests SKIP cleanly
+- [ ] `CODEGRAPH_RS_TEST_NEO4J=1 cargo test -- --test-threads=1` — all tests pass
+- [ ] `codegraph-rs index` runs against a live workspace and produces non-zero counts
+- [ ] `codegraph-rs status` after indexing reports the same counts
+- [ ] No CALLS edges yet (Slice 3)
+- [ ] No embeddings yet (Slice 4)
+
+When all check, slice 2 is complete and we can write slice 3 (Resolution).

--- a/docs/superpowers/plans/2026-05-11-codegraph-rs-slice-3-resolution.md
+++ b/docs/superpowers/plans/2026-05-11-codegraph-rs-slice-3-resolution.md
@@ -1,0 +1,1291 @@
+# codegraph-rs Slice 3 — Resolution
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the persistent `UnresolvedRef` records from Slice 2 into real graph edges. After this slice, `codegraph-rs index` runs extraction followed by resolution; the resulting graph has `(:Function)-[:CALLS]->(:Function)`, `(:File)-[:IMPORTS]->(:Module)`, and `(:Symbol)-[:REFERENCES]->(:Symbol)` edges with a `confidence` property, plus per-ref `unresolved_reason` and `candidate_qids` for unresolvable cases.
+
+**Architecture:** A new top-level `resolution/` module with a single public entry point `resolve(conn) -> Result<ResolutionStats>`. Three phases per spec §7:
+- **Phase A** — process every `(:Import)` Symbol node, look up the named module in the workspace, create `(:File)-[:IMPORTS]->(:Module)` edges. Best-effort; many imports point at external crates (no Module node exists) and remain unresolved.
+- **Phase B** — for `UnresolvedRef`s with `kind="call"|"type_ref"|"reference"`, walk the source file's `IMPORTS` edges; candidates are `(:Module)-[:CONTAINS]->(symbol)` and `(:Module)-[:EXPORTS]->(symbol)` matching by name. Single candidate → resolution edge with `confidence: "import_resolved"`.
+- **Phase C** — fallback for refs Phase B didn't resolve: exact name-match against `qualified_name` across the entire workspace. Single candidate → edge with `confidence: "name_match"`. Multiple candidates → record `candidate_qids` + `unresolved_reason = "ambiguous"`. Zero → `unresolved_reason = "no_candidate"`.
+
+Resolution is **idempotent**: each `resolve()` call drops all existing `confidence`-bearing edges first, resets ref state, then rebuilds. Structural edges (`CONTAINS`, `HAS_REF`) are untouched.
+
+**Tech Stack:** unchanged from Slice 2 (neo4rs 0.8 with `json` feature, anyhow, tokio). No new crates.
+
+**Source spec:** [`docs/superpowers/specs/2026-04-22-codegraph-rs-design.md`](../specs/2026-04-22-codegraph-rs-design.md) §7 (Resolution pipeline) — fully implemented here.
+
+**Slice 2 baseline:** HEAD of `codegraph-rs` is `097b38b` (tagged `slice-2-rust-extraction`). Slice 3 builds on it.
+
+---
+
+## What gets resolved in Slice 3
+
+From the existing graph state produced by `codegraph-rs index` (Slice 2):
+
+| Input | Phase | Output |
+|---|---|---|
+| `(:Import)` Symbol nodes (with `name` containing the use path) | A | `(:File)-[:IMPORTS]->(:Module)` edge, `confidence: "import_resolved"` — only when target Module exists in the workspace |
+| `(:UnresolvedRef {kind: "call"})` | B then C | `(:Function|:Method)-[:CALLS]->(:Function|:Method)`, `confidence: "import_resolved"` or `"name_match"` |
+| `(:UnresolvedRef {kind: "type_ref"})` | B then C | `-[:TYPE_OF]->()` edges |
+| `(:UnresolvedRef {kind: "reference"})` | B then C | `-[:REFERENCES]->()` edges |
+| Refs unresolved after C | — | `unresolved_reason` set on the ref (`"no_candidate"` or `"ambiguous"`); `candidate_qids` populated if ambiguous |
+
+**Out of scope for Slice 3** (intentionally):
+- Multi-hop path resolution (Phase B only walks one hop through IMPORTS — no transitive crate resolution)
+- Framework-aware resolution (Rails, Express, React hooks, etc.)
+- Type-aware overload resolution (trait dispatch, generic instantiation)
+- Resolving references to external crates (stdlib, registry crates) — the corresponding Module nodes don't exist
+- Cross-language resolution (we only have Rust in slice 2; Daml lands in slice 7)
+
+## Known limitation: leaf-name resolution
+
+Slice 2's call-site extraction discards the path prefix on multi-segment callees: `util::helper()` becomes `unresolved_name = "helper"`, not `"util::helper"`. This means Phase B/C resolve by leaf name only. For `tiny-rust`'s simple structure this works fine (each function name is globally unique within the workspace). Real codebases will have name collisions resolved as `unresolved_reason = "ambiguous"`.
+
+A future slice can extend the Rust extractor to preserve the path; Slice 3's resolver will trivially benefit since the lookup logic doesn't care which form the name takes.
+
+---
+
+## File structure produced by this slice
+
+```
+codegraph-rs/
+  src/
+    lib.rs                          # add `pub mod resolution;`
+    cli/
+      index.rs                      # call resolve() after write_extraction
+    db/
+      mod.rs                        # add `pub mod queries;`
+      queries.rs                    # NEW: read-side helpers (find modules, candidates, etc.)
+    resolution/
+      mod.rs                        # NEW: re-exports + the `resolve()` entry point
+      stats.rs                      # NEW: ResolutionStats type
+      drop.rs                       # NEW: drop existing confidence-bearing edges
+      phase_a_imports.rs            # NEW: resolve Import nodes -> IMPORTS edges
+      phase_b_import_driven.rs      # NEW: import-driven candidate lookup
+      phase_c_name_match.rs         # NEW: workspace-wide name match
+  tests/
+    resolution_unit.rs              # in-memory tests for the candidate-selection logic
+    integration_resolve.rs          # gated; runs index+resolve on tiny-rust, asserts CALLS edges
+```
+
+---
+
+### Task 1: Module skeleton
+
+**Files:**
+- Modify: `src/lib.rs` (add `pub mod resolution;`)
+- Modify: `src/db/mod.rs` (add `pub mod queries;`)
+- Create: `src/db/queries.rs` (stub)
+- Create: `src/resolution/mod.rs`
+- Create: `src/resolution/stats.rs` (stub)
+- Create: `src/resolution/drop.rs` (stub)
+- Create: `src/resolution/phase_a_imports.rs` (stub)
+- Create: `src/resolution/phase_b_import_driven.rs` (stub)
+- Create: `src/resolution/phase_c_name_match.rs` (stub)
+
+- [ ] **Step 1: Create the module skeleton**
+
+Add `pub mod resolution;` to `src/lib.rs` after `pub mod extraction;`:
+
+```rust
+pub mod cli;
+pub mod config;
+pub mod db;
+pub mod extraction;
+pub mod resolution;
+```
+
+Add `pub mod queries;` to `src/db/mod.rs` after `pub mod write;`:
+
+```rust
+//! Neo4j Bolt client and schema management.
+
+pub mod connection;
+pub mod queries;
+pub mod schema;
+pub mod write;
+
+pub use connection::Connection;
+```
+
+Create `src/db/queries.rs`:
+
+```rust
+//! Read-side Cypher queries used by resolution. Filled in by Task 3.
+```
+
+Create `src/resolution/mod.rs`:
+
+```rust
+//! Resolution pipeline (spec §7).
+//!
+//! Turns `(:UnresolvedRef)` records into `(:Symbol)-[:CALLS|REFERENCES|TYPE_OF]->(:Symbol)`
+//! edges and `(:File)-[:IMPORTS]->(:Module)` edges, each with a `confidence`
+//! property. Idempotent: each `resolve()` call drops existing confidence-bearing
+//! edges and rebuilds.
+
+pub mod drop;
+pub mod phase_a_imports;
+pub mod phase_b_import_driven;
+pub mod phase_c_name_match;
+pub mod stats;
+
+pub use stats::ResolutionStats;
+
+use anyhow::Result;
+use crate::db::Connection;
+
+/// Run the full resolution pipeline. Filled in by Task 8.
+pub async fn resolve(_conn: &Connection) -> Result<ResolutionStats> {
+    anyhow::bail!("resolve: not yet implemented (filled in by Task 8)")
+}
+```
+
+Create `src/resolution/stats.rs`:
+
+```rust
+//! ResolutionStats — counters returned by `resolve()`. Filled in by Task 2.
+```
+
+Create the three phase stubs (`src/resolution/phase_a_imports.rs`, `phase_b_import_driven.rs`, `phase_c_name_match.rs`) each containing only a one-line doc comment:
+
+```rust
+//! Phase A: resolve Import nodes -> IMPORTS edges. Filled in by Task 5.
+```
+
+(For the b and c files, change "A" / "Imports" / "Task 5" to match.)
+
+Create `src/resolution/drop.rs`:
+
+```rust
+//! Drop all existing confidence-bearing edges. Filled in by Task 4.
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cd /Users/gyorgybalazsi/codegraph-rs
+cargo build 2>&1 | tail -5
+```
+
+Expected: clean. The `pub use stats::ResolutionStats;` line in `resolution/mod.rs` will fail because `ResolutionStats` doesn't exist yet (Task 2 adds it). To make the skeleton build, COMMENT OUT that line temporarily — Task 2 will uncomment it:
+
+```rust
+// pub use stats::ResolutionStats;  // Task 2 uncomments after defining the type
+```
+
+Re-run `cargo build` — it should now succeed.
+
+- [ ] **Step 3: Run existing tests to confirm no regressions**
+
+```bash
+cargo test 2>&1 | tail -10
+```
+
+Expected: 51 tests pass.
+
+- [ ] **Step 4: cargo fmt + clippy**
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+```
+
+Both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/
+git commit -m "chore(resolution): module skeleton for slice 3"
+```
+
+---
+
+### Task 2: `ResolutionStats` type (TDD)
+
+**Files:**
+- Modify: `src/resolution/stats.rs`
+- Modify: `src/resolution/mod.rs` (uncomment the `pub use`)
+- Create: `tests/resolution_unit.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/resolution_unit.rs`:
+
+```rust
+//! Unit tests for the resolution module.
+
+use codegraph_rs::resolution::ResolutionStats;
+
+#[test]
+fn resolution_stats_default_is_zero() {
+    let s = ResolutionStats::default();
+    assert_eq!(s.imports_resolved, 0);
+    assert_eq!(s.calls_resolved_phase_b, 0);
+    assert_eq!(s.calls_resolved_phase_c, 0);
+    assert_eq!(s.refs_resolved_phase_b, 0);
+    assert_eq!(s.refs_resolved_phase_c, 0);
+    assert_eq!(s.types_resolved_phase_b, 0);
+    assert_eq!(s.types_resolved_phase_c, 0);
+    assert_eq!(s.unresolved_ambiguous, 0);
+    assert_eq!(s.unresolved_no_candidate, 0);
+}
+
+#[test]
+fn resolution_stats_total_resolved() {
+    let s = ResolutionStats {
+        imports_resolved: 5,
+        calls_resolved_phase_b: 3,
+        calls_resolved_phase_c: 7,
+        refs_resolved_phase_b: 1,
+        refs_resolved_phase_c: 2,
+        types_resolved_phase_b: 0,
+        types_resolved_phase_c: 4,
+        unresolved_ambiguous: 6,
+        unresolved_no_candidate: 8,
+    };
+    assert_eq!(s.total_resolved(), 22);
+    assert_eq!(s.total_unresolved(), 14);
+}
+```
+
+- [ ] **Step 2: Run tests — expect compile failures**
+
+```bash
+cargo test --test resolution_unit 2>&1 | tail -10
+```
+
+Expected: errors about missing `ResolutionStats`.
+
+- [ ] **Step 3: Implement the type**
+
+Overwrite `src/resolution/stats.rs`:
+
+```rust
+//! `ResolutionStats` — counters returned by `resolve()`.
+//!
+//! Separated by phase so an operator can see which mechanism is doing the
+//! work (Phase B = high-confidence import-driven, Phase C = lower-confidence
+//! name match).
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ResolutionStats {
+    /// `(:File)-[:IMPORTS]->(:Module)` edges created by Phase A.
+    pub imports_resolved: usize,
+
+    pub calls_resolved_phase_b: usize,
+    pub calls_resolved_phase_c: usize,
+
+    pub refs_resolved_phase_b: usize,
+    pub refs_resolved_phase_c: usize,
+
+    pub types_resolved_phase_b: usize,
+    pub types_resolved_phase_c: usize,
+
+    /// UnresolvedRef with `unresolved_reason = "ambiguous"`.
+    pub unresolved_ambiguous: usize,
+    /// UnresolvedRef with `unresolved_reason = "no_candidate"`.
+    pub unresolved_no_candidate: usize,
+}
+
+impl ResolutionStats {
+    pub fn total_resolved(&self) -> usize {
+        self.imports_resolved
+            + self.calls_resolved_phase_b + self.calls_resolved_phase_c
+            + self.refs_resolved_phase_b + self.refs_resolved_phase_c
+            + self.types_resolved_phase_b + self.types_resolved_phase_c
+    }
+
+    pub fn total_unresolved(&self) -> usize {
+        self.unresolved_ambiguous + self.unresolved_no_candidate
+    }
+}
+```
+
+- [ ] **Step 4: Uncomment the `pub use` line in src/resolution/mod.rs**
+
+```rust
+pub use stats::ResolutionStats;
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cargo test --test resolution_unit 2>&1 | tail -10
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 6: cargo fmt + clippy + commit**
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+git add src/resolution tests/resolution_unit.rs
+git commit -m "feat(resolution): add ResolutionStats type"
+```
+
+---
+
+### Task 3: `db::queries` read helpers
+
+**Files:**
+- Modify: `src/db/queries.rs`
+
+This task adds read-side query helpers used by all three phases. No tests in this task — they exercise live Neo4j and are verified through the integration test in Task 10. Code is small and reviewable by inspection.
+
+- [ ] **Step 1: Implement the helpers**
+
+Overwrite `src/db/queries.rs`:
+
+```rust
+//! Read-side Cypher queries used by the resolution pipeline.
+//!
+//! These all take a `Connection` and a small set of parameters and return
+//! plain Rust types (no Cypher leaks beyond this module).
+
+use anyhow::{Context, Result};
+use neo4rs::query as cypher;
+
+use crate::db::Connection;
+
+/// One match: a candidate Symbol's qid.
+#[derive(Debug, Clone)]
+pub struct CandidateQid {
+    pub qid: String,
+}
+
+/// List all `(:Import)` nodes in the database with their containing File and use-path name.
+pub async fn list_imports(conn: &Connection) -> Result<Vec<(String, String, String)>> {
+    let mut stream = conn.graph.execute(cypher(
+        "MATCH (f:File)-[:CONTAINS]->(i:Import) \
+         RETURN i.qid AS ref_qid, f.qid AS file_qid, i.name AS name",
+    )).await.context("list_imports")?;
+    let mut out = Vec::new();
+    while let Some(row) = stream.next().await.context("list_imports row stream")? {
+        let ref_qid: String = row.get("ref_qid").context("ref_qid")?;
+        let file_qid: String = row.get("file_qid").context("file_qid")?;
+        let name: String = row.get("name").context("name")?;
+        out.push((ref_qid, file_qid, name));
+    }
+    Ok(out)
+}
+
+/// Look up a `(:Module)` node by exact `qualified_name`. Returns the qid if a
+/// single match exists, None if zero, Err if more than one (a workspace
+/// invariant violation worth surfacing).
+pub async fn find_module_by_qualified_name(
+    conn: &Connection,
+    qualified_name: &str,
+) -> Result<Option<String>> {
+    let mut stream = conn.graph
+        .execute(
+            cypher("MATCH (m:Module {qualified_name: $qn}) RETURN m.qid AS qid LIMIT 2")
+                .param("qn", qualified_name.to_string()),
+        )
+        .await
+        .context("find_module_by_qualified_name")?;
+    let mut qids = Vec::new();
+    while let Some(row) = stream.next().await.context("row stream")? {
+        qids.push(row.get::<String>("qid").context("qid")?);
+    }
+    match qids.len() {
+        0 => Ok(None),
+        1 => Ok(Some(qids.into_iter().next().unwrap())),
+        _ => anyhow::bail!("multiple Module nodes with qualified_name `{qualified_name}`"),
+    }
+}
+
+/// List all `(:UnresolvedRef)` nodes with their source_qid and kind.
+/// Returned tuples: (ref_qid, source_qid, kind, unresolved_name).
+pub async fn list_unresolved_refs(conn: &Connection) -> Result<Vec<UnresolvedRefRow>> {
+    let mut stream = conn.graph.execute(cypher(
+        "MATCH (r:UnresolvedRef) \
+         RETURN r.qid AS qid, r.source_qid AS source_qid, r.kind AS kind, r.unresolved_name AS name",
+    )).await.context("list_unresolved_refs")?;
+    let mut out = Vec::new();
+    while let Some(row) = stream.next().await.context("row stream")? {
+        out.push(UnresolvedRefRow {
+            ref_qid: row.get("qid").context("qid")?,
+            source_qid: row.get("source_qid").context("source_qid")?,
+            kind: row.get("kind").context("kind")?,
+            name: row.get("name").context("name")?,
+        });
+    }
+    Ok(out)
+}
+
+#[derive(Debug, Clone)]
+pub struct UnresolvedRefRow {
+    pub ref_qid: String,
+    pub source_qid: String,
+    pub kind: String,
+    pub name: String,
+}
+
+/// Given a source File qid and a leaf name, find candidates reachable via that
+/// file's IMPORTS edges: targets of `(:Module)-[:CONTAINS|EXPORTS]->(:Symbol {name: $name})`.
+/// Returns matching candidate qids.
+pub async fn import_driven_candidates(
+    conn: &Connection,
+    file_qid: &str,
+    leaf_name: &str,
+) -> Result<Vec<CandidateQid>> {
+    let mut stream = conn.graph
+        .execute(
+            cypher(
+                "MATCH (f:File {qid: $file_qid})-[:IMPORTS]->(m:Module) \
+                 MATCH (m)-[:CONTAINS|EXPORTS]->(c:Symbol {name: $name}) \
+                 RETURN DISTINCT c.qid AS qid LIMIT 50",
+            )
+            .param("file_qid", file_qid.to_string())
+            .param("name", leaf_name.to_string()),
+        )
+        .await
+        .context("import_driven_candidates")?;
+    let mut out = Vec::new();
+    while let Some(row) = stream.next().await.context("row stream")? {
+        out.push(CandidateQid { qid: row.get("qid").context("qid")? });
+    }
+    Ok(out)
+}
+
+/// Workspace-wide name-match candidates: Symbols whose `qualified_name` ends
+/// in `::<name>` or equals `<name>` exactly. Used by Phase C.
+pub async fn name_match_candidates(
+    conn: &Connection,
+    leaf_name: &str,
+) -> Result<Vec<CandidateQid>> {
+    // Match either exact qualified_name or one ending in `::<name>`.
+    let mut stream = conn.graph
+        .execute(
+            cypher(
+                "MATCH (s:Symbol) \
+                 WHERE s.name = $name \
+                 RETURN DISTINCT s.qid AS qid LIMIT 50",
+            )
+            .param("name", leaf_name.to_string()),
+        )
+        .await
+        .context("name_match_candidates")?;
+    let mut out = Vec::new();
+    while let Some(row) = stream.next().await.context("row stream")? {
+        out.push(CandidateQid { qid: row.get("qid").context("qid")? });
+    }
+    Ok(out)
+}
+
+/// Source file qid for an UnresolvedRef (walks UnresolvedRef.source_qid → Symbol → CONTAINS-parent File).
+pub async fn file_qid_for_source(conn: &Connection, source_qid: &str) -> Result<Option<String>> {
+    let mut stream = conn.graph
+        .execute(
+            cypher(
+                "MATCH (s:Symbol {qid: $sq}) \
+                 OPTIONAL MATCH (f:File)-[:CONTAINS*1..]->(s) \
+                 RETURN f.qid AS file_qid LIMIT 1",
+            )
+            .param("sq", source_qid.to_string()),
+        )
+        .await
+        .context("file_qid_for_source")?;
+    match stream.next().await.context("row stream")? {
+        Some(row) => Ok(row.get::<Option<String>>("file_qid").context("file_qid")?),
+        None => Ok(None),
+    }
+}
+```
+
+> **Note on `LIMIT 50`:** the candidate-set queries cap their result count. In practice a leaf name resolving to 50+ candidates means we've blown past "ambiguous" — but the cap protects against pathological workspaces.
+
+> **Note on `name_match_candidates`:** matches by `s.name` (not `s.qualified_name`). `name` is just the leaf identifier (e.g., `"helper"`). For slice 3 v1 this is sufficient; if collisions become a problem, future slices can use qualified-name suffix matching instead.
+
+- [ ] **Step 2: Build and verify**
+
+```bash
+cargo build 2>&1 | tail -3
+```
+
+Expected: clean.
+
+- [ ] **Step 3: cargo fmt + clippy**
+
+Both clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/db/queries.rs
+git commit -m "feat(db): add read-side query helpers for resolution"
+```
+
+---
+
+### Task 4: Drop existing confidence-bearing edges
+
+**Files:**
+- Modify: `src/resolution/drop.rs`
+
+The idempotent-rebuild model requires dropping all existing resolution-derived edges before each pass. Spec §7 specifies a type-restricted Cypher.
+
+- [ ] **Step 1: Implement**
+
+Overwrite `src/resolution/drop.rs`:
+
+```rust
+//! Drop existing resolution-derived edges before each resolve() call.
+//!
+//! Restricted to edge types known to carry the `confidence` property:
+//! `CALLS`, `IMPORTS`, `REFERENCES`, `TYPE_OF`. The type filter lets Neo4j
+//! use its relationship-type index instead of a full scan.
+
+use anyhow::{Context, Result};
+use neo4rs::query as cypher;
+
+use crate::db::Connection;
+
+pub async fn drop_resolution_edges(conn: &Connection) -> Result<()> {
+    conn.graph
+        .execute(cypher(
+            "MATCH ()-[r:CALLS|IMPORTS|REFERENCES|TYPE_OF]->() \
+             WHERE r.confidence IS NOT NULL \
+             DELETE r",
+        ))
+        .await
+        .context("drop_resolution_edges")?
+        .next()
+        .await
+        .ok();
+    Ok(())
+}
+
+/// Reset UnresolvedRef state — clears `candidate_qids` and `unresolved_reason`
+/// so a fresh resolution pass starts from a clean slate.
+pub async fn reset_unresolved_state(conn: &Connection) -> Result<()> {
+    conn.graph
+        .execute(cypher(
+            "MATCH (r:UnresolvedRef) \
+             SET r.candidate_qids = NULL, r.unresolved_reason = NULL",
+        ))
+        .await
+        .context("reset_unresolved_state")?
+        .next()
+        .await
+        .ok();
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Build, clippy, fmt, commit**
+
+```bash
+cargo build && cargo clippy --all-targets -- -D warnings && cargo fmt --check
+git add src/resolution/drop.rs
+git commit -m "feat(resolution): add drop_resolution_edges + reset_unresolved_state"
+```
+
+---
+
+### Task 5: Phase A — resolve imports
+
+**Files:**
+- Modify: `src/resolution/phase_a_imports.rs`
+
+- [ ] **Step 1: Implement**
+
+Overwrite `src/resolution/phase_a_imports.rs`:
+
+```rust
+//! Phase A: resolve `(:Import)` Symbol nodes into `(:File)-[:IMPORTS]->(:Module)` edges.
+//!
+//! For each Import, look up a Module whose `qualified_name` equals the
+//! Import's `name`. If exactly one Module exists in the workspace, emit the
+//! IMPORTS edge with `confidence: "import_resolved"`. Otherwise leave it
+//! unresolved (most imports point at external crates we don't have nodes for).
+
+use anyhow::{Context, Result};
+use neo4rs::query as cypher;
+
+use crate::db::queries::{find_module_by_qualified_name, list_imports};
+use crate::db::Connection;
+
+/// Returns the count of IMPORTS edges created.
+pub async fn run(conn: &Connection) -> Result<usize> {
+    let imports = list_imports(conn).await.context("listing imports")?;
+    let mut created = 0;
+
+    for (_ref_qid, file_qid, name) in imports {
+        // The Import node's `name` carries the full use path text. Try to find
+        // a Module with that exact qualified_name.
+        if let Some(module_qid) = find_module_by_qualified_name(conn, &name)
+            .await
+            .with_context(|| format!("looking up Module `{name}`"))?
+        {
+            // Create the IMPORTS edge with confidence.
+            conn.graph
+                .execute(
+                    cypher(
+                        "MATCH (f:File {qid: $file_qid}), (m:Module {qid: $module_qid}) \
+                         MERGE (f)-[r:IMPORTS]->(m) \
+                         SET r.confidence = 'import_resolved'",
+                    )
+                    .param("file_qid", file_qid.clone())
+                    .param("module_qid", module_qid),
+                )
+                .await
+                .with_context(|| format!("creating IMPORTS edge from `{file_qid}` to module `{name}`"))?
+                .next()
+                .await
+                .ok();
+            created += 1;
+        }
+        // If no Module found, leave the import unresolved (external crate).
+    }
+
+    Ok(created)
+}
+```
+
+- [ ] **Step 2: Build, clippy, fmt, commit**
+
+```bash
+cargo build && cargo clippy --all-targets -- -D warnings && cargo fmt --check
+git add src/resolution/phase_a_imports.rs
+git commit -m "feat(resolution): Phase A — resolve Import nodes into IMPORTS edges"
+```
+
+---
+
+### Task 6: Phase B — import-driven resolution for non-imports
+
+**Files:**
+- Modify: `src/resolution/phase_b_import_driven.rs`
+
+- [ ] **Step 1: Implement**
+
+Overwrite `src/resolution/phase_b_import_driven.rs`:
+
+```rust
+//! Phase B: import-driven candidate lookup for `UnresolvedRef`s of
+//! `kind="call" | "type_ref" | "reference"`.
+//!
+//! For each unresolved ref, find the source File via the source Symbol's
+//! `CONTAINS*` ancestor, then look up candidates reachable via the file's
+//! IMPORTS edges. If exactly one candidate matches by name, create the
+//! appropriate edge with `confidence: "import_resolved"`.
+
+use anyhow::{Context, Result};
+use neo4rs::query as cypher;
+
+use crate::db::queries::{file_qid_for_source, import_driven_candidates, UnresolvedRefRow};
+use crate::db::Connection;
+
+/// Returns (calls, refs, types) — number of edges created per kind.
+pub async fn run(conn: &Connection, refs: &[UnresolvedRefRow]) -> Result<(usize, usize, usize)> {
+    let mut calls = 0;
+    let mut refs_count = 0;
+    let mut types = 0;
+
+    for r in refs {
+        if r.kind == "import" {
+            continue; // Phase A handled imports.
+        }
+
+        // Locate the source file for this ref.
+        let file_qid = match file_qid_for_source(conn, &r.source_qid).await
+            .with_context(|| format!("file_qid_for_source({})", r.source_qid))?
+        {
+            Some(f) => f,
+            None => continue, // orphaned source; skip
+        };
+
+        // Import-driven candidates by leaf name.
+        let candidates = import_driven_candidates(conn, &file_qid, &r.name).await
+            .with_context(|| format!("import_driven_candidates(file={file_qid}, name={})", r.name))?;
+
+        if candidates.len() != 1 {
+            continue; // 0 or many; let Phase C handle it
+        }
+
+        let target_qid = &candidates[0].qid;
+        let rel = relationship_for_kind(&r.kind);
+
+        // Create the edge with confidence.
+        conn.graph
+            .execute(
+                cypher(&format!(
+                    "MATCH (a {{qid: $a}}), (b {{qid: $b}}) \
+                     MERGE (a)-[e:{rel}]->(b) \
+                     SET e.confidence = 'import_resolved'"
+                ))
+                .param("a", r.source_qid.clone())
+                .param("b", target_qid.clone()),
+            )
+            .await
+            .with_context(|| format!("creating {rel} edge from {} to {}", r.source_qid, target_qid))?
+            .next()
+            .await
+            .ok();
+
+        // Mark the ref resolved by clearing unresolved_reason explicitly.
+        conn.graph
+            .execute(
+                cypher("MATCH (r:UnresolvedRef {qid: $q}) SET r.unresolved_reason = NULL, r.candidate_qids = NULL")
+                    .param("q", r.ref_qid.clone()),
+            )
+            .await
+            .with_context(|| format!("clearing ref state for {}", r.ref_qid))?
+            .next()
+            .await
+            .ok();
+
+        match r.kind.as_str() {
+            "call" => calls += 1,
+            "type_ref" => types += 1,
+            "reference" => refs_count += 1,
+            _ => {}
+        }
+    }
+
+    Ok((calls, refs_count, types))
+}
+
+fn relationship_for_kind(kind: &str) -> &'static str {
+    match kind {
+        "call" => "CALLS",
+        "type_ref" => "TYPE_OF",
+        "reference" => "REFERENCES",
+        _ => "REFERENCES", // shouldn't happen; pessimistic default
+    }
+}
+```
+
+- [ ] **Step 2: Build, clippy, fmt, commit**
+
+```bash
+cargo build && cargo clippy --all-targets -- -D warnings && cargo fmt --check
+git add src/resolution/phase_b_import_driven.rs
+git commit -m "feat(resolution): Phase B — import-driven resolution for calls/refs/types"
+```
+
+---
+
+### Task 7: Phase C — name-match fallback
+
+**Files:**
+- Modify: `src/resolution/phase_c_name_match.rs`
+
+- [ ] **Step 1: Implement**
+
+Overwrite `src/resolution/phase_c_name_match.rs`:
+
+```rust
+//! Phase C: workspace-wide name-match for refs Phase B couldn't resolve.
+//!
+//! Single candidate → resolution edge with `confidence: "name_match"`.
+//! Multiple → record `candidate_qids` + `unresolved_reason = "ambiguous"`.
+//! Zero → `unresolved_reason = "no_candidate"`.
+
+use anyhow::{Context, Result};
+use neo4rs::query as cypher;
+use serde_json::Value;
+
+use crate::db::queries::{name_match_candidates, UnresolvedRefRow};
+use crate::db::Connection;
+
+pub struct PhaseCResult {
+    pub calls: usize,
+    pub refs: usize,
+    pub types: usize,
+    pub ambiguous: usize,
+    pub no_candidate: usize,
+}
+
+/// Run Phase C against all UnresolvedRefs whose `unresolved_reason` is NULL
+/// (i.e. either fresh or cleared by Phase B's successful resolution).
+pub async fn run(conn: &Connection, refs: &[UnresolvedRefRow]) -> Result<PhaseCResult> {
+    let mut result = PhaseCResult {
+        calls: 0, refs: 0, types: 0, ambiguous: 0, no_candidate: 0,
+    };
+
+    for r in refs {
+        if r.kind == "import" {
+            continue;
+        }
+
+        // Skip if already resolved by Phase B (we detect via a probe: does the
+        // expected outgoing edge already exist?). Cheaper alternative: pass a
+        // HashSet of already-resolved ref_qids from Phase B. For slice 3 we
+        // accept the extra round-trip in favor of simplicity.
+        if is_already_resolved(conn, r).await.unwrap_or(false) {
+            continue;
+        }
+
+        let candidates = name_match_candidates(conn, &r.name).await
+            .with_context(|| format!("name_match_candidates({})", r.name))?;
+
+        match candidates.len() {
+            0 => {
+                mark_unresolved(conn, &r.ref_qid, "no_candidate", &[]).await?;
+                result.no_candidate += 1;
+            }
+            1 => {
+                let target = &candidates[0].qid;
+                let rel = relationship_for_kind(&r.kind);
+                create_edge_with_confidence(conn, &r.source_qid, target, rel, "name_match").await?;
+                conn.graph.execute(
+                    cypher("MATCH (r:UnresolvedRef {qid: $q}) \
+                            SET r.unresolved_reason = NULL, r.candidate_qids = NULL")
+                        .param("q", r.ref_qid.clone())
+                ).await?.next().await.ok();
+                match r.kind.as_str() {
+                    "call" => result.calls += 1,
+                    "type_ref" => result.types += 1,
+                    "reference" => result.refs += 1,
+                    _ => {}
+                }
+            }
+            _ => {
+                let qids: Vec<String> = candidates.iter().map(|c| c.qid.clone()).collect();
+                mark_unresolved(conn, &r.ref_qid, "ambiguous", &qids).await?;
+                result.ambiguous += 1;
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+async fn is_already_resolved(conn: &Connection, r: &UnresolvedRefRow) -> Result<bool> {
+    let rel = relationship_for_kind(&r.kind);
+    let cypher_text = format!(
+        "MATCH (a {{qid: $sq}})-[e:{rel}]->() WHERE e.confidence IS NOT NULL \
+         RETURN count(e) AS c LIMIT 1"
+    );
+    let mut stream = conn.graph
+        .execute(cypher(&cypher_text).param("sq", r.source_qid.clone()))
+        .await?;
+    let row = stream.next().await?.context("no row")?;
+    let c: i64 = row.get("c")?;
+    Ok(c > 0)
+}
+
+async fn create_edge_with_confidence(
+    conn: &Connection,
+    from: &str,
+    to: &str,
+    rel: &str,
+    confidence: &str,
+) -> Result<()> {
+    let cypher_text = format!(
+        "MATCH (a {{qid: $a}}), (b {{qid: $b}}) \
+         MERGE (a)-[e:{rel}]->(b) SET e.confidence = $c"
+    );
+    conn.graph
+        .execute(
+            cypher(&cypher_text)
+                .param("a", from.to_string())
+                .param("b", to.to_string())
+                .param("c", confidence.to_string()),
+        )
+        .await?
+        .next()
+        .await
+        .ok();
+    Ok(())
+}
+
+async fn mark_unresolved(conn: &Connection, ref_qid: &str, reason: &str, candidate_qids: &[String]) -> Result<()> {
+    let candidates_json = if candidate_qids.is_empty() {
+        Value::Null
+    } else {
+        Value::Array(candidate_qids.iter().map(|s| Value::String(s.clone())).collect())
+    };
+    let candidates_param = crate::db::write::to_bolt(candidates_json)?;
+    conn.graph
+        .execute(
+            cypher(
+                "MATCH (r:UnresolvedRef {qid: $q}) \
+                 SET r.unresolved_reason = $reason, r.candidate_qids = $cands",
+            )
+            .param("q", ref_qid.to_string())
+            .param("reason", reason.to_string())
+            .param("cands", candidates_param),
+        )
+        .await?
+        .next()
+        .await
+        .ok();
+    Ok(())
+}
+
+fn relationship_for_kind(kind: &str) -> &'static str {
+    match kind {
+        "call" => "CALLS",
+        "type_ref" => "TYPE_OF",
+        "reference" => "REFERENCES",
+        _ => "REFERENCES",
+    }
+}
+```
+
+> **Note: `crate::db::write::to_bolt`** — this is the BoltType adapter added in Slice 2 Task 10. It's currently a private function in `src/db/write.rs`. Either:
+> (a) Make it `pub(crate)` in `src/db/write.rs` so Phase C can use it, OR
+> (b) Duplicate the small adapter here (it's 3 lines).
+> Prefer (a) — promote the existing helper to `pub(crate)` to avoid duplication.
+
+> **Note on `is_already_resolved`:** the probe assumes Phase B's resolution edges have `confidence IS NOT NULL`, which they do (set to `'import_resolved'`). Resolution always sets confidence, so any confidence-bearing outgoing edge of the right type from `source_qid` indicates Phase B already handled this ref. The probe is per-ref so it's a Cypher round-trip — fine for slice 3, room for optimization later.
+
+- [ ] **Step 2: Promote `to_bolt` to `pub(crate)` in `src/db/write.rs`**
+
+Change the signature in `src/db/write.rs`:
+
+```rust
+pub(crate) fn to_bolt(v: Value) -> Result<neo4rs::BoltType> {
+    // ... existing body unchanged ...
+}
+```
+
+- [ ] **Step 3: Build, clippy, fmt, commit**
+
+```bash
+cargo build && cargo clippy --all-targets -- -D warnings && cargo fmt --check
+git add src/resolution/phase_c_name_match.rs src/db/write.rs
+git commit -m "feat(resolution): Phase C — workspace name-match fallback with ambiguity handling"
+```
+
+---
+
+### Task 8: `resolve()` orchestrator
+
+**Files:**
+- Modify: `src/resolution/mod.rs`
+
+- [ ] **Step 1: Implement the orchestrator**
+
+Replace the stub `resolve()` in `src/resolution/mod.rs`:
+
+```rust
+//! Resolution pipeline (spec §7).
+
+pub mod drop;
+pub mod phase_a_imports;
+pub mod phase_b_import_driven;
+pub mod phase_c_name_match;
+pub mod stats;
+
+pub use stats::ResolutionStats;
+
+use anyhow::{Context, Result};
+use tracing::info;
+
+use crate::db::queries::list_unresolved_refs;
+use crate::db::Connection;
+
+/// Run the full resolution pipeline against the database referenced by `conn`.
+///
+/// Idempotent: each call drops all `confidence`-bearing edges and resets the
+/// state of every `UnresolvedRef`, then runs Phases A → B → C.
+pub async fn resolve(conn: &Connection) -> Result<ResolutionStats> {
+    info!("dropping existing resolution edges");
+    drop::drop_resolution_edges(conn).await.context("drop_resolution_edges")?;
+    drop::reset_unresolved_state(conn).await.context("reset_unresolved_state")?;
+
+    info!("Phase A: resolving imports");
+    let imports_resolved = phase_a_imports::run(conn).await.context("Phase A")?;
+
+    info!("listing UnresolvedRefs for Phases B+C");
+    let refs = list_unresolved_refs(conn).await.context("list_unresolved_refs")?;
+
+    info!("Phase B: import-driven candidates for {} unresolved refs", refs.len());
+    let (b_calls, b_refs, b_types) = phase_b_import_driven::run(conn, &refs).await.context("Phase B")?;
+
+    info!("Phase C: name-match fallback");
+    let c = phase_c_name_match::run(conn, &refs).await.context("Phase C")?;
+
+    let stats = ResolutionStats {
+        imports_resolved,
+        calls_resolved_phase_b: b_calls,
+        calls_resolved_phase_c: c.calls,
+        refs_resolved_phase_b: b_refs,
+        refs_resolved_phase_c: c.refs,
+        types_resolved_phase_b: b_types,
+        types_resolved_phase_c: c.types,
+        unresolved_ambiguous: c.ambiguous,
+        unresolved_no_candidate: c.no_candidate,
+    };
+    info!(
+        "resolution complete: {} resolved, {} unresolved",
+        stats.total_resolved(),
+        stats.total_unresolved()
+    );
+    Ok(stats)
+}
+```
+
+- [ ] **Step 2: Build, clippy, fmt, commit**
+
+```bash
+cargo build && cargo clippy --all-targets -- -D warnings && cargo fmt --check
+git add src/resolution/mod.rs
+git commit -m "feat(resolution): resolve() orchestrator — Phases A → B → C"
+```
+
+---
+
+### Task 9: Wire resolution into `codegraph-rs index`
+
+**Files:**
+- Modify: `src/cli/index.rs`
+
+- [ ] **Step 1: Call `resolve()` after `write_extraction`**
+
+Add the import at the top of `src/cli/index.rs` (alongside the existing `use crate::...` lines):
+
+```rust
+use crate::resolution;
+```
+
+Inside the `rt.block_on` block, after `write_extraction(&conn, results).await?;` call `resolution::resolve(&conn).await?` and log the stats. Concretely the async block becomes:
+
+```rust
+    rt.block_on(async {
+        let conn = Connection::open(
+            &cfg.workspace.neo4j.uri,
+            &cfg.workspace.neo4j.username,
+            &pw.value,
+            &cfg.workspace.neo4j.database,
+        ).await.context("connecting to workspace database")?;
+
+        apply_schema(&conn).await.context("applying schema")?;
+        write_extraction(&conn, results).await.context("writing extraction to Neo4j")?;
+
+        let stats = resolution::resolve(&conn).await.context("resolving references")?;
+        info!(
+            "resolution stats: imports={}, calls(B/C)={}/{}, refs(B/C)={}/{}, types(B/C)={}/{}, ambiguous={}, no_candidate={}",
+            stats.imports_resolved,
+            stats.calls_resolved_phase_b, stats.calls_resolved_phase_c,
+            stats.refs_resolved_phase_b, stats.refs_resolved_phase_c,
+            stats.types_resolved_phase_b, stats.types_resolved_phase_c,
+            stats.unresolved_ambiguous, stats.unresolved_no_candidate,
+        );
+
+        Ok::<(), anyhow::Error>(())
+    })?;
+```
+
+> The path is `crate::resolution::resolve` (via the `use crate::resolution;` import) — `src/cli/index.rs` lives inside the library crate, not in `src/main.rs`. Don't write `codegraph_rs::resolution`.
+
+- [ ] **Step 2: Build, clippy, fmt, commit**
+
+```bash
+cargo build && cargo clippy --all-targets -- -D warnings && cargo fmt --check
+git add src/cli/index.rs
+git commit -m "feat(cli): run resolution after extraction in index command"
+```
+
+---
+
+### Task 10: Integration test against tiny-rust
+
+**Files:**
+- Create: `tests/integration_resolve.rs` (gated)
+- Optional: extend `tests/integration_index.rs` to also assert on resolution outcomes — but a separate file is cleaner.
+
+- [ ] **Step 1: Create the integration test**
+
+Create `tests/integration_resolve.rs`:
+
+```rust
+//! Integration test for resolution. Runs `codegraph-rs index` (which now
+//! includes resolution) on the tiny-rust fixture and verifies the expected
+//! `CALLS` edges exist.
+//!
+//! Gated on CODEGRAPH_RS_TEST_NEO4J=1.
+
+use codegraph_rs::cli::{index, init::{InitArgs, self}};
+use neo4rs::query;
+use std::fs;
+use tempfile::tempdir;
+
+fn enabled() -> bool {
+    std::env::var("CODEGRAPH_RS_TEST_NEO4J").as_deref() == Ok("1")
+}
+
+#[test]
+fn resolves_tiny_rust_calls() {
+    if !enabled() {
+        eprintln!("SKIP: set CODEGRAPH_RS_TEST_NEO4J=1 to enable");
+        return;
+    }
+    let pw = std::env::var("CODEGRAPH_RS_TEST_NEO4J_PASSWORD")
+        .expect("CODEGRAPH_RS_TEST_NEO4J_PASSWORD required");
+
+    let dir = tempdir().unwrap();
+    let workspace_name = format!("resolve-test-{}", std::process::id());
+
+    let fixture_src = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/tiny-rust");
+    let fixture_dst = dir.path().join("tiny-rust");
+    copy_dir(&fixture_src, &fixture_dst).unwrap();
+
+    let args = InitArgs {
+        name: workspace_name.clone(),
+        neo4j_uri: "bolt://localhost:7687".into(),
+        neo4j_user: "neo4j".into(),
+        neo4j_password: pw.clone(),
+        root: vec!["tiny=tiny-rust".into()],
+    };
+    init::run(args, Some(dir.path())).expect("init must succeed");
+
+    // Index (now runs resolution as well).
+    std::env::set_var("CODEGRAPH_RS_NEO4J_PASSWORD", &pw);
+    index::run(Some(dir.path())).expect("index+resolve must succeed");
+    std::env::remove_var("CODEGRAPH_RS_NEO4J_PASSWORD");
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let db_name = format!("codegraph-resolve-test-{}", std::process::id());
+        let conn = codegraph_rs::db::Connection::open(
+            "bolt://localhost:7687", "neo4j", &pw, &db_name,
+        ).await.unwrap();
+
+        // Expect: at least 3 CALLS edges (main → library_entry, library_entry → helper, helper → constant).
+        // Some may be name_match (Phase C); some may be import_resolved (Phase B). Either is fine.
+        let calls_count: i64 = scalar(&conn, "MATCH ()-[r:CALLS]->() RETURN count(r) AS c").await;
+        assert!(calls_count >= 3, "expected at least 3 CALLS edges, got {calls_count}");
+
+        // Specifically verify helper → constant.
+        let helper_to_constant: i64 = scalar(
+            &conn,
+            "MATCH (a:Symbol {name: 'helper'})-[:CALLS]->(b:Symbol {name: 'constant'}) \
+             RETURN count(*) AS c",
+        ).await;
+        assert_eq!(helper_to_constant, 1, "expected exactly one helper→constant CALLS edge");
+
+        // All CALLS edges must carry a confidence property.
+        let unconfidence: i64 = scalar(
+            &conn,
+            "MATCH ()-[r:CALLS]->() WHERE r.confidence IS NULL RETURN count(r) AS c",
+        ).await;
+        assert_eq!(unconfidence, 0, "every CALLS edge must have a confidence property");
+
+        // No UnresolvedRef should still claim `unresolved_reason IS NULL` AND lack an
+        // outgoing resolution edge. (Either resolved with edge OR has a reason.)
+        // For tiny-rust this is fine because every call resolves via name_match.
+
+        // Cleanup.
+        let sys = codegraph_rs::db::Connection::system(
+            "bolt://localhost:7687", "neo4j", &pw,
+        ).await.unwrap();
+        sys.graph.execute(query(&format!("DROP DATABASE `{db_name}` IF EXISTS WAIT")))
+            .await.unwrap().next().await.ok();
+    });
+}
+
+async fn scalar(conn: &codegraph_rs::db::Connection, cypher: &str) -> i64 {
+    let mut stream = conn.graph.execute(query(cypher)).await.unwrap();
+    let row = stream.next().await.unwrap().unwrap();
+    row.get::<i64>("c").unwrap()
+}
+
+fn copy_dir(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        let dest = dst.join(entry.file_name());
+        if path.is_dir() {
+            copy_dir(&path, &dest)?;
+        } else {
+            fs::copy(&path, &dest)?;
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Verify SKIP path**
+
+```bash
+cargo test --test integration_resolve -- --nocapture 2>&1 | tail -10
+```
+
+Expected: 1 test, prints SKIP, passes.
+
+- [ ] **Step 3: cargo fmt + clippy**
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration_resolve.rs
+git commit -m "test(resolution): integration test verifying CALLS edges on tiny-rust"
+```
+
+---
+
+### Task 11: README + slice-3 tag
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update README**
+
+Update `/Users/gyorgybalazsi/codegraph-rs/README.md`'s "Status" section to mention slice 3:
+
+```markdown
+## Status
+
+In development. Currently implements **Slice 3: Resolution** —
+workspace initialization, indexing (Rust files, structural extraction), and
+resolution (CALLS / IMPORTS / REFERENCES / TYPE_OF edges with confidence).
+Vector embeddings, sync, MCP server, and Daml support land in subsequent slices.
+```
+
+- [ ] **Step 2: Final test suite + tag**
+
+```bash
+cargo test 2>&1 | tail -15
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+git add README.md
+git commit -m "docs: update README for slice 3"
+git tag slice-3-resolution
+```
+
+Expected test count breakdown:
+
+| Test binary | Count |
+|---|---|
+| `extraction_unit` | 31 |
+| `resolution_unit` (new) | 2 |
+| `config_parsing` | 13 |
+| `cli_smoke` | 2 |
+| `integration_db` (SKIP) | 2 |
+| `integration_init` (SKIP) | 1 |
+| `integration_status` (SKIP) | 1 |
+| `integration_index` (SKIP) | 1 |
+| `integration_resolve` (new, SKIP) | 1 |
+| **Total** | **54** |
+
+---
+
+## Slice 3 Done
+
+Verify the artifact:
+
+- [ ] `cargo build` clean
+- [ ] `cargo test` (no env vars) — all tests pass; integration tests SKIP cleanly
+- [ ] `CODEGRAPH_RS_TEST_NEO4J=1 cargo test -- --test-threads=1` — all tests pass
+- [ ] `codegraph-rs index` runs both extraction and resolution; status reports the same counts as before but the graph now has `CALLS` edges with `confidence` property
+- [ ] Manual smoke: index a small Rust workspace, query Neo4j Browser for `MATCH ()-[r:CALLS]->() RETURN r LIMIT 25` — see real edges
+- [ ] No embeddings yet (Slice 4)
+- [ ] No sync yet (Slice 5) — running `index` re-runs the full extraction + resolution
+
+When all check, slice 3 is complete and we can write slice 4 (vector embeddings).

--- a/docs/superpowers/plans/2026-05-11-codegraph-rs-slice-5-sync.md
+++ b/docs/superpowers/plans/2026-05-11-codegraph-rs-slice-5-sync.md
@@ -46,8 +46,9 @@ The resolve step at the end is what makes cross-file edges self-heal: even if a 
 - Git hook auto-sync — not v1
 - Tree-sitter incremental reparse (`edit()` API) — v1 reparses whole-file
 - Parallel-root sync — v1 iterates roots sequentially
-- Locking against concurrent sync sessions — documented as "don't run two at once" (same caveat as `index`)
-- Embeddings (Slice 4) — sync re-embedding will be added when Slice 4 lands
+- Embeddings — sync re-embedding will be added when the embeddings slice lands
+- **Scoped re-resolution.** `resolve()` rebuilds confidence-bearing edges for the entire workspace on every sync, even if only one file changed. Spec §7 acknowledges this as a known v1 cost: "for an UnresolvedRef count R, complexity is roughly O(R × log N); expect <2s for a 50k-symbol workspace." A future slice can scope re-resolution to refs whose source file or candidate set changed. For now: sync cost scales with workspace size, not change size.
+- **Concurrent sync invocations.** Per spec §9: "running two at once will cause MERGE conflicts and corrupted intermediate state. Documented as 'don't run two at once.'" The CLI does NOT take a file lock. Same caveat as `codegraph-rs index`. A v2 lockfile at `<workspace>/.codegraph/.lock` is planned.
 
 ---
 
@@ -518,20 +519,47 @@ pub async fn run(conn: &Connection, cfg: &WorkspaceConfig) -> Result<SyncStats> 
     for root in &cfg.workspace.roots {
         info!("syncing root `{}`", root.name);
 
-        // Filesystem state: walk + hash.
-        let fs_state: HashMap<String, String> = walk_root(&root.path, &root.name, languages)
-            .map(|f| {
-                let source = std::fs::read_to_string(&f.absolute_path)
-                    .with_context(|| format!("reading {}", f.absolute_path.display()))?;
-                Ok((f.relative_path.clone(), source_hash(&source)))
-            })
-            .collect::<Result<HashMap<_, _>>>()?;
+        // Filesystem state: walk + hash + stash source (so we don't re-read
+        // changed/added files later during extraction).
+        // Unreadable files are warn-and-skipped, matching slice 2's
+        // orchestrator behavior. A skipped file is treated as "unchanged":
+        // omitting it from the hash map means it won't appear in the
+        // Added/Changed buckets, AND if it's already in the DB, it also
+        // won't appear in Deleted because we'll see it in the walker
+        // (just couldn't read it). To make sure a transiently unreadable
+        // file isn't bucketed as Deleted, we still record its presence with
+        // a placeholder by re-using the DB's hash if available.
+        let mut fs_hashes: HashMap<String, String> = HashMap::new();
+        let mut fs_sources: HashMap<String, String> = HashMap::new();
+        let mut unreadable: Vec<String> = Vec::new();
+        for f in walk_root(&root.path, &root.name, languages) {
+            match std::fs::read_to_string(&f.absolute_path) {
+                Ok(source) => {
+                    fs_hashes.insert(f.relative_path.clone(), source_hash(&source));
+                    fs_sources.insert(f.relative_path, source);
+                }
+                Err(e) => {
+                    warn!("read failed for {}: {e:#} — treating as unchanged", f.absolute_path.display());
+                    unreadable.push(f.relative_path);
+                }
+            }
+        }
 
         // DB state for this root.
         let db_state = list_files_in_root(conn, &root.name).await
             .with_context(|| format!("list_files_in_root({})", root.name))?;
 
-        let diff: FileDiff = diff_files(&fs_state, &db_state);
+        // For unreadable files that are already in the DB, preserve their
+        // DB hash in fs_hashes so the diff treats them as unchanged (not
+        // Deleted). This prevents transient I/O failures from triggering
+        // destructive sync actions.
+        for rel in &unreadable {
+            if let Some(db_hash) = db_state.get(rel) {
+                fs_hashes.insert(rel.clone(), db_hash.clone());
+            }
+        }
+
+        let diff: FileDiff = diff_files(&fs_hashes, &db_state);
         info!(
             "root `{}`: added={}, changed={}, deleted={}",
             root.name,
@@ -546,20 +574,22 @@ pub async fn run(conn: &Connection, cfg: &WorkspaceConfig) -> Result<SyncStats> 
                 .with_context(|| format!("delete_file_subtree({}, {})", root.name, rel))?;
         }
 
-        // Re-extract added + changed files.
+        // Re-extract added + changed files using the stashed source (no
+        // second filesystem read).
         for rel in diff.added.iter().chain(diff.changed.iter()) {
-            let abs = root.path.join(rel);
-            let source = match std::fs::read_to_string(&abs) {
-                Ok(s) => s,
-                Err(e) => {
-                    warn!("read failed for {}: {e:#}", abs.display());
-                    continue;
-                }
+            let Some(source) = fs_sources.get(rel) else {
+                // Should never happen since added/changed files came from
+                // fs_hashes which was populated alongside fs_sources, but
+                // be defensive.
+                warn!("missing stashed source for {rel}, skipping");
+                continue;
             };
-            // Slice 5 only supports Rust here. Slice 7 adds Daml dispatch.
-            // Source-extension routing matches the walker's `language` field.
+            let abs = root.path.join(rel);
+            // Slice 5 only supports Rust here. The Daml slice will add
+            // Daml dispatch. Source-extension routing matches the walker's
+            // `language` field.
             let result = match abs.extension().and_then(|s| s.to_str()) {
-                Some("rs") => extract_rust(&source, &root.name, rel),
+                Some("rs") => extract_rust(source, &root.name, rel),
                 Some(other) => {
                     warn!("no extractor for `.{other}`, skipping {}", rel);
                     continue;
@@ -602,7 +632,7 @@ pub async fn run(conn: &Connection, cfg: &WorkspaceConfig) -> Result<SyncStats> 
 }
 ```
 
-> Note on the language dispatch — sync's per-file extraction has a small switch that mirrors the orchestrator's. Slice 7 (Daml) will need to update both call sites. Cleaner refactor: extract a `dispatch_by_language(lang, &source, root_name, relative_path) -> Result<ExtractionResult>` helper and call it from both places. Defer to slice 7 unless trivial to do now.
+> Note on the language dispatch — sync's per-file extraction has a small switch that mirrors the orchestrator's. The Daml slice will need to update both call sites. Cleaner refactor: extract a `dispatch_by_language(lang, &source, root_name, relative_path) -> Result<ExtractionResult>` helper and call it from both places. Defer to the Daml slice unless trivial to do now.
 
 - [ ] **Step 2: Build, clippy, fmt, test**
 
@@ -1012,7 +1042,7 @@ Verify the artifact:
 - [ ] `CODEGRAPH_RS_TEST_NEO4J=1 cargo test -- --test-threads=1` — all 61 pass
 - [ ] Manual: `codegraph-rs sync` runs against an already-initialized workspace; idempotent (running twice on unchanged workspace produces 0 added/changed/deleted)
 - [ ] Modifying a file and re-running `sync` updates only that file's subgraph; resolution edges re-emerge
-- [ ] No embeddings yet (Slice 4 deferred)
-- [ ] No MCP server yet (Slice 6)
+- [ ] No embeddings yet (deferred — embeddings slice produces vector data; MCP slice exposes search)
+- [ ] No MCP server yet
 
-When all check, slice 5 is complete and we can write the next slice. Likely Slice 4 (vector embeddings) next, then Slice 6 (MCP) so the embeddings get a consumer.
+When all check, slice 5 is complete and we can write the next slice. Likely the embeddings slice next, then the MCP slice so the embeddings get a consumer.

--- a/docs/superpowers/plans/2026-05-11-codegraph-rs-slice-5-sync.md
+++ b/docs/superpowers/plans/2026-05-11-codegraph-rs-slice-5-sync.md
@@ -1,0 +1,1018 @@
+# codegraph-rs Slice 5 — Sync (Incremental Updates)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `codegraph-rs sync` work. After this slice, re-running on an unchanged workspace is cheap; modifying/adding/deleting files updates only what changed; resolution edges remain consistent across edits. Skipping Slice 4 (vector embeddings) for now — sync is more practically useful and can be implemented without embedding plumbing.
+
+**Architecture:** Diff-driven, per spec §9. For each workspace root: walk the filesystem with the `ignore` crate, BLAKE3-hash every source file, query Neo4j for the currently-indexed `(relative_path, content_hash)` pairs, then compute a three-bucket diff:
+- **Added** — in filesystem, not in DB → extract + write
+- **Changed** — in both, hashes differ → DETACH DELETE old subtree + UnresolvedRefs, then re-extract
+- **Deleted** — in DB, not in filesystem → DETACH DELETE old subtree
+
+After all per-file changes, run the global resolution rebuild from §7 (already implemented in Slice 3). The rebuild drops every `confidence`-bearing edge and recomputes from the surviving `UnresolvedRef` records, so cross-file references self-heal against new target qids.
+
+**Tech Stack:** unchanged from Slice 3. `ignore` + `blake3` are already in Cargo.toml (from Slice 2). No new dependencies.
+
+**Source spec:** [`docs/superpowers/specs/2026-04-22-codegraph-rs-design.md`](../specs/2026-04-22-codegraph-rs-design.md) §9 (Sync). Reuses §6 (extraction) and §7 (resolution) infrastructure end-to-end.
+
+**Slice 3 baseline:** HEAD `97eb68b`, tagged `slice-3-resolution`. 54 tests pass.
+
+---
+
+## What sync does
+
+For a workspace with N roots:
+
+1. **Walk** each root with the `ignore` crate (same walker Slice 2 uses).
+2. **Hash** each discovered file with BLAKE3 (`source_hash` helper from Slice 2 Task 4).
+3. **Query** Neo4j for the currently-indexed File nodes' `(root_name, relative_path, content_hash)` triples.
+4. **Diff** filesystem state vs DB state into `Added`, `Changed`, `Deleted` buckets.
+5. **Delete** subtrees for `Changed` + `Deleted` files. Cypher (per spec §9):
+   ```cypher
+   MATCH (f:File {root_name: $root, relative_path: $rel})
+   OPTIONAL MATCH (f)-[:CONTAINS*]->(child:Symbol)
+   OPTIONAL MATCH (child)-[:HAS_REF]->(ref:UnresolvedRef)
+   DETACH DELETE f, child, ref
+   ```
+6. **Extract** `Added` + `Changed` files (same orchestrator from Slice 2 Task 11).
+7. **Write** the new nodes/edges/UnresolvedRefs (same `write_extraction` from Slice 2 Task 10).
+8. **Resolve** globally (same `resolution::resolve` from Slice 3).
+
+The resolve step at the end is what makes cross-file edges self-heal: even if a function's qid changed in a re-extracted file, the surviving `UnresolvedRef`s in other files still describe the original intent, and Phase B/C re-create the edges against the new target qids.
+
+## Out of scope for Slice 5
+
+- Watch-mode (`codegraph-rs sync --watch`) — not v1
+- Git hook auto-sync — not v1
+- Tree-sitter incremental reparse (`edit()` API) — v1 reparses whole-file
+- Parallel-root sync — v1 iterates roots sequentially
+- Locking against concurrent sync sessions — documented as "don't run two at once" (same caveat as `index`)
+- Embeddings (Slice 4) — sync re-embedding will be added when Slice 4 lands
+
+---
+
+## File structure produced by this slice
+
+```
+codegraph-rs/
+  src/
+    lib.rs                      # add `pub mod sync;`
+    cli/
+      sync.rs                   # NEW: codegraph-rs sync command
+      mod.rs                    # wire Sync variant -> sync::run
+    sync/
+      mod.rs                    # NEW: re-exports + `run()` entry point
+      diff.rs                   # NEW: FileDiff types + diff algorithm (TDD)
+    db/
+      queries.rs                # add `list_files_in_root(root_name)`
+      write.rs                  # add `delete_file_subtree(root_name, relative_path)`
+  tests/
+    sync_unit.rs                # NEW: diff algorithm tests
+    integration_sync.rs         # NEW: gated; full index → modify → sync → verify
+```
+
+---
+
+### Task 1: Module skeleton
+
+**Files:**
+- Modify: `src/lib.rs` (add `pub mod sync;`)
+- Create: `src/sync/mod.rs`
+- Create: `src/sync/diff.rs` (stub)
+
+- [ ] **Step 1: Add `pub mod sync;` to src/lib.rs**
+
+After the existing `pub mod resolution;`:
+
+```rust
+pub mod cli;
+pub mod config;
+pub mod db;
+pub mod extraction;
+pub mod resolution;
+pub mod sync;
+```
+
+- [ ] **Step 2: Create src/sync/mod.rs**
+
+```rust
+//! Sync (incremental update) pipeline (spec §9).
+//!
+//! Compares the filesystem state of each workspace root against the indexed
+//! state in Neo4j, applies per-file delete/extract operations, and runs the
+//! global resolution rebuild.
+
+pub mod diff;
+
+use anyhow::Result;
+
+use crate::db::Connection;
+
+/// Run the full sync pipeline. Filled in by Task 5.
+pub async fn run(_conn: &Connection) -> Result<()> {
+    anyhow::bail!("sync::run: not yet implemented (filled in by Task 5)")
+}
+```
+
+- [ ] **Step 3: Create src/sync/diff.rs**
+
+```rust
+//! FileDiff types and the diff algorithm. Filled in by Task 2.
+```
+
+- [ ] **Step 4: Build, clippy, fmt, run tests**
+
+```bash
+cd /Users/gyorgybalazsi/codegraph-rs
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+```
+
+All clean, 54 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib.rs src/sync/
+git commit -m "chore(sync): module skeleton for slice 5"
+```
+
+---
+
+### Task 2: `FileDiff` type + diff algorithm (TDD)
+
+The diff algorithm is purely in-memory: take a map of `(relative_path, content_hash)` for the filesystem and another for the database; produce three vectors. This is the only logic-heavy piece of sync that's not just plumbing existing components together.
+
+**Files:**
+- Modify: `src/sync/diff.rs`
+- Create: `tests/sync_unit.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/sync_unit.rs`:
+
+```rust
+//! Unit tests for sync diff algorithm.
+
+use codegraph_rs::sync::diff::{diff_files, FileDiff};
+use std::collections::HashMap;
+
+#[test]
+fn diff_empty_state_is_empty() {
+    let fs = HashMap::new();
+    let db = HashMap::new();
+    let d = diff_files(&fs, &db);
+    assert!(d.added.is_empty());
+    assert!(d.changed.is_empty());
+    assert!(d.deleted.is_empty());
+}
+
+#[test]
+fn diff_added_files() {
+    let fs: HashMap<String, String> = [
+        ("a.rs".to_string(), "hash_a".to_string()),
+        ("b.rs".to_string(), "hash_b".to_string()),
+    ].into_iter().collect();
+    let db = HashMap::new();
+    let d = diff_files(&fs, &db);
+    let mut added = d.added.clone();
+    added.sort();
+    assert_eq!(added, vec!["a.rs", "b.rs"]);
+    assert!(d.changed.is_empty());
+    assert!(d.deleted.is_empty());
+}
+
+#[test]
+fn diff_deleted_files() {
+    let fs = HashMap::new();
+    let db: HashMap<String, String> = [
+        ("a.rs".to_string(), "hash_a".to_string()),
+    ].into_iter().collect();
+    let d = diff_files(&fs, &db);
+    assert!(d.added.is_empty());
+    assert!(d.changed.is_empty());
+    assert_eq!(d.deleted, vec!["a.rs"]);
+}
+
+#[test]
+fn diff_changed_files() {
+    let fs: HashMap<String, String> = [
+        ("a.rs".to_string(), "hash_v2".to_string()),
+    ].into_iter().collect();
+    let db: HashMap<String, String> = [
+        ("a.rs".to_string(), "hash_v1".to_string()),
+    ].into_iter().collect();
+    let d = diff_files(&fs, &db);
+    assert!(d.added.is_empty());
+    assert_eq!(d.changed, vec!["a.rs"]);
+    assert!(d.deleted.is_empty());
+}
+
+#[test]
+fn diff_unchanged_files_appear_in_no_bucket() {
+    let fs: HashMap<String, String> = [
+        ("a.rs".to_string(), "hash_a".to_string()),
+    ].into_iter().collect();
+    let db: HashMap<String, String> = [
+        ("a.rs".to_string(), "hash_a".to_string()),
+    ].into_iter().collect();
+    let d = diff_files(&fs, &db);
+    assert!(d.added.is_empty(), "unchanged file should not appear in any bucket: {d:?}");
+    assert!(d.changed.is_empty());
+    assert!(d.deleted.is_empty());
+}
+
+#[test]
+fn diff_mixed_buckets() {
+    let fs: HashMap<String, String> = [
+        ("kept.rs".to_string(), "h1".to_string()),
+        ("changed.rs".to_string(), "h2_new".to_string()),
+        ("added.rs".to_string(), "h3".to_string()),
+    ].into_iter().collect();
+    let db: HashMap<String, String> = [
+        ("kept.rs".to_string(), "h1".to_string()),
+        ("changed.rs".to_string(), "h2_old".to_string()),
+        ("deleted.rs".to_string(), "h4".to_string()),
+    ].into_iter().collect();
+    let d = diff_files(&fs, &db);
+    assert_eq!(d.added, vec!["added.rs"]);
+    assert_eq!(d.changed, vec!["changed.rs"]);
+    assert_eq!(d.deleted, vec!["deleted.rs"]);
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+cargo test --test sync_unit 2>&1 | tail -10
+```
+
+Expected: compile errors about missing `diff_files`, `FileDiff`.
+
+- [ ] **Step 3: Implement the diff**
+
+Overwrite `src/sync/diff.rs`:
+
+```rust
+//! FileDiff types and the diff algorithm.
+//!
+//! Pure functions over (path, content_hash) maps — no I/O. Slice 5 Task 5
+//! wraps this with filesystem walking + Neo4j querying.
+
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FileDiff {
+    /// Files present in the filesystem but not in the DB.
+    pub added: Vec<String>,
+    /// Files in both but with different content hashes.
+    pub changed: Vec<String>,
+    /// Files present in the DB but not in the filesystem.
+    pub deleted: Vec<String>,
+}
+
+/// Compute the three-bucket diff. Inputs are maps of `relative_path -> content_hash`.
+pub fn diff_files(
+    filesystem: &HashMap<String, String>,
+    database: &HashMap<String, String>,
+) -> FileDiff {
+    let mut diff = FileDiff::default();
+
+    for (path, fs_hash) in filesystem {
+        match database.get(path) {
+            None => diff.added.push(path.clone()),
+            Some(db_hash) if db_hash != fs_hash => diff.changed.push(path.clone()),
+            Some(_) => { /* unchanged — no bucket */ }
+        }
+    }
+
+    for path in database.keys() {
+        if !filesystem.contains_key(path) {
+            diff.deleted.push(path.clone());
+        }
+    }
+
+    // Deterministic order makes test assertions stable and helps debugging.
+    diff.added.sort();
+    diff.changed.sort();
+    diff.deleted.sort();
+    diff
+}
+```
+
+- [ ] **Step 4: Run tests, fmt, clippy**
+
+```bash
+cargo test --test sync_unit 2>&1 | tail -10
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: 6 tests pass. fmt/clippy clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sync/diff.rs tests/sync_unit.rs
+git commit -m "feat(sync): add FileDiff types and diff_files algorithm"
+```
+
+---
+
+### Task 3: `db::queries::list_files_in_root`
+
+**Files:**
+- Modify: `src/db/queries.rs`
+
+Adds one query helper that fetches all `File` nodes for a given root, returning `(relative_path, content_hash)` pairs. Used by the sync orchestrator (Task 5) to populate the DB-side of the diff.
+
+- [ ] **Step 1: Append to src/db/queries.rs**
+
+After the existing `file_qid_for_source` function, append:
+
+```rust
+/// List all `(:File)` nodes in the given workspace root with their content hashes.
+/// Returns a HashMap of `relative_path -> content_hash`. Files without a
+/// `content_hash` property are skipped (shouldn't happen for slice-2-indexed
+/// files but defensive against partial schema migrations).
+pub async fn list_files_in_root(
+    conn: &Connection,
+    root_name: &str,
+) -> Result<std::collections::HashMap<String, String>> {
+    let mut stream = conn
+        .graph
+        .execute(
+            cypher(
+                "MATCH (f:File {root_name: $root}) \
+                 WHERE f.content_hash IS NOT NULL \
+                 RETURN f.relative_path AS path, f.content_hash AS hash",
+            )
+            .param("root", root_name.to_string()),
+        )
+        .await
+        .context("list_files_in_root")?;
+    let mut out = std::collections::HashMap::new();
+    while let Some(row) = stream.next().await.context("row stream")? {
+        let path: String = row.get("path").context("path")?;
+        let hash: String = row.get("hash").context("hash")?;
+        out.insert(path, hash);
+    }
+    Ok(out)
+}
+```
+
+- [ ] **Step 2: Build, clippy, fmt, test**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+```
+
+Expected: 60 tests pass (54 prior + 6 from Task 2 sync_unit).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/db/queries.rs
+git commit -m "feat(db): add list_files_in_root query helper"
+```
+
+---
+
+### Task 4: `db::write::delete_file_subtree`
+
+**Files:**
+- Modify: `src/db/write.rs`
+
+Adds the per-file deletion helper used by sync for Changed and Deleted files. Reaches the File, all CONTAINS-children Symbols, and the HAS_REF UnresolvedRef nodes hanging off those Symbols — exactly the subtree to delete on a file change.
+
+- [ ] **Step 1: Append to src/db/write.rs**
+
+After the existing `to_bolt` function, append:
+
+```rust
+/// Delete a File and everything it transitively contains, including the
+/// UnresolvedRef records attached to its Symbol children via HAS_REF.
+///
+/// Per spec §9: cross-file `UnresolvedRef` nodes (whose `source_qid` lives in
+/// a DIFFERENT file but happen to name a symbol in this file) are NOT touched.
+/// The global resolution rebuild that follows sync recreates cross-file edges
+/// against the new target qids.
+pub async fn delete_file_subtree(
+    conn: &Connection,
+    root_name: &str,
+    relative_path: &str,
+) -> Result<()> {
+    conn.graph
+        .execute(
+            neo4rs::query(
+                "MATCH (f:File {root_name: $root, relative_path: $rel}) \
+                 OPTIONAL MATCH (f)-[:CONTAINS*]->(child:Symbol) \
+                 OPTIONAL MATCH (child)-[:HAS_REF]->(ref:UnresolvedRef) \
+                 DETACH DELETE f, child, ref",
+            )
+            .param("root", root_name.to_string())
+            .param("rel", relative_path.to_string()),
+        )
+        .await
+        .with_context(|| {
+            format!("delete_file_subtree(root={root_name}, rel={relative_path})")
+        })?
+        .next()
+        .await
+        .ok();
+    Ok(())
+}
+```
+
+> Note: imports at the top of `write.rs` already include `Context`, `Result`, `neo4rs::query as cypher`, and `Connection`. If `delete_file_subtree`'s body uses `neo4rs::query` directly (not the `cypher` alias) for clarity, that's fine — both are valid.
+
+- [ ] **Step 2: Build, clippy, fmt, test**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+```
+
+Expected: 60 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/db/write.rs
+git commit -m "feat(db): add delete_file_subtree for sync's per-file cleanup"
+```
+
+---
+
+### Task 5: Sync orchestrator
+
+**Files:**
+- Modify: `src/sync/mod.rs`
+
+Replaces the stub `run()` with the real sync orchestrator. Walks roots, hashes, diffs, deletes, extracts, writes, resolves.
+
+- [ ] **Step 1: Implement**
+
+Overwrite `src/sync/mod.rs`:
+
+```rust
+//! Sync (incremental update) pipeline (spec §9).
+//!
+//! Compares the filesystem state of each workspace root against the indexed
+//! state in Neo4j, applies per-file delete/extract operations, and runs the
+//! global resolution rebuild.
+
+pub mod diff;
+
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use tracing::{info, warn};
+
+use crate::config::workspace::WorkspaceConfig;
+use crate::db::queries::list_files_in_root;
+use crate::db::write::{delete_file_subtree, write_extraction};
+use crate::db::Connection;
+use crate::extraction::hash::source_hash;
+use crate::extraction::languages::rust::extract_rust;
+use crate::extraction::result::ExtractionResult;
+use crate::extraction::walker::walk_root;
+use crate::resolution;
+use crate::resolution::ResolutionStats;
+use diff::{diff_files, FileDiff};
+
+/// One per-root sync outcome.
+#[derive(Debug, Clone, Default)]
+pub struct RootSyncStats {
+    pub root_name: String,
+    pub added: usize,
+    pub changed: usize,
+    pub deleted: usize,
+}
+
+/// Aggregate sync stats for the whole workspace.
+#[derive(Debug, Default)]
+pub struct SyncStats {
+    pub per_root: Vec<RootSyncStats>,
+    pub resolution: ResolutionStats,
+}
+
+impl SyncStats {
+    pub fn total_added(&self) -> usize { self.per_root.iter().map(|r| r.added).sum() }
+    pub fn total_changed(&self) -> usize { self.per_root.iter().map(|r| r.changed).sum() }
+    pub fn total_deleted(&self) -> usize { self.per_root.iter().map(|r| r.deleted).sum() }
+}
+
+/// Run the full sync pipeline against the workspace's Neo4j database.
+pub async fn run(conn: &Connection, cfg: &WorkspaceConfig) -> Result<SyncStats> {
+    let languages = &cfg.indexing.languages;
+    let mut stats = SyncStats::default();
+    let mut all_new_results: Vec<ExtractionResult> = Vec::new();
+
+    for root in &cfg.workspace.roots {
+        info!("syncing root `{}`", root.name);
+
+        // Filesystem state: walk + hash.
+        let fs_state: HashMap<String, String> = walk_root(&root.path, &root.name, languages)
+            .map(|f| {
+                let source = std::fs::read_to_string(&f.absolute_path)
+                    .with_context(|| format!("reading {}", f.absolute_path.display()))?;
+                Ok((f.relative_path.clone(), source_hash(&source)))
+            })
+            .collect::<Result<HashMap<_, _>>>()?;
+
+        // DB state for this root.
+        let db_state = list_files_in_root(conn, &root.name).await
+            .with_context(|| format!("list_files_in_root({})", root.name))?;
+
+        let diff: FileDiff = diff_files(&fs_state, &db_state);
+        info!(
+            "root `{}`: added={}, changed={}, deleted={}",
+            root.name,
+            diff.added.len(),
+            diff.changed.len(),
+            diff.deleted.len()
+        );
+
+        // Delete changed + deleted file subtrees.
+        for rel in diff.changed.iter().chain(diff.deleted.iter()) {
+            delete_file_subtree(conn, &root.name, rel).await
+                .with_context(|| format!("delete_file_subtree({}, {})", root.name, rel))?;
+        }
+
+        // Re-extract added + changed files.
+        for rel in diff.added.iter().chain(diff.changed.iter()) {
+            let abs = root.path.join(rel);
+            let source = match std::fs::read_to_string(&abs) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("read failed for {}: {e:#}", abs.display());
+                    continue;
+                }
+            };
+            // Slice 5 only supports Rust here. Slice 7 adds Daml dispatch.
+            // Source-extension routing matches the walker's `language` field.
+            let result = match abs.extension().and_then(|s| s.to_str()) {
+                Some("rs") => extract_rust(&source, &root.name, rel),
+                Some(other) => {
+                    warn!("no extractor for `.{other}`, skipping {}", rel);
+                    continue;
+                }
+                None => continue,
+            };
+            match result {
+                Ok(er) => all_new_results.push(er),
+                Err(e) => warn!("extraction failed for {}: {e:#}", abs.display()),
+            }
+        }
+
+        stats.per_root.push(RootSyncStats {
+            root_name: root.name.clone(),
+            added: diff.added.len(),
+            changed: diff.changed.len(),
+            deleted: diff.deleted.len(),
+        });
+    }
+
+    // Write all new extraction results in one batch (across roots).
+    if !all_new_results.is_empty() {
+        write_extraction(conn, all_new_results).await.context("write_extraction")?;
+    }
+
+    // Always run resolution rebuild: even pure deletions invalidate confidence edges.
+    let resolution_stats = resolution::resolve(conn).await.context("resolve")?;
+    stats.resolution = resolution_stats;
+
+    info!(
+        "sync done: added={}, changed={}, deleted={}, resolved={}, unresolved={}",
+        stats.total_added(),
+        stats.total_changed(),
+        stats.total_deleted(),
+        stats.resolution.total_resolved(),
+        stats.resolution.total_unresolved()
+    );
+
+    Ok(stats)
+}
+```
+
+> Note on the language dispatch — sync's per-file extraction has a small switch that mirrors the orchestrator's. Slice 7 (Daml) will need to update both call sites. Cleaner refactor: extract a `dispatch_by_language(lang, &source, root_name, relative_path) -> Result<ExtractionResult>` helper and call it from both places. Defer to slice 7 unless trivial to do now.
+
+- [ ] **Step 2: Build, clippy, fmt, test**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+```
+
+Expected: 60 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/sync/mod.rs
+git commit -m "feat(sync): orchestrator — walk/hash/diff/delete/extract/resolve"
+```
+
+---
+
+### Task 6: Wire `codegraph-rs sync` CLI command
+
+**Files:**
+- Create: `src/cli/sync.rs`
+- Modify: `src/cli/mod.rs`
+
+- [ ] **Step 1: Create src/cli/sync.rs**
+
+```rust
+//! `codegraph-rs sync` — incremental update.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+use tracing::info;
+
+use crate::config::secrets::resolve_neo4j_password;
+use crate::config::workspace;
+use crate::db::{schema::apply_schema, Connection};
+use crate::sync;
+
+pub fn run(workspace_arg: Option<&Path>) -> Result<()> {
+    let starting = workspace_arg.map(Path::to_path_buf).unwrap_or_else(|| {
+        std::env::current_dir().expect("cwd readable")
+    });
+    let workspace_dir = workspace::find_workspace_root(&starting)
+        .context("no workspace found; run `codegraph-rs init` first")?;
+    let cfg = workspace::load_from_path(&workspace_dir)?;
+    let pw = resolve_neo4j_password(&workspace_dir, None)?;
+
+    info!("syncing workspace `{}`", cfg.workspace.name);
+
+    let rt = tokio::runtime::Runtime::new().context("starting tokio runtime")?;
+    let stats = rt.block_on(async {
+        let conn = Connection::open(
+            &cfg.workspace.neo4j.uri,
+            &cfg.workspace.neo4j.username,
+            &pw.value,
+            &cfg.workspace.neo4j.database,
+        )
+        .await
+        .context("connecting to workspace database")?;
+
+        // Schema is idempotent; ensure it's present (defensive — should already be).
+        apply_schema(&conn).await.context("applying schema")?;
+
+        sync::run(&conn, &cfg).await.context("sync")
+    })?;
+
+    println!(
+        "Synced workspace `{}`: added={}, changed={}, deleted={}",
+        cfg.workspace.name,
+        stats.total_added(),
+        stats.total_changed(),
+        stats.total_deleted(),
+    );
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Wire dispatch in src/cli/mod.rs**
+
+Add `pub mod sync;` alongside `pub mod index;`:
+
+```rust
+pub mod index;
+pub mod init;
+pub mod status;
+pub mod sync;
+```
+
+Replace the existing combined stub arm:
+```rust
+        Command::Sync | Command::Query { .. } | Command::Serve => {
+            anyhow::bail!("not yet implemented");
+        }
+```
+
+With:
+```rust
+        Command::Sync => sync::run(cli.workspace.as_deref()),
+        Command::Query { .. } | Command::Serve => {
+            anyhow::bail!("not yet implemented");
+        }
+```
+
+- [ ] **Step 3: Update the cli_smoke test**
+
+In `tests/cli_smoke.rs`, the `stub_commands_fail_with_not_implemented` test iterates over `["sync", "serve"]`. Remove `"sync"` from the list — it's now a real command and will produce a different error message (likely "no workspace found").
+
+```rust
+    for sub in &["serve"] {
+```
+
+- [ ] **Step 4: Build, clippy, fmt, test**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+```
+
+Expected: 60 tests pass. The cli_smoke test still passes with its reduced loop.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/sync.rs src/cli/mod.rs tests/cli_smoke.rs
+git commit -m "feat(cli): wire up sync command"
+```
+
+---
+
+### Task 7: Integration test — full sync lifecycle
+
+**Files:**
+- Create: `tests/integration_sync.rs` (gated)
+
+Exercises the full sync lifecycle against live Neo4j:
+1. Index tiny-rust → verify initial state
+2. Add a new file → sync → verify new file's symbols appear
+3. Modify an existing file (remove a call) → sync → verify CALLS edge count drops
+4. Delete a file → sync → verify the file's symbols are gone
+
+- [ ] **Step 1: Create the integration test**
+
+Create `tests/integration_sync.rs`:
+
+```rust
+//! Integration test for sync. Walks through a realistic sequence:
+//!  1) full index
+//!  2) add a new file -> sync
+//!  3) modify an existing file -> sync
+//!  4) delete a file -> sync
+//! Gated on CODEGRAPH_RS_TEST_NEO4J=1.
+
+use codegraph_rs::cli::{index, init::{InitArgs, self}, sync as cli_sync};
+use neo4rs::query;
+use std::fs;
+use tempfile::tempdir;
+
+fn enabled() -> bool {
+    std::env::var("CODEGRAPH_RS_TEST_NEO4J").as_deref() == Ok("1")
+}
+
+#[test]
+fn sync_handles_add_modify_delete() {
+    if !enabled() {
+        eprintln!("SKIP: set CODEGRAPH_RS_TEST_NEO4J=1 to enable");
+        return;
+    }
+    let pw = std::env::var("CODEGRAPH_RS_TEST_NEO4J_PASSWORD")
+        .expect("CODEGRAPH_RS_TEST_NEO4J_PASSWORD required");
+
+    let dir = tempdir().unwrap();
+    let workspace_name = format!("sync-test-{}", std::process::id());
+
+    let fixture_src = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/tiny-rust");
+    let fixture_dst = dir.path().join("tiny-rust");
+    copy_dir(&fixture_src, &fixture_dst).unwrap();
+
+    // Init + initial index.
+    let args = InitArgs {
+        name: workspace_name.clone(),
+        neo4j_uri: "bolt://localhost:7687".into(),
+        neo4j_user: "neo4j".into(),
+        neo4j_password: pw.clone(),
+        root: vec!["tiny=tiny-rust".into()],
+    };
+    init::run(args, Some(dir.path())).expect("init must succeed");
+    std::env::set_var("CODEGRAPH_RS_NEO4J_PASSWORD", &pw);
+    index::run(Some(dir.path())).expect("index must succeed");
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let db_name = format!("codegraph-sync-test-{}", std::process::id());
+
+    // Capture initial counts.
+    let initial_file_count = rt.block_on(scalar_async(&pw, &db_name,
+        "MATCH (n:File) RETURN count(n) AS c"));
+    let initial_func_count = rt.block_on(scalar_async(&pw, &db_name,
+        "MATCH (n:Function) RETURN count(n) AS c"));
+    let initial_calls = rt.block_on(scalar_async(&pw, &db_name,
+        "MATCH ()-[r:CALLS]->() RETURN count(r) AS c"));
+    assert_eq!(initial_file_count, 3, "tiny-rust has 3 .rs files");
+    assert!(initial_func_count >= 4, "expected ≥4 Functions, got {initial_func_count}");
+    assert!(initial_calls >= 3, "expected ≥3 CALLS, got {initial_calls}");
+
+    // ── Step 1: Add a new file ──────────────────────────────────────────
+    fs::write(
+        fixture_dst.join("src/extra.rs"),
+        "pub fn brand_new_function() -> u32 { 99 }\n",
+    ).unwrap();
+    cli_sync::run(Some(dir.path())).expect("sync after add must succeed");
+
+    let file_count = rt.block_on(scalar_async(&pw, &db_name,
+        "MATCH (n:File) RETURN count(n) AS c"));
+    assert_eq!(file_count, 4, "expected File count to grow by 1 after adding extra.rs");
+
+    let new_fn_exists = rt.block_on(scalar_async(&pw, &db_name,
+        "MATCH (n:Function {name: 'brand_new_function'}) RETURN count(n) AS c"));
+    assert_eq!(new_fn_exists, 1, "brand_new_function should be indexed");
+
+    // ── Step 2: Modify an existing file (remove a CALLS source) ─────────
+    fs::write(
+        fixture_dst.join("src/lib.rs"),
+        // Remove the `util::helper();` call from library_entry
+        "pub mod util;\n\npub fn library_entry() {\n    // no calls anymore\n}\n",
+    ).unwrap();
+    cli_sync::run(Some(dir.path())).expect("sync after modify must succeed");
+
+    let calls_after_modify = rt.block_on(scalar_async(&pw, &db_name,
+        "MATCH ()-[r:CALLS]->() RETURN count(r) AS c"));
+    assert!(
+        calls_after_modify < initial_calls,
+        "CALLS count should have dropped (was {initial_calls}, now {calls_after_modify})"
+    );
+
+    // library_entry → helper should be gone specifically.
+    let library_to_helper = rt.block_on(scalar_async(&pw, &db_name,
+        "MATCH (:Function {name: 'library_entry'})-[:CALLS]->(:Function {name: 'helper'}) RETURN count(*) AS c"));
+    assert_eq!(library_to_helper, 0, "library_entry → helper CALLS edge should be gone after modify");
+
+    // ── Step 3: Delete a file ───────────────────────────────────────────
+    fs::remove_file(fixture_dst.join("src/util.rs")).unwrap();
+    cli_sync::run(Some(dir.path())).expect("sync after delete must succeed");
+
+    let file_count_after_delete = rt.block_on(scalar_async(&pw, &db_name,
+        "MATCH (n:File) RETURN count(n) AS c"));
+    assert_eq!(
+        file_count_after_delete, 3,
+        "expected File count 3 (extra.rs + lib.rs + main.rs) after deleting util.rs"
+    );
+
+    let util_funcs = rt.block_on(scalar_async(&pw, &db_name,
+        "MATCH (n:Function) WHERE n.name IN ['helper', 'constant'] RETURN count(n) AS c"));
+    assert_eq!(util_funcs, 0, "helper/constant should be gone after util.rs deletion");
+
+    std::env::remove_var("CODEGRAPH_RS_NEO4J_PASSWORD");
+
+    // ── Cleanup ─────────────────────────────────────────────────────────
+    rt.block_on(async {
+        let sys = codegraph_rs::db::Connection::system(
+            "bolt://localhost:7687", "neo4j", &pw,
+        ).await.unwrap();
+        sys.graph.execute(query(&format!("DROP DATABASE `{db_name}` IF EXISTS WAIT")))
+            .await.unwrap().next().await.ok();
+    });
+}
+
+async fn scalar_async(pw: &str, db_name: &str, cypher_text: &str) -> i64 {
+    let conn = codegraph_rs::db::Connection::open(
+        "bolt://localhost:7687", "neo4j", pw, db_name,
+    ).await.unwrap();
+    let mut stream = conn.graph.execute(query(cypher_text)).await.unwrap();
+    let row = stream.next().await.unwrap().unwrap();
+    row.get::<i64>("c").unwrap()
+}
+
+fn copy_dir(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        let dest = dst.join(entry.file_name());
+        if path.is_dir() {
+            copy_dir(&path, &dest)?;
+        } else {
+            fs::copy(&path, &dest)?;
+        }
+    }
+    Ok(())
+}
+```
+
+> Note: each `scalar_async` opens its own connection. Inefficient but simple — the test runs sequentially with `--test-threads=1`. Cleanup at the end uses a system connection.
+
+- [ ] **Step 2: Verify SKIP path**
+
+```bash
+cargo test --test integration_sync -- --nocapture 2>&1 | tail -10
+```
+
+Expected: 1 test, SKIP, passes.
+
+- [ ] **Step 3: Build, clippy, fmt**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+```
+
+All clean.
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+cargo test 2>&1 | tail -15
+```
+
+Expected: 61 total tests (60 from prior tasks + 1 new SKIP-passing integration test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/integration_sync.rs
+git commit -m "test(sync): integration test for add/modify/delete on tiny-rust"
+```
+
+---
+
+### Task 8: README + slice-5 tag
+
+**Files:**
+- Modify: `/Users/gyorgybalazsi/codegraph-rs/README.md`
+
+- [ ] **Step 1: Update README Status section**
+
+Replace the current Status section with:
+
+```markdown
+## Status
+
+In development. Currently implements **Slice 5: Sync** —
+workspace initialization, indexing, resolution, and incremental sync (diff-driven
+add/modify/delete handling with global resolution rebuild). Vector embeddings,
+MCP server, and Daml support land in subsequent slices.
+```
+
+(Adjust the wording if the current section uses a different format.)
+
+- [ ] **Step 2: Final test suite**
+
+```bash
+cd /Users/gyorgybalazsi/codegraph-rs
+cargo test 2>&1 | tail -20
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+```
+
+Expected:
+
+| Test binary | Count |
+|---|---|
+| `extraction_unit` | 31 |
+| `resolution_unit` | 2 |
+| `sync_unit` (new) | 6 |
+| `config_parsing` | 13 |
+| `cli_smoke` | 2 |
+| `integration_db` (SKIP) | 2 |
+| `integration_init` (SKIP) | 1 |
+| `integration_status` (SKIP) | 1 |
+| `integration_index` (SKIP) | 1 |
+| `integration_resolve` (SKIP) | 1 |
+| `integration_sync` (new, SKIP) | 1 |
+| **Total** | **61** |
+
+All clippy/fmt clean.
+
+- [ ] **Step 3: Commit and tag**
+
+```bash
+git add README.md
+git commit -m "docs: update README for slice 5"
+git tag slice-5-sync
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+git log --oneline | head -5
+git tag --list
+```
+
+Expected: 4 slice tags now (`slice-1-walking-skeleton`, `slice-2-rust-extraction`, `slice-3-resolution`, `slice-5-sync`). No `slice-4` — we skipped embeddings; will come later.
+
+---
+
+## Slice 5 Done
+
+Verify the artifact:
+
+- [ ] `cargo build` clean
+- [ ] `cargo test` (no env vars) — 61 tests pass, integration tests SKIP cleanly
+- [ ] `CODEGRAPH_RS_TEST_NEO4J=1 cargo test -- --test-threads=1` — all 61 pass
+- [ ] Manual: `codegraph-rs sync` runs against an already-initialized workspace; idempotent (running twice on unchanged workspace produces 0 added/changed/deleted)
+- [ ] Modifying a file and re-running `sync` updates only that file's subgraph; resolution edges re-emerge
+- [ ] No embeddings yet (Slice 4 deferred)
+- [ ] No MCP server yet (Slice 6)
+
+When all check, slice 5 is complete and we can write the next slice. Likely Slice 4 (vector embeddings) next, then Slice 6 (MCP) so the embeddings get a consumer.

--- a/docs/superpowers/plans/2026-05-11-codegraph-rs-slice-6-mcp.md
+++ b/docs/superpowers/plans/2026-05-11-codegraph-rs-slice-6-mcp.md
@@ -1239,8 +1239,14 @@ fn enabled() -> bool {
     std::env::var("CODEGRAPH_RS_TEST_NEO4J").as_deref() == Ok("1")
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn mcp_exposes_graph_tools_against_tiny_rust() {
+// Plain `#[test]` (not `#[tokio::test]`) — `init::run` and `index::run` each
+// build their own internal `tokio::runtime::Runtime` and call `block_on`,
+// which panics ("Cannot start a runtime from within a runtime") if invoked
+// from inside an outer Tokio context. All other Slice 2/3/5 integration
+// tests follow the same pattern: synchronous body for the CLI calls, then
+// a dedicated `Runtime` for ad-hoc async work.
+#[test]
+fn mcp_exposes_graph_tools_against_tiny_rust() {
     if !enabled() {
         eprintln!("SKIP: set CODEGRAPH_RS_TEST_NEO4J=1 to enable");
         return;
@@ -1268,40 +1274,44 @@ async fn mcp_exposes_graph_tools_against_tiny_rust() {
     index::run(Some(dir.path())).expect("index must succeed");
 
     let cfg = load_from_path(dir.path()).unwrap();
-    let conn = Connection::open(
-        &cfg.workspace.neo4j.uri,
-        &cfg.workspace.neo4j.username,
-        &pw,
-        &cfg.workspace.neo4j.database,
-    ).await.unwrap();
-
-    // Capture the db name before moving cfg into the server.
     let db_name = cfg.workspace.neo4j.database.clone();
 
-    let server = McpServer::new(conn, cfg, dir.path().to_path_buf());
+    // All async work — MCP server + client + cleanup — happens inside one
+    // dedicated runtime. `Runtime::new()` is safe here because we are NOT
+    // inside another Tokio context (this is a plain `#[test]`).
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let conn = Connection::open(
+            &cfg.workspace.neo4j.uri,
+            &cfg.workspace.neo4j.username,
+            &pw,
+            &cfg.workspace.neo4j.database,
+        ).await.unwrap();
 
-    // Build paired duplex pipes: server side ↔ client side.
-    // Each DuplexStream is AsyncRead + AsyncWrite; rmcp's `IntoTransport for (R, W)`
-    // requires a tuple, so split each half into its read/write components.
-    let (server_io, client_io) = tokio::io::duplex(64 * 1024);
-    let (server_rx, server_tx) = tokio::io::split(server_io);
-    let (client_rx, client_tx) = tokio::io::split(client_io);
+        let server = McpServer::new(conn, cfg, dir.path().to_path_buf());
 
-    let server_running = server
-        .serve((server_rx, server_tx))
-        .await
-        .expect("server serve");
+        // Build paired duplex pipes: server side ↔ client side.
+        // Each DuplexStream is AsyncRead + AsyncWrite; rmcp's `IntoTransport for (R, W)`
+        // requires a tuple, so split each half into its read/write components.
+        let (server_io, client_io) = tokio::io::duplex(64 * 1024);
+        let (server_rx, server_tx) = tokio::io::split(server_io);
+        let (client_rx, client_tx) = tokio::io::split(client_io);
 
-    // Client side speaks MCP over the other half.
-    let client_info = ClientInfo {
-        protocol_version: ProtocolVersion::default(),
-        capabilities: Default::default(),
-        client_info: Implementation { name: "test".into(), version: "0".into() },
-    };
-    let client = client_info
-        .serve((client_rx, client_tx))
-        .await
-        .expect("client init");
+        let server_running = server
+            .serve((server_rx, server_tx))
+            .await
+            .expect("server serve");
+
+        // Client side speaks MCP over the other half.
+        let client_info = ClientInfo {
+            protocol_version: ProtocolVersion::default(),
+            capabilities: Default::default(),
+            client_info: Implementation { name: "test".into(), version: "0".into() },
+        };
+        let client = client_info
+            .serve((client_rx, client_tx))
+            .await
+            .expect("client init");
 
     // list_tools should return all 7.
     let tools = client.list_tools(Default::default()).await.expect("list_tools").tools;
@@ -1363,14 +1373,21 @@ async fn mcp_exposes_graph_tools_against_tiny_rust() {
     assert_eq!(nbody["node"]["name"], json!("library_entry"));
     assert!(nbody["source"].as_str().unwrap().contains("library_entry"));
 
-    // node with bogus qid — should come back as a tool-level error (CallToolResult
-    // with `is_error: Some(true)`), not silently succeed with empty content.
-    let bogus = client.call_tool(CallToolRequestParam {
+    // node with bogus qid — should surface as an error, not silently succeed
+    // with empty content. rmcp 1.5 may route a `Err(ErrorData)` from a tool
+    // handler either as a tool-level error (Ok with `is_error: Some(true)`)
+    // or as a JSON-RPC error (`Err` from `call_tool`). Both are acceptable;
+    // the test must FAIL only if the call returned a successful result.
+    match client.call_tool(CallToolRequestParam {
         name: "codegraph_rs_node".into(),
         arguments: Some(json!({ "qid": "definitely-not-a-real-qid" }).as_object().unwrap().clone()),
-    }).await.expect("bogus-node call returns Ok with is_error=true");
-    assert_eq!(bogus.is_error, Some(true),
-               "unknown qid should mark CallToolResult.is_error=true; got {:?}", bogus);
+    }).await {
+        Ok(r) => assert_eq!(
+            r.is_error, Some(true),
+            "unknown qid should mark CallToolResult.is_error=true; got {r:?}"
+        ),
+        Err(_) => { /* RPC-level error is also acceptable */ }
+    }
 
     // callees: library_entry → helper
     let callees = client.call_tool(CallToolRequestParam {
@@ -1427,16 +1444,17 @@ async fn mcp_exposes_graph_tools_against_tiny_rust() {
         assert_eq!(f["root_name"], json!("tiny"), "every entry should be `tiny`-rooted");
     }
 
-    // Clean shutdown
-    drop(client);
-    drop(server_running);
+        // Clean shutdown
+        drop(client);
+        drop(server_running);
+
+        // Cleanup database (db_name was captured before moving cfg into the server).
+        let sys = Connection::system("bolt://localhost:7687", "neo4j", &pw).await.unwrap();
+        sys.graph.execute(query(&format!("DROP DATABASE `{db_name}` IF EXISTS WAIT")))
+            .await.unwrap().next().await.ok();
+    });
 
     std::env::remove_var("CODEGRAPH_RS_NEO4J_PASSWORD");
-
-    // Cleanup database (db_name was captured before moving cfg into the server)
-    let sys = Connection::system("bolt://localhost:7687", "neo4j", &pw).await.unwrap();
-    sys.graph.execute(query(&format!("DROP DATABASE `{db_name}` IF EXISTS WAIT")))
-        .await.unwrap().next().await.ok();
 }
 
 fn copy_dir(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {

--- a/docs/superpowers/plans/2026-05-11-codegraph-rs-slice-6-mcp.md
+++ b/docs/superpowers/plans/2026-05-11-codegraph-rs-slice-6-mcp.md
@@ -1332,6 +1332,21 @@ async fn mcp_exposes_graph_tools_against_tiny_rust() {
     let arr = results.as_array().expect("results array");
     assert!(arr.iter().any(|r| r["name"] == "library_entry"), "library_entry should match search");
 
+    // search with `kinds: ["Function"]` filter — exercises the kinds-filter branch.
+    // tiny-rust has File, Module, Function, Struct, Enum nodes; with kinds=[Function]
+    // we should only see Function-labeled hits.
+    let search_funcs = client.call_tool(CallToolRequestParam {
+        name: "codegraph_rs_search".into(),
+        arguments: Some(json!({ "query": "library_entry", "kinds": ["Function"] }).as_object().unwrap().clone()),
+    }).await.expect("search-funcs call");
+    let fres = &search_funcs.structured_content.expect("search-funcs structured")["results"];
+    let farr = fres.as_array().expect("results array");
+    assert!(!farr.is_empty(), "expected at least one Function hit for `library_entry`");
+    for hit in farr {
+        assert_eq!(hit["kind"], json!("Function"),
+                   "kinds filter should restrict to Function, got {hit}");
+    }
+
     // Pick a qid for downstream tests.
     let library_qid = arr.iter()
         .find(|r| r["name"] == "library_entry")
@@ -1347,6 +1362,15 @@ async fn mcp_exposes_graph_tools_against_tiny_rust() {
     let nbody = node.structured_content.expect("node structured");
     assert_eq!(nbody["node"]["name"], json!("library_entry"));
     assert!(nbody["source"].as_str().unwrap().contains("library_entry"));
+
+    // node with bogus qid — should come back as a tool-level error (CallToolResult
+    // with `is_error: Some(true)`), not silently succeed with empty content.
+    let bogus = client.call_tool(CallToolRequestParam {
+        name: "codegraph_rs_node".into(),
+        arguments: Some(json!({ "qid": "definitely-not-a-real-qid" }).as_object().unwrap().clone()),
+    }).await.expect("bogus-node call returns Ok with is_error=true");
+    assert_eq!(bogus.is_error, Some(true),
+               "unknown qid should mark CallToolResult.is_error=true; got {:?}", bogus);
 
     // callees: library_entry → helper
     let callees = client.call_tool(CallToolRequestParam {
@@ -1390,6 +1414,18 @@ async fn mcp_exposes_graph_tools_against_tiny_rust() {
     let fbody = files.structured_content.expect("files structured");
     let files_arr = fbody["files"].as_array().unwrap();
     assert_eq!(files_arr.len(), 3);
+
+    // files with `root: "tiny"` filter — exercises the root-filter branch.
+    let files_tiny = client.call_tool(CallToolRequestParam {
+        name: "codegraph_rs_files".into(),
+        arguments: Some(json!({ "root": "tiny" }).as_object().unwrap().clone()),
+    }).await.expect("files-tiny call");
+    let ftbody = files_tiny.structured_content.expect("files-tiny structured");
+    let ftarr = ftbody["files"].as_array().unwrap();
+    assert_eq!(ftarr.len(), 3, "tiny root should also list all 3 files");
+    for f in ftarr {
+        assert_eq!(f["root_name"], json!("tiny"), "every entry should be `tiny`-rooted");
+    }
 
     // Clean shutdown
     drop(client);

--- a/docs/superpowers/plans/2026-05-11-codegraph-rs-slice-6-mcp.md
+++ b/docs/superpowers/plans/2026-05-11-codegraph-rs-slice-6-mcp.md
@@ -1,0 +1,1538 @@
+# codegraph-rs Slice 6 — MCP (graph-traversal tools)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `codegraph-rs serve` work as an MCP stdio server that exposes the graph-traversal subset of spec §10. After this slice, Claude Code can connect to a codegraph-rs workspace and discover symbols by name, fetch a symbol's full detail with source snippet, and walk callers/callees/impact. **No embeddings.** Semantic search, context bundles, and explore are explicitly deferred to the embeddings slice and the slice that follows it.
+
+**Architecture:** Thin MCP server (rmcp) wrapping a new `graph` module. Each tool is a 5-line adapter: deserialize input → call `graph::*` method → serialize output. Heavy logic stays in `graph/` and in the existing `db/` queries. State is a single struct (`McpServer`) holding the Neo4j `Connection`, the `WorkspaceConfig`, and the workspace dir (needed for source-snippet reads).
+
+**Tech Stack additions:**
+- `rmcp = { version = "1.5", features = ["server", "macros", "transport-io", "transport-async-rw", "schemars"] }` — official Rust MCP SDK from Anthropic. The `transport-async-rw` feature is required because rmcp's `IntoTransport for (R, W)` impl (used to pass a tuple of `(AsyncRead, AsyncWrite)` to `serve(...)`) is gated on that feature. Without it, neither the `(Stdin, Stdout)` tuple in production nor the `tokio::io::duplex` halves in the integration test can be turned into a transport.
+- `schemars = "0.8"` — JSON Schema generation for tool input/output structs (rmcp generates `inputSchema` / `outputSchema` from these).
+
+No other new dependencies.
+
+**Source spec:** [`docs/superpowers/specs/2026-04-22-codegraph-rs-design.md`](../specs/2026-04-22-codegraph-rs-design.md) §10 (MCP server) and §11 (CLI surface, the `serve` row).
+
+**Slice 5 baseline:** HEAD `62a885b`, tagged `slice-5-sync`. 61 tests pass.
+
+---
+
+## Tool surface in this slice
+
+All tools prefixed `codegraph_rs_` per spec §10 to coexist with the TS-version tools without collision.
+
+| Tool | Inputs | Returns | Notes |
+|---|---|---|---|
+| `codegraph_rs_status` | — | `{ workspace, database, roots[], file_count, symbol_count, unresolved_count, last_indexed_at? }` | Reuses status logic refactored out of `cli/status.rs` |
+| `codegraph_rs_files` | `root?: string` | `{ files: [{ root_name, relative_path, symbol_count }] }` | Optional `root` filter |
+| `codegraph_rs_search` | `query: string`, `kinds?: string[]`, `root?: string`, `limit?: number=10` | `{ results: [{ qid, name, kind, qualified_name, root_name, relative_path }] }` | Cypher uses Neo4j FTS index `symbol_fts` (already present in schema since slice 2) |
+| `codegraph_rs_node` | `qid: string` | `{ node: { qid, name, kind, qualified_name, root_name, relative_path, start_line, end_line }, source: string }` | Reads source slice from disk using `root_name` + `relative_path` |
+| `codegraph_rs_callers` | `qid: string`, `depth?: number=2` | `{ callers: [{ qid, name, kind, hops }] }` | Reverse direction of `CALLS` |
+| `codegraph_rs_callees` | `qid: string`, `depth?: number=2` | `{ callees: [{ qid, name, kind, hops }] }` | Forward direction of `CALLS` |
+| `codegraph_rs_impact` | `qid: string`, `depth?: number=3` | `{ impact: [{ qid, name, kind, hops, edge_kind }] }` | Reverse-transitive closure of `CALLS`/`REFERENCES`/`TYPE_OF` |
+
+## Out of scope for Slice 6
+
+- **Semantic search** (`codegraph_rs_semantic_search`). Needs embeddings; deferred to the embeddings slice.
+- **Context bundles and explore** (`codegraph_rs_context`, `codegraph_rs_explore`). Far more valuable with embeddings; designed in the slice after embeddings.
+- **Streaming responses, auth, multi-client.** Per spec §10 "Not in v1".
+- **Background reindex during `serve`.** User runs `codegraph-rs sync` separately. Per spec §10 and prior slices.
+- **MCP `Resources` and `Prompts` capabilities.** Slice exposes only `Tools`.
+- **Error suggestion fuzzy-match** (spec §10 "Unknown qid → fuzzy-match suggestion"). v1 returns a plain "qid not found" error; fuzzy match deferred.
+- **HTTP/SSE transport.** stdio only.
+
+---
+
+## File structure produced by this slice
+
+```
+codegraph-rs/
+  Cargo.toml                  # add rmcp + schemars
+  src/
+    lib.rs                    # add `pub mod mcp;` and `pub mod graph;`
+    cli/
+      mod.rs                  # wire Command::Serve -> serve::run
+      serve.rs                # NEW: codegraph-rs serve command
+      status.rs               # MODIFY: delegate to graph::status::collect()
+    graph/
+      mod.rs                  # NEW: re-exports + module index
+      status.rs               # NEW: StatusSnapshot + collect()
+      files.rs                # NEW: FileEntry + list()
+      search.rs               # NEW: SearchHit + search()
+      node.rs                 # NEW: NodeDetail + find()
+      traverse.rs             # NEW: callers(), callees(), impact()
+      source.rs               # NEW: read_snippet() — disk read by root_name + relative_path + line range
+    mcp/
+      mod.rs                  # NEW: McpServer struct + ServerHandler impl + 7 tools
+  tests/
+    graph_unit.rs             # NEW: pure-Rust tests for source::read_snippet
+    integration_mcp.rs        # NEW: gated; in-process MCP via tokio::io::duplex
+```
+
+**Lines of new code estimate:** ~600 production + ~250 test. Most code is short Cypher wrappers and thin MCP adapters.
+
+---
+
+## Why a separate `graph` module
+
+The MCP tools must dispatch to **pure** functions: take typed args, return typed structs, no Cypher leakage. Today the only candidates for this work are `db::queries::*` (resolution-specific) and inline Cypher in `cli/status.rs`. Inlining 7 more Cypher queries into MCP tool handlers would put all the schema knowledge in one place where it's hardest to test (inside the MCP server). Extracting them into `graph::*` modules:
+
+- Keeps each query independently testable (later, via integration tests against tiny-rust).
+- Makes `mcp/tools.rs` adapter code stay thin (one liners), matching spec §10's "Heavy logic stays in non-MCP modules".
+- Lets `cli/status.rs` reuse `graph::status::collect()` instead of duplicating count Cypher.
+- Sets up the API surface that the embeddings slice and the context/explore slice will extend.
+
+---
+
+### Task 1: Module skeleton + dependencies
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `src/lib.rs`
+- Create: `src/graph/mod.rs`, `src/mcp/mod.rs`
+
+- [ ] **Step 1: Add deps to Cargo.toml**
+
+Append to `[dependencies]`:
+
+```toml
+rmcp = { version = "1.5", features = ["server", "macros", "transport-io", "transport-async-rw", "schemars"] }
+schemars = "0.8"
+```
+
+- [ ] **Step 2: Derive `Clone` on workspace config types**
+
+Slice 6's MCP server takes ownership of `WorkspaceConfig` and the integration test also needs to retain the config for post-test cleanup. Edit `src/config/workspace.rs` and add `Clone` to the four config struct derives:
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+pub struct WorkspaceConfig { ... }
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Workspace { ... }
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Neo4j { ... }
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Root { ... }
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Indexing { ... }
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Embeddings { ... }
+```
+
+No other change to those types.
+
+- [ ] **Step 3: Module declarations**
+
+In `src/lib.rs`, add (alphabetical, after `pub mod extraction;`):
+
+```rust
+pub mod graph;
+pub mod mcp;
+```
+
+- [ ] **Step 4: Create empty module roots**
+
+`src/graph/mod.rs`:
+```rust
+//! Read-only graph queries — typed wrappers over Cypher.
+//!
+//! Each submodule defines a small set of pure-data response structs and a single
+//! `pub async fn` that takes a `&Connection` (and parameters) and returns those
+//! structs. No Cypher leaks beyond this module.
+```
+
+`src/mcp/mod.rs`:
+```rust
+//! MCP stdio server. See spec §10.
+```
+
+- [ ] **Step 5: Build + clippy + fmt**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -3
+```
+
+Expected: clean build (downloads rmcp + schemars + transitive deps the first time), 61 tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock src/lib.rs src/config/workspace.rs src/graph/mod.rs src/mcp/mod.rs
+git commit -m "chore(mcp): add rmcp + schemars deps and module skeleton"
+```
+
+---
+
+### Task 2: `graph::status` and `graph::source`
+
+**Files:**
+- Create: `src/graph/status.rs`
+- Create: `src/graph/source.rs`
+- Modify: `src/graph/mod.rs` (declare submodules)
+- Modify: `src/cli/status.rs` (delegate)
+
+The `status` query is a no-arg snapshot of workspace counts. The `source` helper is needed early because the `node` query depends on it. Combining them in one task keeps Task 5 (`graph::node`) tight.
+
+- [ ] **Step 1: `src/graph/status.rs`**
+
+```rust
+//! Workspace snapshot — file / symbol / unresolved counts + last-indexed timestamp.
+
+use anyhow::{Context, Result};
+use neo4rs::query;
+use serde::Serialize;
+
+use crate::config::workspace::WorkspaceConfig;
+use crate::db::Connection;
+
+#[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
+pub struct StatusSnapshot {
+    pub workspace: String,
+    pub database: String,
+    pub roots: Vec<String>,
+    pub file_count: i64,
+    pub symbol_count: i64,
+    pub unresolved_count: i64,
+    pub last_indexed_at: Option<i64>,
+}
+
+pub async fn collect(conn: &Connection, cfg: &WorkspaceConfig) -> Result<StatusSnapshot> {
+    let file_count = single_count(conn, "MATCH (n:File) RETURN count(n) AS c").await?;
+    let symbol_count = single_count(conn, "MATCH (n:Symbol) RETURN count(n) AS c").await?;
+    let unresolved_count =
+        single_count(conn, "MATCH (n:UnresolvedRef) RETURN count(n) AS c").await?;
+    let last_indexed_at = max_last_indexed(conn).await?;
+
+    Ok(StatusSnapshot {
+        workspace: cfg.workspace.name.clone(),
+        database: cfg.workspace.neo4j.database.clone(),
+        roots: cfg.workspace.roots.iter().map(|r| r.name.clone()).collect(),
+        file_count,
+        symbol_count,
+        unresolved_count,
+        last_indexed_at,
+    })
+}
+
+async fn single_count(conn: &Connection, cypher: &str) -> Result<i64> {
+    let mut stream = conn
+        .graph
+        .execute(query(cypher))
+        .await
+        .with_context(|| format!("running `{cypher}`"))?;
+    let row = stream
+        .next()
+        .await
+        .with_context(|| format!("stream error reading `{cypher}`"))?
+        .with_context(|| format!("`{cypher}` returned no row"))?;
+    row.get("c").context("row missing `c`")
+}
+
+async fn max_last_indexed(conn: &Connection) -> Result<Option<i64>> {
+    let mut stream = conn
+        .graph
+        .execute(query("MATCH (n:File) RETURN max(n.last_indexed_at) AS t"))
+        .await?;
+    match stream.next().await? {
+        None => Ok(None),
+        Some(row) => row.get::<Option<i64>>("t").context("missing `t`"),
+    }
+}
+```
+
+This is a verbatim port of the helpers in the current `cli/status.rs` — same Cypher, same error contexts.
+
+- [ ] **Step 2: `src/graph/source.rs`**
+
+```rust
+//! Read source-code slices from disk using stored (root_name, relative_path, line range).
+
+use anyhow::{anyhow, Context, Result};
+use std::path::{Path, PathBuf};
+
+use crate::config::workspace::WorkspaceConfig;
+
+/// Resolves a `root_name` to an absolute filesystem path under `workspace_dir`.
+pub fn root_path(
+    workspace_dir: &Path,
+    cfg: &WorkspaceConfig,
+    root_name: &str,
+) -> Result<PathBuf> {
+    let root = cfg
+        .workspace
+        .roots
+        .iter()
+        .find(|r| r.name == root_name)
+        .ok_or_else(|| anyhow!("unknown root `{root_name}` (not in workspace config)"))?;
+    Ok(workspace_dir.join(&root.path))
+}
+
+/// Reads `[start_line..=end_line]` (1-based, inclusive) from the given file.
+/// Returns the trimmed slice; empty string if the file is shorter than `start_line`.
+pub fn read_snippet(
+    workspace_dir: &Path,
+    cfg: &WorkspaceConfig,
+    root_name: &str,
+    relative_path: &str,
+    start_line: u32,
+    end_line: u32,
+) -> Result<String> {
+    let abs = root_path(workspace_dir, cfg, root_name)?.join(relative_path);
+    let content = std::fs::read_to_string(&abs)
+        .with_context(|| format!("reading {}", abs.display()))?;
+    let s = start_line.saturating_sub(1) as usize;
+    let e = end_line.saturating_sub(1) as usize;
+    let lines: Vec<&str> = content.lines().collect();
+    if s >= lines.len() {
+        return Ok(String::new());
+    }
+    let end = e.min(lines.len().saturating_sub(1));
+    Ok(lines[s..=end].join("\n"))
+}
+```
+
+- [ ] **Step 3: Wire submodules**
+
+In `src/graph/mod.rs`, add:
+```rust
+pub mod source;
+pub mod status;
+```
+
+- [ ] **Step 4: Refactor `src/cli/status.rs`**
+
+Replace the body of `run()` so it uses `graph::status::collect()` and only handles `Connection::open` + `println!` formatting:
+
+```rust
+//! `codegraph-rs status` — print workspace stats.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+use crate::config::secrets::resolve_neo4j_password;
+use crate::config::workspace;
+use crate::db::Connection;
+use crate::graph::status;
+
+pub fn run(workspace_arg: Option<&Path>) -> Result<()> {
+    let starting = workspace_arg
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| std::env::current_dir().expect("cwd readable"));
+    let workspace_dir = workspace::find_workspace_root(&starting)
+        .context("no workspace found; run `codegraph-rs init` first")?;
+    let cfg = workspace::load_from_path(&workspace_dir)?;
+    let pw = resolve_neo4j_password(&workspace_dir, None)?;
+
+    let rt = tokio::runtime::Runtime::new().context("starting tokio runtime")?;
+    rt.block_on(async {
+        let conn = Connection::open(
+            &cfg.workspace.neo4j.uri,
+            &cfg.workspace.neo4j.username,
+            &pw.value,
+            &cfg.workspace.neo4j.database,
+        )
+        .await
+        .context("connecting to workspace database")?;
+
+        let snap = status::collect(&conn, &cfg).await?;
+
+        println!("Workspace: {}", snap.workspace);
+        println!("Database:  {}", snap.database);
+        println!("Roots:     {}", snap.roots.join(", "));
+        println!("Files:     {}", snap.file_count);
+        println!("Symbols:   {}", snap.symbol_count);
+        println!("Unresolved refs: {}", snap.unresolved_count);
+        println!(
+            "Last indexed:    {}",
+            match snap.last_indexed_at {
+                Some(t) => t.to_string(),
+                None => "never".into(),
+            }
+        );
+        Ok::<(), anyhow::Error>(())
+    })
+}
+```
+
+Remove the now-unused `single_count` / `max_last_indexed` helpers and the `neo4rs::query` import from this file.
+
+- [ ] **Step 5: Add a pure-Rust unit test for `read_snippet`**
+
+The config types in `src/config/workspace.rs` are `WorkspaceConfig` / `Workspace` / `Neo4j` / `Root` (not `WorkspaceSection` / `Neo4jConfig` / `RootConfig`) and `WorkspaceConfig` has required fields (`schema_version`, `indexing`, `embeddings`) beyond what the test needs. Rather than construct a struct literal, build the config by parsing a TOML literal via `workspace::parse(...)` (a public function at `src/config/workspace.rs:83`).
+
+Create `tests/graph_unit.rs`:
+
+```rust
+//! Pure-Rust tests for graph helpers that don't need Neo4j.
+
+use codegraph_rs::config::workspace::{self, WorkspaceConfig};
+use codegraph_rs::graph::source::read_snippet;
+use std::fs;
+use tempfile::tempdir;
+
+fn dummy_cfg(root_name: &str) -> WorkspaceConfig {
+    let toml = format!(
+        r#"
+schema_version = 1
+
+[workspace]
+name = "test"
+
+[workspace.neo4j]
+uri = "bolt://localhost:7687"
+database = "test-db"
+username = "neo4j"
+
+[[workspace.roots]]
+name = "{root_name}"
+path = "src"
+"#
+    );
+    workspace::parse(&toml).expect("parse test config")
+}
+
+#[test]
+fn read_snippet_returns_inclusive_line_range() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("file.rs"), "one\ntwo\nthree\nfour\nfive\n").unwrap();
+
+    let cfg = dummy_cfg("primary");
+    let snippet = read_snippet(dir.path(), &cfg, "primary", "file.rs", 2, 4).unwrap();
+    assert_eq!(snippet, "two\nthree\nfour");
+}
+
+#[test]
+fn read_snippet_clamps_end_beyond_eof() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("file.rs"), "a\nb\nc\n").unwrap();
+
+    let cfg = dummy_cfg("primary");
+    let snippet = read_snippet(dir.path(), &cfg, "primary", "file.rs", 2, 999).unwrap();
+    assert_eq!(snippet, "b\nc");
+}
+
+#[test]
+fn read_snippet_empty_when_start_past_eof() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("file.rs"), "a\nb\n").unwrap();
+
+    let cfg = dummy_cfg("primary");
+    let snippet = read_snippet(dir.path(), &cfg, "primary", "file.rs", 50, 60).unwrap();
+    assert_eq!(snippet, "");
+}
+
+#[test]
+fn read_snippet_errors_on_unknown_root() {
+    let dir = tempdir().unwrap();
+    let cfg = dummy_cfg("primary");
+    let err = read_snippet(dir.path(), &cfg, "other", "file.rs", 1, 1).unwrap_err();
+    assert!(err.to_string().contains("unknown root"));
+}
+```
+
+- [ ] **Step 6: Build + tests**
+
+Expected: 65 tests pass (61 + 4 new graph_unit tests). Clippy + fmt clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/graph/mod.rs src/graph/status.rs src/graph/source.rs src/cli/status.rs tests/graph_unit.rs
+git commit -m "feat(graph): status + source snippet helpers; refactor cli/status to reuse"
+```
+
+---
+
+### Task 3: `graph::files`
+
+**Files:**
+- Create: `src/graph/files.rs`
+- Modify: `src/graph/mod.rs`
+
+- [ ] **Step 1: `src/graph/files.rs`**
+
+```rust
+//! List indexed files with per-file symbol counts. Optional `root` filter.
+
+use anyhow::{Context, Result};
+use neo4rs::query;
+use serde::Serialize;
+
+use crate::db::Connection;
+
+#[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
+pub struct FileEntry {
+    pub root_name: String,
+    pub relative_path: String,
+    pub symbol_count: i64,
+}
+
+pub async fn list(conn: &Connection, root: Option<&str>) -> Result<Vec<FileEntry>> {
+    let cypher = match root {
+        Some(_) => {
+            "MATCH (f:File {root_name: $root}) \
+             OPTIONAL MATCH (f)-[:CONTAINS*]->(s:Symbol) \
+             RETURN f.root_name AS root_name, f.relative_path AS relative_path, \
+                    count(s) AS symbol_count \
+             ORDER BY relative_path"
+        }
+        None => {
+            "MATCH (f:File) \
+             OPTIONAL MATCH (f)-[:CONTAINS*]->(s:Symbol) \
+             RETURN f.root_name AS root_name, f.relative_path AS relative_path, \
+                    count(s) AS symbol_count \
+             ORDER BY root_name, relative_path"
+        }
+    };
+
+    let mut q = query(cypher);
+    if let Some(r) = root {
+        q = q.param("root", r);
+    }
+    let mut stream = conn.graph.execute(q).await.context("listing files")?;
+    let mut out = Vec::new();
+    while let Some(row) = stream.next().await? {
+        out.push(FileEntry {
+            root_name: row.get("root_name").context("row missing root_name")?,
+            relative_path: row.get("relative_path").context("row missing relative_path")?,
+            symbol_count: row.get("symbol_count").context("row missing symbol_count")?,
+        });
+    }
+    Ok(out)
+}
+```
+
+- [ ] **Step 2: Wire submodule**
+
+In `src/graph/mod.rs`:
+```rust
+pub mod files;
+```
+
+- [ ] **Step 3: Build + clippy + fmt + test**
+
+No new tests — exercised end-to-end via `integration_mcp.rs` in Task 10.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/graph/mod.rs src/graph/files.rs
+git commit -m "feat(graph): files() listing with optional root filter"
+```
+
+---
+
+### Task 4: `graph::search`
+
+**Files:**
+- Create: `src/graph/search.rs`
+- Modify: `src/graph/mod.rs`
+
+The schema already has FTS index `symbol_fts` on `[n.name, n.qualified_name, n.signature, n.doc]` (per `src/db/schema.rs`). The query uses `CALL db.index.fulltext.queryNodes("symbol_fts", $query)` and filters by optional `kinds` / `root` after.
+
+- [ ] **Step 1: `src/graph/search.rs`**
+
+```rust
+//! Symbol search via Neo4j FTS index `symbol_fts`.
+
+use anyhow::{Context, Result};
+use neo4rs::query;
+use serde::Serialize;
+use serde_json::json;
+
+use crate::db::write::to_bolt;
+use crate::db::Connection;
+
+#[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
+pub struct SearchHit {
+    pub qid: String,
+    pub name: String,
+    pub kind: String,
+    pub qualified_name: Option<String>,
+    pub root_name: String,
+    pub relative_path: String,
+    pub score: f64,
+}
+
+pub async fn search(
+    conn: &Connection,
+    q: &str,
+    kinds: Option<&[String]>,
+    root: Option<&str>,
+    limit: i64,
+) -> Result<Vec<SearchHit>> {
+    // FTS query string is passed through verbatim. Neo4j tokenizes it
+    // with the standard analyzer (lowercases, splits on whitespace/punct).
+    let cypher = "\
+        CALL db.index.fulltext.queryNodes('symbol_fts', $q) YIELD node AS n, score \
+        WHERE ($root IS NULL OR n.root_name = $root) \
+          AND ($kinds IS NULL OR any(k IN $kinds WHERE k IN labels(n))) \
+        RETURN n.qid AS qid, n.name AS name, n.qualified_name AS qualified_name, \
+               n.root_name AS root_name, n.relative_path AS relative_path, \
+               [l IN labels(n) WHERE l <> 'Symbol'][0] AS kind, score \
+        ORDER BY score DESC \
+        LIMIT $limit";
+
+    // Nullable params go through the established JSON→BoltType path
+    // (db::write::to_bolt) — same pattern used by write_extraction.
+    // serde_json maps None -> Value::Null which BoltType::TryFrom handles.
+    let root_param = to_bolt(json!(root)).context("encoding `root` param")?;
+    let kinds_param = to_bolt(json!(kinds)).context("encoding `kinds` param")?;
+
+    let mut stream = conn
+        .graph
+        .execute(
+            query(cypher)
+                .param("q", q)
+                .param("root", root_param)
+                .param("kinds", kinds_param)
+                .param("limit", limit),
+        )
+        .await
+        .context("running search")?;
+
+    let mut out = Vec::new();
+    while let Some(row) = stream.next().await? {
+        out.push(SearchHit {
+            qid: row.get("qid").context("row missing qid")?,
+            name: row.get("name").context("row missing name")?,
+            kind: row.get::<Option<String>>("kind")?.unwrap_or_default(),
+            qualified_name: row.get::<Option<String>>("qualified_name")?,
+            root_name: row.get("root_name").context("row missing root_name")?,
+            relative_path: row.get("relative_path").context("row missing relative_path")?,
+            score: row.get("score").context("row missing score")?,
+        });
+    }
+    Ok(out)
+}
+```
+
+> **Visibility note.** `db::write::to_bolt` is currently `pub(crate)`; that's already crate-visible so `graph::search` can call it as-is.
+
+> **Implementer note on `kind` extraction.** Each symbol carries two labels: `:Symbol` and exactly one of `Function` / `Method` / `Class` / etc. (the writer at `src/db/write.rs:66` always merges with two labels: `MERGE (n:Symbol:{label} ...)`). The Cypher `[l IN labels(n) WHERE l <> 'Symbol'][0]` picks the only non-`Symbol` label. If a node somehow had more than one kind label, Neo4j's label order is unspecified — but that invariant doesn't hold today and isn't relied on elsewhere.
+
+> **FTS injection note.** The `query` string is passed verbatim into `db.index.fulltext.queryNodes`. Lucene-syntax errors (`name:`, unbalanced `"`, trailing `~`) will produce a Neo4j error that the MCP server surfaces as `ErrorData::internal_error` with the underlying message. Acceptable for v1; sanitization deferred.
+
+- [ ] **Step 2: Wire submodule**
+
+```rust
+pub mod search;
+```
+
+- [ ] **Step 3: Build + clippy + fmt + test**
+
+Exercised end-to-end via `integration_mcp.rs`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/graph/mod.rs src/graph/search.rs
+git commit -m "feat(graph): FTS-backed search() with kind/root filters"
+```
+
+---
+
+### Task 5: `graph::node`
+
+**Files:**
+- Create: `src/graph/node.rs`
+- Modify: `src/graph/mod.rs`
+
+- [ ] **Step 1: `src/graph/node.rs`**
+
+```rust
+//! Detail lookup for a single symbol by qid, plus its source snippet.
+
+use anyhow::{Context, Result};
+use neo4rs::query;
+use serde::Serialize;
+use std::path::Path;
+
+use crate::config::workspace::WorkspaceConfig;
+use crate::db::Connection;
+use crate::graph::source::read_snippet;
+
+#[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
+pub struct NodeDetail {
+    pub qid: String,
+    pub name: String,
+    pub kind: String,
+    pub qualified_name: Option<String>,
+    pub root_name: String,
+    pub relative_path: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub signature: Option<String>,
+    pub doc: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
+pub struct NodeResponse {
+    pub node: NodeDetail,
+    pub source: String,
+}
+
+pub async fn find(
+    conn: &Connection,
+    workspace_dir: &Path,
+    cfg: &WorkspaceConfig,
+    qid: &str,
+) -> Result<NodeResponse> {
+    let cypher = "\
+        MATCH (n:Symbol {qid: $qid}) \
+        RETURN n.qid AS qid, n.name AS name, n.qualified_name AS qualified_name, \
+               [l IN labels(n) WHERE l <> 'Symbol'][0] AS kind, \
+               n.root_name AS root_name, n.relative_path AS relative_path, \
+               n.start_line AS start_line, n.end_line AS end_line, \
+               n.signature AS signature, n.doc AS doc \
+        LIMIT 1";
+    let mut stream = conn
+        .graph
+        .execute(query(cypher).param("qid", qid))
+        .await
+        .context("running node lookup")?;
+    let row = stream
+        .next()
+        .await
+        .context("stream error")?
+        .with_context(|| format!("qid `{qid}` not found"))?;
+
+    let detail = NodeDetail {
+        qid: row.get("qid")?,
+        name: row.get("name")?,
+        kind: row.get::<Option<String>>("kind")?.unwrap_or_default(),
+        qualified_name: row.get::<Option<String>>("qualified_name")?,
+        root_name: row.get("root_name")?,
+        relative_path: row.get("relative_path")?,
+        start_line: row.get::<i64>("start_line")? as u32,
+        end_line: row.get::<i64>("end_line")? as u32,
+        signature: row.get::<Option<String>>("signature")?,
+        doc: row.get::<Option<String>>("doc")?,
+    };
+
+    let source = read_snippet(
+        workspace_dir,
+        cfg,
+        &detail.root_name,
+        &detail.relative_path,
+        detail.start_line,
+        detail.end_line,
+    )
+    .unwrap_or_default();
+
+    Ok(NodeResponse { node: detail, source })
+}
+```
+
+> **Implementer note.** If `start_line` / `end_line` are stored as `i64` in Neo4j, the `as u32` cast is fine; if they can be NULL, fall back to 0 / 0 — the snippet will just be empty.
+
+> **Snippet read failures are non-fatal.** `read_snippet` may fail (file deleted since last index). We use `.unwrap_or_default()` so the response still carries the detail; the empty source signals to callers that the file is unreadable.
+
+- [ ] **Step 2: Wire submodule**
+
+```rust
+pub mod node;
+```
+
+- [ ] **Step 3: Build + clippy + fmt + test**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/graph/mod.rs src/graph/node.rs
+git commit -m "feat(graph): node() detail lookup + source snippet"
+```
+
+---
+
+### Task 6: `graph::traverse` — callers + callees + impact
+
+**Files:**
+- Create: `src/graph/traverse.rs`
+- Modify: `src/graph/mod.rs`
+
+All three are variable-length path queries with a `hops` count.
+
+- [ ] **Step 1: `src/graph/traverse.rs`**
+
+```rust
+//! Callers, callees, and impact (reverse-transitive closure) via variable-length paths.
+
+use anyhow::{Context, Result};
+use neo4rs::query;
+use serde::Serialize;
+
+use crate::db::Connection;
+
+#[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
+pub struct Neighbor {
+    pub qid: String,
+    pub name: String,
+    pub kind: String,
+    pub hops: i64,
+}
+
+pub async fn callers(conn: &Connection, qid: &str, depth: i64) -> Result<Vec<Neighbor>> {
+    let cypher = "\
+        MATCH path = (caller:Symbol)-[:CALLS*1..]->(target:Symbol {qid: $qid}) \
+        WHERE length(path) <= $depth \
+        WITH caller, min(length(path)) AS hops \
+        RETURN caller.qid AS qid, caller.name AS name, \
+               [l IN labels(caller) WHERE l <> 'Symbol'][0] AS kind, hops \
+        ORDER BY hops ASC, name ASC";
+    rows_to_neighbors(conn, cypher, qid, depth).await
+}
+
+pub async fn callees(conn: &Connection, qid: &str, depth: i64) -> Result<Vec<Neighbor>> {
+    let cypher = "\
+        MATCH path = (source:Symbol {qid: $qid})-[:CALLS*1..]->(callee:Symbol) \
+        WHERE length(path) <= $depth \
+        WITH callee, min(length(path)) AS hops \
+        RETURN callee.qid AS qid, callee.name AS name, \
+               [l IN labels(callee) WHERE l <> 'Symbol'][0] AS kind, hops \
+        ORDER BY hops ASC, name ASC";
+    rows_to_neighbors(conn, cypher, qid, depth).await
+}
+
+/// Impact = reverse-transitive closure across CALLS, REFERENCES, TYPE_OF.
+/// "What's affected if this symbol changes?"
+pub async fn impact(conn: &Connection, qid: &str, depth: i64) -> Result<Vec<Neighbor>> {
+    let cypher = "\
+        MATCH path = (affected:Symbol)-[:CALLS|REFERENCES|TYPE_OF*1..]->(target:Symbol {qid: $qid}) \
+        WHERE length(path) <= $depth \
+        WITH affected, min(length(path)) AS hops \
+        RETURN affected.qid AS qid, affected.name AS name, \
+               [l IN labels(affected) WHERE l <> 'Symbol'][0] AS kind, hops \
+        ORDER BY hops ASC, name ASC";
+    rows_to_neighbors(conn, cypher, qid, depth).await
+}
+
+async fn rows_to_neighbors(
+    conn: &Connection,
+    cypher: &str,
+    qid: &str,
+    depth: i64,
+) -> Result<Vec<Neighbor>> {
+    let mut stream = conn
+        .graph
+        .execute(query(cypher).param("qid", qid).param("depth", depth))
+        .await
+        .context("running traversal")?;
+    let mut out = Vec::new();
+    while let Some(row) = stream.next().await? {
+        out.push(Neighbor {
+            qid: row.get("qid")?,
+            name: row.get("name")?,
+            kind: row.get::<Option<String>>("kind")?.unwrap_or_default(),
+            hops: row.get("hops")?,
+        });
+    }
+    Ok(out)
+}
+```
+
+> **Implementer note on relationship type names.** The Cypher above assumes the relationship types are exactly `CALLS`, `REFERENCES`, `TYPE_OF`. Verify against `src/extraction/result.rs` (or wherever edge kinds are serialized) — if any differ, adjust.
+
+- [ ] **Step 2: Wire submodule**
+
+```rust
+pub mod traverse;
+```
+
+- [ ] **Step 3: Build + clippy + fmt + test**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/graph/mod.rs src/graph/traverse.rs
+git commit -m "feat(graph): callers/callees/impact traversal queries"
+```
+
+---
+
+### Task 7: MCP server skeleton + `serve` CLI
+
+**Files:**
+- Create: `src/mcp/mod.rs` (replace skeleton)
+- Create: `src/cli/serve.rs`
+- Modify: `src/cli/mod.rs`
+
+Establishes the rmcp plumbing with **only one tool** wired (`codegraph_rs_status`). Task 8 will add the remaining six. This split keeps the rmcp wiring isolated from the per-tool wiring so any rmcp API quirks surface in a small commit.
+
+- [ ] **Step 1: Replace `src/mcp/mod.rs`**
+
+```rust
+//! MCP stdio server exposing graph-traversal tools. See spec §10.
+
+use anyhow::{Context, Result};
+use rmcp::{
+    handler::server::tool::Parameters,
+    model::{Implementation, ProtocolVersion, ServerCapabilities, ServerInfo},
+    schemars,
+    serde_json::{self, Value},
+    service::ServiceExt,
+    tool, tool_handler, tool_router,
+    ErrorData, Json,
+};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::config::workspace::WorkspaceConfig;
+use crate::db::Connection;
+use crate::graph;
+
+#[derive(Clone)]
+pub struct McpServer {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    conn: Connection,
+    cfg: WorkspaceConfig,
+    workspace_dir: PathBuf,
+}
+
+impl McpServer {
+    pub fn new(conn: Connection, cfg: WorkspaceConfig, workspace_dir: PathBuf) -> Self {
+        Self { inner: Arc::new(Inner { conn, cfg, workspace_dir }) }
+    }
+}
+
+#[tool_router(server_handler)]
+impl McpServer {
+    #[tool(
+        name = "codegraph_rs_status",
+        description = "Return workspace stats: file/symbol/unresolved counts and last-indexed timestamp."
+    )]
+    async fn status(&self) -> Result<Json<graph::status::StatusSnapshot>, ErrorData> {
+        graph::status::collect(&self.inner.conn, &self.inner.cfg)
+            .await
+            .map(Json)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))
+    }
+}
+
+/// Run the server on stdio until stdin closes.
+pub async fn serve(conn: Connection, cfg: WorkspaceConfig, workspace_dir: PathBuf) -> Result<()> {
+    let server = McpServer::new(conn, cfg, workspace_dir);
+    let (stdin, stdout) = rmcp::transport::io::stdio();
+    let running = server
+        .serve((stdin, stdout))
+        .await
+        .context("starting MCP server")?;
+    // `RunningService::waiting()` returns `Result<QuitReason, JoinError>`.
+    // A normal stdin EOF (e.g. parent process closing) yields `Ok(QuitReason::Closed)`;
+    // a panic in the task yields `Err(JoinError)`. We treat both as "server stopped"
+    // for the CLI exit path — JoinError is logged but doesn't propagate as anyhow.
+    match running.waiting().await {
+        Ok(reason) => {
+            tracing::info!("MCP server exited: {reason:?}");
+        }
+        Err(join_err) => {
+            tracing::warn!("MCP server task join error: {join_err}");
+        }
+    }
+    Ok(())
+}
+```
+
+> **rmcp 1.5 API anchors (verified before writing this plan):**
+> - `#[tool_router(server_handler)]` on the `impl` block auto-derives the `ServerHandler` trait. No separate `#[tool_handler] impl ServerHandler for McpServer {}` block is required.
+> - `serve(transport).await` returns `Result<RunningService, _>`; `RunningService::waiting(self).await -> Result<QuitReason, JoinError>`.
+> - `ErrorData::internal_error(message: impl Into<Cow<'static, str>>, data: Option<Value>)` — pass `None` for `data`.
+> - The default `ServerInfo` (name + version from `Cargo.toml`) is generated by the `server_handler` flag of `#[tool_router]`. To add a custom "instructions" string, override `fn get_info(&self) -> ServerInfo` explicitly inside the impl block.
+
+- [ ] **Step 2: `src/cli/serve.rs`**
+
+`serve` is a read-only consumer. Unlike `index` and `sync` (which write nodes/edges), it never mutates the graph, so it does NOT call `apply_schema` — the schema is established by `init` and maintained by `index`/`sync`. Calling `apply_schema` here would add latency on every `serve` start and could mask drift in upstream slices.
+
+```rust
+//! `codegraph-rs serve` — MCP stdio server.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+use tracing::info;
+
+use crate::config::secrets::resolve_neo4j_password;
+use crate::config::workspace;
+use crate::db::Connection;
+use crate::mcp;
+
+pub fn run(workspace_arg: Option<&Path>) -> Result<()> {
+    let starting = workspace_arg
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| std::env::current_dir().expect("cwd readable"));
+    let workspace_dir = workspace::find_workspace_root(&starting)
+        .context("no workspace found; run `codegraph-rs init` first")?;
+    let cfg = workspace::load_from_path(&workspace_dir)?;
+    let pw = resolve_neo4j_password(&workspace_dir, None)?;
+
+    let rt = tokio::runtime::Runtime::new().context("starting tokio runtime")?;
+    rt.block_on(async {
+        let conn = Connection::open(
+            &cfg.workspace.neo4j.uri,
+            &cfg.workspace.neo4j.username,
+            &pw.value,
+            &cfg.workspace.neo4j.database,
+        )
+        .await
+        .context("connecting to workspace database")?;
+
+        info!("MCP serve: workspace `{}`, db `{}`", cfg.workspace.name, cfg.workspace.neo4j.database);
+        mcp::serve(conn, cfg, workspace_dir).await
+    })
+}
+```
+
+- [ ] **Step 3: Wire dispatch in `src/cli/mod.rs`**
+
+Add `pub mod serve;` next to `pub mod sync;`. Replace the stub arm:
+```rust
+Command::Query { .. } | Command::Serve => {
+    anyhow::bail!("not yet implemented");
+}
+```
+with:
+```rust
+Command::Serve => serve::run(cli.workspace.as_deref()),
+Command::Query { .. } => {
+    anyhow::bail!("not yet implemented");
+}
+```
+
+- [ ] **Step 4: Update cli_smoke test**
+
+`tests/cli_smoke.rs` currently has a `stub_commands_fail_with_not_implemented` test whose body asserts that `serve` exits non-zero with "not yet implemented". After this task wires `serve`, that assertion no longer holds — `serve` will now exit non-zero with a *different* message ("no workspace found" or similar, depending on where this test runs). Rename and retarget the test to `query`, which remains a stub in this slice:
+
+Replace:
+```rust
+#[test]
+fn stub_commands_fail_with_not_implemented() {
+    let sub = "serve";
+    let out = bin().arg(sub).output().expect("run subcommand");
+    assert!(!out.status.success(), "`{sub}` should exit nonzero");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not yet implemented"),
+        "`{sub}` should print 'not yet implemented' in stderr; got: {stderr}"
+    );
+}
+```
+
+With:
+```rust
+#[test]
+fn query_stub_fails_with_not_implemented() {
+    let out = bin().arg("query").arg("foo").output().expect("run query");
+    assert!(!out.status.success(), "`query` should exit nonzero");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not yet implemented"),
+        "`query` should print 'not yet implemented'; got: {stderr}"
+    );
+}
+```
+
+The `help_exits_zero_and_lists_all_subcommands` test is unchanged — it still asserts all six subcommands appear in `--help`.
+
+- [ ] **Step 5: Build + clippy + fmt + test**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -10
+```
+
+Expected: 65 tests pass (test count unchanged from Task 2; cli_smoke loses one assert-loop iteration but the renamed test covers it). All integration tests still SKIP cleanly without `CODEGRAPH_RS_TEST_NEO4J`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mcp/mod.rs src/cli/serve.rs src/cli/mod.rs tests/cli_smoke.rs
+git commit -m "feat(mcp): rmcp stdio server skeleton with status tool; wire serve CLI"
+```
+
+---
+
+### Task 8: Wire remaining 6 MCP tools
+
+**Files:**
+- Modify: `src/mcp/mod.rs`
+
+Add `files`, `search`, `node`, `callers`, `callees`, `impact` tools — each a 5-10 line adapter dispatching to `graph::*`.
+
+- [ ] **Step 1: Add parameter structs**
+
+At the top of `src/mcp/mod.rs`, after the `use` block, add:
+
+```rust
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+pub struct FilesParams {
+    pub root: Option<String>,
+}
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+pub struct SearchParams {
+    pub query: String,
+    pub kinds: Option<Vec<String>>,
+    pub root: Option<String>,
+    pub limit: Option<i64>,
+}
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+pub struct NodeParams {
+    pub qid: String,
+}
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+pub struct CallersParams {
+    pub qid: String,
+    pub depth: Option<i64>,
+}
+
+pub type CalleesParams = CallersParams;
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+pub struct ImpactParams {
+    pub qid: String,
+    pub depth: Option<i64>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+pub struct FilesResponse { pub files: Vec<graph::files::FileEntry> }
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+pub struct SearchResponse { pub results: Vec<graph::search::SearchHit> }
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+pub struct CallersResponse { pub callers: Vec<graph::traverse::Neighbor> }
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+pub struct CalleesResponse { pub callees: Vec<graph::traverse::Neighbor> }
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+pub struct ImpactResponse { pub impact: Vec<graph::traverse::Neighbor> }
+```
+
+- [ ] **Step 2: Add the 6 tool handlers to the `#[tool_router]` impl**
+
+Inside the `impl McpServer` block, alongside `status`:
+
+```rust
+#[tool(name = "codegraph_rs_files", description = "List indexed files with per-file symbol counts. Optional root filter.")]
+async fn files(&self, Parameters(p): Parameters<FilesParams>) -> Result<Json<FilesResponse>, ErrorData> {
+    graph::files::list(&self.inner.conn, p.root.as_deref())
+        .await
+        .map(|files| Json(FilesResponse { files }))
+        .map_err(internal_err)
+}
+
+#[tool(name = "codegraph_rs_search", description = "Search symbols by name via Neo4j FTS. Supports kind/root filters.")]
+async fn search(&self, Parameters(p): Parameters<SearchParams>) -> Result<Json<SearchResponse>, ErrorData> {
+    graph::search::search(
+        &self.inner.conn,
+        &p.query,
+        p.kinds.as_deref(),
+        p.root.as_deref(),
+        p.limit.unwrap_or(10),
+    )
+    .await
+    .map(|results| Json(SearchResponse { results }))
+    .map_err(internal_err)
+}
+
+#[tool(name = "codegraph_rs_node", description = "Get full detail and source snippet for a symbol by qid.")]
+async fn node(&self, Parameters(p): Parameters<NodeParams>) -> Result<Json<graph::node::NodeResponse>, ErrorData> {
+    graph::node::find(&self.inner.conn, &self.inner.workspace_dir, &self.inner.cfg, &p.qid)
+        .await
+        .map(Json)
+        .map_err(internal_err)
+}
+
+#[tool(name = "codegraph_rs_callers", description = "Functions that call this symbol up to `depth` hops (default 2).")]
+async fn callers(&self, Parameters(p): Parameters<CallersParams>) -> Result<Json<CallersResponse>, ErrorData> {
+    graph::traverse::callers(&self.inner.conn, &p.qid, p.depth.unwrap_or(2))
+        .await
+        .map(|callers| Json(CallersResponse { callers }))
+        .map_err(internal_err)
+}
+
+#[tool(name = "codegraph_rs_callees", description = "Functions called by this symbol up to `depth` hops (default 2).")]
+async fn callees(&self, Parameters(p): Parameters<CalleesParams>) -> Result<Json<CalleesResponse>, ErrorData> {
+    graph::traverse::callees(&self.inner.conn, &p.qid, p.depth.unwrap_or(2))
+        .await
+        .map(|callees| Json(CalleesResponse { callees }))
+        .map_err(internal_err)
+}
+
+#[tool(name = "codegraph_rs_impact", description = "Reverse-transitive closure across CALLS/REFERENCES/TYPE_OF (default depth 3).")]
+async fn impact(&self, Parameters(p): Parameters<ImpactParams>) -> Result<Json<ImpactResponse>, ErrorData> {
+    graph::traverse::impact(&self.inner.conn, &p.qid, p.depth.unwrap_or(3))
+        .await
+        .map(|impact| Json(ImpactResponse { impact }))
+        .map_err(internal_err)
+}
+```
+
+Add the small helper at module scope:
+```rust
+fn internal_err(e: anyhow::Error) -> ErrorData {
+    ErrorData::internal_error(e.to_string(), None)
+}
+```
+
+- [ ] **Step 3: Build + clippy + fmt + test**
+
+Expected: 65 tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/mcp/mod.rs
+git commit -m "feat(mcp): wire files/search/node/callers/callees/impact tools"
+```
+
+---
+
+### Task 9: Integration test — in-process MCP
+
+**Files:**
+- Create: `tests/integration_mcp.rs`
+
+Exercises every tool against a freshly-indexed tiny-rust workspace. Uses `tokio::io::duplex` for in-process JSON-RPC framing (per spec §811: "in-memory channel pair").
+
+- [ ] **Step 1: Create the test**
+
+```rust
+//! Integration test for the MCP server: index tiny-rust, spin up the server
+//! over duplex pipes, and exercise initialize + list_tools + each tool.
+//! Gated on CODEGRAPH_RS_TEST_NEO4J=1.
+
+use codegraph_rs::cli::{index, init::{self, InitArgs}};
+use codegraph_rs::config::workspace::load_from_path;
+use codegraph_rs::db::Connection;
+use codegraph_rs::mcp::McpServer;
+use neo4rs::query;
+use rmcp::model::{CallToolRequestParam, ClientInfo, Implementation, ProtocolVersion};
+use rmcp::service::ServiceExt;
+use serde_json::json;
+use std::fs;
+use tempfile::tempdir;
+
+fn enabled() -> bool {
+    std::env::var("CODEGRAPH_RS_TEST_NEO4J").as_deref() == Ok("1")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mcp_exposes_graph_tools_against_tiny_rust() {
+    if !enabled() {
+        eprintln!("SKIP: set CODEGRAPH_RS_TEST_NEO4J=1 to enable");
+        return;
+    }
+    let pw = std::env::var("CODEGRAPH_RS_TEST_NEO4J_PASSWORD")
+        .expect("CODEGRAPH_RS_TEST_NEO4J_PASSWORD required");
+
+    let dir = tempdir().unwrap();
+    let workspace_name = format!("mcp-test-{}", std::process::id());
+
+    let fixture_src = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/tiny-rust");
+    let fixture_dst = dir.path().join("tiny-rust");
+    copy_dir(&fixture_src, &fixture_dst).unwrap();
+
+    let args = InitArgs {
+        name: workspace_name.clone(),
+        neo4j_uri: "bolt://localhost:7687".into(),
+        neo4j_user: "neo4j".into(),
+        neo4j_password: pw.clone(),
+        root: vec!["tiny=tiny-rust".into()],
+    };
+    init::run(args, Some(dir.path())).expect("init must succeed");
+    std::env::set_var("CODEGRAPH_RS_NEO4J_PASSWORD", &pw);
+    index::run(Some(dir.path())).expect("index must succeed");
+
+    let cfg = load_from_path(dir.path()).unwrap();
+    let conn = Connection::open(
+        &cfg.workspace.neo4j.uri,
+        &cfg.workspace.neo4j.username,
+        &pw,
+        &cfg.workspace.neo4j.database,
+    ).await.unwrap();
+
+    // Capture the db name before moving cfg into the server.
+    let db_name = cfg.workspace.neo4j.database.clone();
+
+    let server = McpServer::new(conn, cfg, dir.path().to_path_buf());
+
+    // Build paired duplex pipes: server side ↔ client side.
+    // Each DuplexStream is AsyncRead + AsyncWrite; rmcp's `IntoTransport for (R, W)`
+    // requires a tuple, so split each half into its read/write components.
+    let (server_io, client_io) = tokio::io::duplex(64 * 1024);
+    let (server_rx, server_tx) = tokio::io::split(server_io);
+    let (client_rx, client_tx) = tokio::io::split(client_io);
+
+    let server_running = server
+        .serve((server_rx, server_tx))
+        .await
+        .expect("server serve");
+
+    // Client side speaks MCP over the other half.
+    let client_info = ClientInfo {
+        protocol_version: ProtocolVersion::default(),
+        capabilities: Default::default(),
+        client_info: Implementation { name: "test".into(), version: "0".into() },
+    };
+    let client = client_info
+        .serve((client_rx, client_tx))
+        .await
+        .expect("client init");
+
+    // list_tools should return all 7.
+    let tools = client.list_tools(Default::default()).await.expect("list_tools").tools;
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    for expected in [
+        "codegraph_rs_status", "codegraph_rs_files", "codegraph_rs_search",
+        "codegraph_rs_node", "codegraph_rs_callers", "codegraph_rs_callees",
+        "codegraph_rs_impact",
+    ] {
+        assert!(names.contains(&expected), "tool `{expected}` missing; have {names:?}");
+    }
+
+    // status
+    let status = client.call_tool(CallToolRequestParam {
+        name: "codegraph_rs_status".into(),
+        arguments: None,
+    }).await.expect("status call");
+    let body = status.structured_content.expect("status structured");
+    assert_eq!(body["workspace"], json!(workspace_name));
+    assert!(body["file_count"].as_i64().unwrap() >= 3);
+
+    // search: find `library_entry`
+    let search = client.call_tool(CallToolRequestParam {
+        name: "codegraph_rs_search".into(),
+        arguments: Some(json!({ "query": "library_entry" }).as_object().unwrap().clone()),
+    }).await.expect("search call");
+    let results = &search.structured_content.expect("search structured")["results"];
+    let arr = results.as_array().expect("results array");
+    assert!(arr.iter().any(|r| r["name"] == "library_entry"), "library_entry should match search");
+
+    // Pick a qid for downstream tests.
+    let library_qid = arr.iter()
+        .find(|r| r["name"] == "library_entry")
+        .and_then(|r| r["qid"].as_str())
+        .expect("found qid")
+        .to_string();
+
+    // node
+    let node = client.call_tool(CallToolRequestParam {
+        name: "codegraph_rs_node".into(),
+        arguments: Some(json!({ "qid": library_qid }).as_object().unwrap().clone()),
+    }).await.expect("node call");
+    let nbody = node.structured_content.expect("node structured");
+    assert_eq!(nbody["node"]["name"], json!("library_entry"));
+    assert!(nbody["source"].as_str().unwrap().contains("library_entry"));
+
+    // callees: library_entry → helper
+    let callees = client.call_tool(CallToolRequestParam {
+        name: "codegraph_rs_callees".into(),
+        arguments: Some(json!({ "qid": library_qid, "depth": 2 }).as_object().unwrap().clone()),
+    }).await.expect("callees call");
+    let cbody = callees.structured_content.expect("callees structured");
+    let callees_arr = cbody["callees"].as_array().unwrap();
+    assert!(callees_arr.iter().any(|c| c["name"] == "helper"), "library_entry should call helper");
+
+    // callers: who calls `helper`? library_entry should (transitively at depth 1)
+    let helper_qid = arr.iter()
+        .find(|r| r["name"] == "helper")
+        .and_then(|r| r["qid"].as_str())
+        .map(str::to_string);
+    if let Some(helper_qid) = helper_qid {
+        let callers = client.call_tool(CallToolRequestParam {
+            name: "codegraph_rs_callers".into(),
+            arguments: Some(json!({ "qid": helper_qid, "depth": 2 }).as_object().unwrap().clone()),
+        }).await.expect("callers call");
+        let crs = callers.structured_content.expect("callers structured");
+        let callers_arr = crs["callers"].as_array().unwrap();
+        assert!(callers_arr.iter().any(|c| c["name"] == "library_entry"),
+                "helper should be called by library_entry");
+
+        // impact: with depth 3, helper's reverse-transitive closure should be non-empty
+        let impact = client.call_tool(CallToolRequestParam {
+            name: "codegraph_rs_impact".into(),
+            arguments: Some(json!({ "qid": helper_qid, "depth": 3 }).as_object().unwrap().clone()),
+        }).await.expect("impact call");
+        let ibody = impact.structured_content.expect("impact structured");
+        let impact_arr = ibody["impact"].as_array().unwrap();
+        assert!(!impact_arr.is_empty(), "impact of helper should not be empty");
+    }
+
+    // files: 3 files in tiny-rust
+    let files = client.call_tool(CallToolRequestParam {
+        name: "codegraph_rs_files".into(),
+        arguments: None,
+    }).await.expect("files call");
+    let fbody = files.structured_content.expect("files structured");
+    let files_arr = fbody["files"].as_array().unwrap();
+    assert_eq!(files_arr.len(), 3);
+
+    // Clean shutdown
+    drop(client);
+    drop(server_running);
+
+    std::env::remove_var("CODEGRAPH_RS_NEO4J_PASSWORD");
+
+    // Cleanup database (db_name was captured before moving cfg into the server)
+    let sys = Connection::system("bolt://localhost:7687", "neo4j", &pw).await.unwrap();
+    sys.graph.execute(query(&format!("DROP DATABASE `{db_name}` IF EXISTS WAIT")))
+        .await.unwrap().next().await.ok();
+}
+
+fn copy_dir(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        let dest = dst.join(entry.file_name());
+        if path.is_dir() {
+            copy_dir(&path, &dest)?;
+        } else {
+            fs::copy(&path, &dest)?;
+        }
+    }
+    Ok(())
+}
+```
+
+> **rmcp 1.5 client + transport notes:**
+> - `ClientInfo::serve(transport)` (via the `ServiceExt` trait) returns a running client handle. `ClientInfo` is a model struct with `protocol_version`, `capabilities`, and `client_info: Implementation`.
+> - `client.call_tool(CallToolRequestParam { name, arguments }).await` returns `CallToolResult`. Structured JSON is on `.structured_content: Option<serde_json::Value>`. If a tool returns `Json<T>`, that payload appears in `structured_content`.
+> - `client.list_tools(...).await.tools` is `Vec<Tool>` where `Tool.name` is the registered string.
+> - `tokio::io::duplex` returns two `DuplexStream`s, each `AsyncRead + AsyncWrite`. The `IntoTransport for (R, W)` impl (gated on the `transport-async-rw` feature, added in Task 1) wants the read and write halves as a tuple; the test splits each half via `tokio::io::split` and passes the resulting tuple.
+
+- [ ] **Step 2: Verify SKIP path**
+
+```bash
+cargo test --test integration_mcp -- --nocapture 2>&1 | tail -5
+```
+
+Expected: 1 test, SKIP, passes.
+
+- [ ] **Step 3: Build + clippy + fmt + test**
+
+Expected: 66 tests pass (65 + 1 new SKIP-passing integration test).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration_mcp.rs
+git commit -m "test(mcp): in-process MCP integration test against tiny-rust"
+```
+
+---
+
+### Task 10: README + slice-6-mcp tag
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update README Status section**
+
+Replace:
+```markdown
+## Status
+
+In development. Currently implements **Slice 5: Sync** —
+workspace initialization, indexing, resolution, and incremental sync (diff-driven
+add/modify/delete handling with global resolution rebuild). Vector embeddings,
+MCP server, and Daml support land in subsequent slices.
+```
+
+With:
+```markdown
+## Status
+
+In development. Currently implements **Slice 6: MCP (graph tools)** —
+workspace initialization, indexing, resolution, incremental sync, and a
+stdio MCP server exposing 7 graph-traversal tools (status, files, search,
+node, callers, callees, impact). Semantic search, context bundles, and
+Daml support land in subsequent slices.
+```
+
+Also update the Quick start section to mention `codegraph-rs serve`:
+```markdown
+codegraph-rs serve  # stdio MCP server for Claude Code (config it as an MCP server)
+```
+
+- [ ] **Step 2: Final test suite**
+
+```bash
+cargo test 2>&1 | tail -20
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+```
+
+Expected: 66 tests pass total. All clippy/fmt clean.
+
+| Test binary | Count |
+|---|---|
+| `extraction_unit` | 31 |
+| `resolution_unit` | 2 |
+| `sync_unit` | 6 |
+| `graph_unit` (new) | 4 |
+| `config_parsing` | 13 |
+| `cli_smoke` | 2 |
+| `integration_db` (SKIP) | 2 |
+| `integration_init` (SKIP) | 1 |
+| `integration_status` (SKIP) | 1 |
+| `integration_index` (SKIP) | 1 |
+| `integration_resolve` (SKIP) | 1 |
+| `integration_sync` (SKIP) | 1 |
+| `integration_mcp` (new, SKIP) | 1 |
+| **Total** | **66** |
+
+- [ ] **Step 3: Commit and tag**
+
+```bash
+git add README.md
+git commit -m "docs: update README for slice 6"
+git tag slice-6-mcp
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+git log --oneline | head -12
+git tag --list
+```
+
+Expected tags: `slice-1-walking-skeleton`, `slice-2-rust-extraction`, `slice-3-resolution`, `slice-5-sync`, `slice-6-mcp`.
+
+---
+
+## Slice 6 Done
+
+- [ ] `cargo build` clean
+- [ ] `cargo test` (no env vars) — 66 tests pass, all integration tests SKIP cleanly
+- [ ] `CODEGRAPH_RS_TEST_NEO4J=1 cargo test -- --test-threads=1` — all 66 pass; the new `integration_mcp` test exercises all 7 tools end-to-end
+- [ ] Manual: configure `codegraph-rs serve` as an MCP server in Claude Code; verify the 7 tools appear in the tool listing and the typical flow works (search → node → callers / callees / impact)
+- [ ] `cli/status.rs` is now ~20 lines shorter (the count helpers moved to `graph::status`)
+- [ ] No embeddings yet (next slice)
+- [ ] No `context` / `explore` tools yet (after embeddings slice)
+
+When all check, slice 6 is complete. **Next slice: embeddings** (`fastembed-rs` model loading, on-write embedding during extract, vector storage, and a `codegraph-rs reembed` command). Then a follow-up MCP slice adds `codegraph_rs_semantic_search`, `codegraph_rs_context`, and `codegraph_rs_explore` to complete the spec §10 surface.

--- a/docs/superpowers/plans/2026-05-18-codegraph-rs-slice-10a-daml-structure.md
+++ b/docs/superpowers/plans/2026-05-18-codegraph-rs-slice-10a-daml-structure.md
@@ -1,0 +1,1686 @@
+# codegraph-rs Slice 10a — Daml structure + fields
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the regex-based `pass_d_templates_and_choices` in `src/extraction/languages/daml.rs` with tree-sitter queries that filter `(variable)` nodes by Daml keyword. Add four new NodeKinds (`Interface`, `Viewtype`, `Exception`, `Field`); make Template / Choice / Interface fields first-class CONTAINS-children with byte-precise spans.
+
+**Architecture:** Tree-sitter-haskell parses Daml-specific keywords as `(variable)` nodes inside `(apply ...)` expressions (confirmed by DLC-link/zed-daml-lsp). We exploit that by writing keyword-anchored queries in `daml.scm`. Field extraction shares the `(signature)` query shape with Function signatures; disambiguation happens at emit time by checking the ancestor chain for a Daml keyword anchor.
+
+**Tech Stack additions:** None. `tree-sitter-haskell 0.23.1` is already in `Cargo.toml` since slice 9; `regex 1` is in but will be removed by the end of this slice (we delete the regex-based passes).
+
+**Source spec:** [`docs/superpowers/specs/2026-05-15-codegraph-rs-v2-daml-depth-design.md`](../specs/2026-05-15-codegraph-rs-v2-daml-depth-design.md) §2.1, §3.2, §5.
+
+**Slice 9 baseline:** HEAD `b3fdc0a` on `main`, tag `slice-9-daml`. 97 tests pass.
+
+---
+
+## File structure produced by this slice
+
+```
+codegraph-rs/
+  src/
+    extraction/
+      result.rs                                # MODIFY: add NodeKind::Interface, ::Viewtype, ::Exception, ::Field
+      languages/
+        daml.rs                                # MODIFY: replace regex pass_d with tree-sitter passes
+        daml.scm                               # MODIFY: add keyword-anchored queries
+    graph/
+      status.rs                                # MODIFY: extend EMBED_KINDS_CYPHER_LIST (3 entries: Interface, Viewtype, Exception)
+    vectors/
+      query.rs                                 # MODIFY: extend EMBED_KINDS_CYPHER_LIST (same 3 entries)
+  tests/
+    fixtures/
+      tiny-daml/
+        Splice/
+          Authorization.daml                   # NEW: v2 fixture (interfaces, viewtypes, exceptions, fields)
+    extraction_unit.rs                         # MODIFY: ~10 new unit tests
+    integration_daml_index.rs                  # MODIFY: extended Cypher assertions
+  Cargo.toml                                   # MODIFY at end: remove `regex` dep (no longer used after pass_d swap)
+  README.md                                    # MODIFY at end: bump Status to slice 10a
+```
+
+---
+
+### Task 1: Add `NodeKind::Interface`, `::Viewtype`, `::Exception`, `::Field`
+
+**Files:**
+- Modify: `src/extraction/result.rs`
+- Modify: `src/graph/status.rs`
+- Modify: `src/vectors/query.rs`
+- Modify: `tests/extraction_unit.rs`
+
+- [ ] **Step 1: Append failing tests to `tests/extraction_unit.rs`**
+
+```rust
+#[test]
+fn nodekind_interface_label() {
+    assert_eq!(NodeKind::Interface.as_label(), "Interface");
+}
+
+#[test]
+fn nodekind_viewtype_label() {
+    assert_eq!(NodeKind::Viewtype.as_label(), "Viewtype");
+}
+
+#[test]
+fn nodekind_exception_label() {
+    assert_eq!(NodeKind::Exception.as_label(), "Exception");
+}
+
+#[test]
+fn nodekind_field_label() {
+    assert_eq!(NodeKind::Field.as_label(), "Field");
+}
+```
+
+Also extend the existing `node_kind_round_trips_to_str` test's iteration list:
+
+```rust
+for k in [
+    File, Function, Method, Struct, Enum, Trait, TypeAlias, Module, Import,
+    Template, Choice,
+    Interface, Viewtype, Exception, Field,
+] {
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+cd /Users/gyorgybalazsi/codegraph-rs
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: compile errors — `NodeKind::Interface`, `::Viewtype`, `::Exception`, `::Field` not defined.
+
+- [ ] **Step 3: Add the variants in `src/extraction/result.rs`**
+
+Extend the `NodeKind` enum (add the four variants in alphabetical position; current order is File, Module, Function, Method, Struct, Enum, Trait, TypeAlias, Import, Template, Choice):
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NodeKind {
+    File,
+    Module,
+    Function,
+    Method,
+    Struct,
+    Enum,
+    Trait,
+    TypeAlias,
+    Import,
+    /// Daml `template T with ... where ...`. parse_reliable=false (keyword anchor).
+    Template,
+    /// Daml `choice C : T with ... do ...` inside a template. parse_reliable=false.
+    Choice,
+    /// Daml `interface I where ...`. parse_reliable=false (keyword anchor).
+    Interface,
+    /// Daml `viewtype V` inside an interface body. parse_reliable=false (keyword anchor).
+    Viewtype,
+    /// Daml `exception E with ... where message ...`. parse_reliable=false.
+    Exception,
+    /// `with`-block typed binding inside a Template / Choice / Interface. parse_reliable=true.
+    Field,
+}
+```
+
+Extend `as_label`:
+
+```rust
+impl NodeKind {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            NodeKind::File => "File",
+            NodeKind::Module => "Module",
+            NodeKind::Function => "Function",
+            NodeKind::Method => "Method",
+            NodeKind::Struct => "Struct",
+            NodeKind::Enum => "Enum",
+            NodeKind::Trait => "Trait",
+            NodeKind::TypeAlias => "TypeAlias",
+            NodeKind::Import => "Import",
+            NodeKind::Template => "Template",
+            NodeKind::Choice => "Choice",
+            NodeKind::Interface => "Interface",
+            NodeKind::Viewtype => "Viewtype",
+            NodeKind::Exception => "Exception",
+            NodeKind::Field => "Field",
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Extend `EMBED_KINDS_CYPHER_LIST` in two files**
+
+Read `src/graph/status.rs` to find the existing constant (slice 9 had `'Template','Choice'`). Add `Interface`, `Viewtype`, `Exception`. `Field` is NOT added (fields are not embed-eligible per spec §2.1).
+
+```rust
+const EMBED_KINDS_CYPHER_LIST: &str =
+    "['Function','Method','Class','Struct','Interface','Trait','Enum',\
+      'TypeAlias','Module','Template','Choice','Viewtype','Exception']";
+```
+
+Same change in `src/vectors/query.rs`:
+
+```rust
+const EMBED_KINDS_CYPHER_LIST: &str =
+    "['Function','Method','Class','Struct','Interface','Trait','Enum',\
+      'TypeAlias','Module','Template','Choice','Viewtype','Exception']";
+```
+
+- [ ] **Step 5: Run tests + clippy + fmt**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+# Regression guard: confirm slice-9 Daml integration test still SKIPs cleanly
+# (it's the existing end-to-end test the extractor's structural changes could
+# break). Without env vars set, it just exits ok.
+cargo test --test integration_daml_index 2>&1 | tail -3
+```
+
+Expected: 101 tests pass (97 baseline + 4 new label tests; the iteration test adjustment doesn't add a new test, just exercises new variants).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/extraction/result.rs src/graph/status.rs src/vectors/query.rs tests/extraction_unit.rs
+git commit -m "feat(extraction): add NodeKind::Interface, ::Viewtype, ::Exception, ::Field"
+```
+
+---
+
+### Task 2: Tree-sitter query — Template anchor (TDD; replaces regex template detection)
+
+**Files:**
+- Modify: `src/extraction/languages/daml.scm`
+- Modify: `src/extraction/languages/daml.rs`
+- Modify: `tests/extraction_unit.rs`
+
+This task replaces the regex-based template detection in `pass_d_templates_and_choices` with a tree-sitter query in a new `pass_e_templates` function. The regex function's template-emission block is commented out in this task; its choice-emission block keeps running until Task 3 replaces it. The whole regex function is deleted in Task 7.
+
+The existing slice-9 unit tests for template extraction must still pass after the swap (they assert on `name`, `qualified_name`, `parse_reliable` — all of which the tree-sitter version preserves).
+
+**Cross-task `pass_d` state summary.**
+
+| After task | `pass_d_templates_and_choices` state |
+|---|---|
+| slice 9 (baseline) | Emits both templates and choices via regex |
+| Task 2 | Template-emission block commented out; choice-emission block still running |
+| Task 3 | Both blocks commented out; function is a no-op |
+| Task 7 | Function deleted entirely |
+
+- [ ] **Step 1: Inspect tree-sitter-haskell `apply` shape**
+
+Verify the grammar shape before writing anything. Two probes:
+
+```bash
+DAMLDIR=$(find ~/.cargo/registry/src -type d -name 'tree-sitter-haskell-*' | head -1)
+grep -B 2 -A 30 '"type": "apply"' $DAMLDIR/src/node-types.json | head -40
+```
+
+Confirms `apply` has `function:` field (slice 9 task 8 found this in 0.23.1; re-confirm).
+
+Then add a temporary `#[ignore]`d Rust test in `tests/extraction_unit.rs` to print the actual tree for `template Counter ...`:
+
+```rust
+#[test]
+#[ignore]
+fn probe_template_parse_shape() {
+    let source = "module Foo where\n\ntemplate Counter\n  with\n    p : Party\n  where\n    signatory p\n";
+    let tree = codegraph_rs::extraction::parser::parse_daml(source).unwrap();
+    print_tree(tree.root_node(), 0);
+}
+
+fn print_tree(node: tree_sitter::Node, depth: usize) {
+    let indent = "  ".repeat(depth);
+    println!("{}{} [{}, {}-{}]", indent, node.kind(), node.byte_range().start, node.start_position().row, node.end_position().row);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        print_tree(child, depth + 1);
+    }
+}
+```
+
+Run with: `cargo test --test extraction_unit probe_template_parse_shape -- --ignored --nocapture 2>&1 | head -50`
+
+**Write down the observed shape** in a code comment at the top of `daml.scm` before continuing. The Step 4 query below assumes the shape `(apply function: (variable "template") argument: (constructor))`. If the probe shows curried `(apply (apply (variable "template") (constructor)) ...)`, the implementer ADAPTS Step 4's query before writing it — don't write the assumed-shape query and "adjust later".
+
+**Probe test disposition:** REMOVE `probe_template_parse_shape` and `print_tree` from `tests/extraction_unit.rs` before Step 9's commit. They're scaffolding, not durable tests. The shape they revealed is preserved in the `daml.scm` comment.
+
+- [ ] **Step 2: Append failing tests**
+
+```rust
+#[test]
+fn daml_template_extracted_via_tree_sitter_query() {
+    let source = "module Foo where\n\ntemplate Counter\n  with\n    p : Party\n  where\n    signatory p\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let templates: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Template).collect();
+    assert_eq!(templates.len(), 1, "expected 1 Template");
+    assert_eq!(templates[0].name, "Counter");
+    assert_eq!(templates[0].qualified_name, "Foo.Counter");
+    assert!(!templates[0].parse_reliable, "Template still parse_reliable=false (keyword anchor)");
+}
+
+#[test]
+fn daml_template_span_is_byte_precise() {
+    // Verify the tree-sitter version emits byte-precise spans (not the line
+    // approximations the slice-9 regex produced).
+    //
+    // The regex version emits end_col=0 always (line-anchored). The tree-sitter
+    // version emits end_col from the AST node's position, which is non-zero for
+    // any template whose last line is not empty. The assertion below
+    // distinguishes the two reliably.
+    let source = "module Foo where\n\ntemplate Counter\n  with\n    p : Party\n  where\n    signatory p\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let template = result.nodes.iter().find(|n| n.kind == NodeKind::Template).unwrap();
+    assert!(template.end_line >= 7, "Template should span at least to line 7; got {}", template.end_line);
+    assert!(template.start_line >= 3, "Template starts at line 3 or later; got {}", template.start_line);
+    assert!(template.end_col > 0,
+            "tree-sitter version emits non-zero end_col (byte-precise); regex emits 0. Got end_col={}",
+            template.end_col);
+}
+```
+
+- [ ] **Step 3: Run failing tests**
+
+```bash
+cargo test --test extraction_unit daml_template_extracted_via_tree_sitter_query 2>&1 | tail -10
+```
+
+Expected: TEST PASSES (the existing regex-based `pass_d_templates_and_choices` from slice 9 already extracts templates — same assertions, just different mechanism). Confirm both new tests pass *with the regex in place*. This is the regression baseline; Step 5 will swap to tree-sitter and rerun.
+
+- [ ] **Step 4: Add the Template query to `src/extraction/languages/daml.scm`**
+
+Using the shape documented in Step 1's `daml.scm` comment, append the matching query. For the assumed flat shape:
+
+```scheme
+; Template anchor: `template Counter ...`.
+; Captures the keyword 'template' as a variable in an apply expression;
+; the Constructor argument is the template name.
+((apply
+  function: (variable) @template.kw
+  argument: (constructor) @template.name) @template.def
+  (#eq? @template.kw "template"))
+```
+
+For a curried `(apply (apply (variable "template") (constructor)) ...)` shape, the equivalent query is:
+
+```scheme
+; Curried form: outer apply wraps the inner template-constructor apply.
+((apply
+  function: (apply
+    function: (variable) @template.kw
+    argument: (constructor) @template.name)) @template.def
+  (#eq? @template.kw "template"))
+```
+
+Pick the form matching Step 1's probe output. Do not write both.
+
+- [ ] **Step 5: Add `pass_e_templates` function in `src/extraction/languages/daml.rs`**
+
+Locate the existing `pass_d_templates_and_choices` function in `daml.rs` (`grep -n 'fn pass_d_templates_and_choices' src/extraction/languages/daml.rs`). Insert the new `pass_e_templates` function immediately after it:
+
+```rust
+/// Tree-sitter-based template extraction. Replaces the regex-anchored detection
+/// in `pass_d_templates_and_choices` with a query over `(apply (variable "template") (constructor))`.
+///
+/// Why: byte-precise spans (vs line-anchored regex), robust to whitespace,
+/// composes naturally with existing tree-sitter machinery.
+fn pass_e_templates(
+    query: &Query,
+    tree: &tree_sitter::Tree,
+    source: &str,
+    root_name: &str,
+    relative_path: &str,
+    module_qid: Option<&str>,
+    file_qid: &str,
+    result: &mut ExtractionResult,
+) {
+    let Some(def_idx) = query.capture_index_for_name("template.def") else { return };
+    let Some(name_idx) = query.capture_index_for_name("template.name") else { return };
+
+    let module_prefix = module_qid
+        .map(|q| q.split(':').skip(2).collect::<Vec<_>>().join(":"))
+        .unwrap_or_default();
+    let parent_for_template: &str = module_qid.unwrap_or(file_qid);
+
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
+
+    while let Some(m) = matches.next() {
+        let mut def_node = None;
+        let mut name_node = None;
+        for cap in m.captures {
+            if cap.index == def_idx { def_node = Some(cap.node); }
+            else if cap.index == name_idx { name_node = Some(cap.node); }
+        }
+        if let (Some(def), Some(name)) = (def_node, name_node) {
+            let template_name = name.utf8_text(source.as_bytes()).unwrap_or("?").trim().to_string();
+            let qname = if module_prefix.is_empty() {
+                template_name.clone()
+            } else {
+                format!("{module_prefix}.{template_name}")
+            };
+            let template_qid = format!("{root_name}:{relative_path}:{qname}");
+
+            // Expand the span to cover the full template definition. The
+            // matched `apply` node only covers `template Counter`; the body
+            // (`with ... where ...`) is the parent's next-sibling chain.
+            // For now, use the def node's parent's range — that's typically
+            // the top_splice or full statement.
+            let span_node = def.parent().unwrap_or(def);
+            let start = span_node.start_position();
+            let end = span_node.end_position();
+
+            result.nodes.push(RawNode {
+                qid: template_qid.clone(),
+                kind: NodeKind::Template,
+                name: template_name,
+                qualified_name: qname,
+                root_name: root_name.to_string(),
+                relative_path: relative_path.to_string(),
+                language: "daml".to_string(),
+                start_line: (start.row as u32) + 1,
+                end_line: (end.row as u32) + 1,
+                start_col: start.column as u32,
+                end_col: end.column as u32,
+                signature: None,
+                doc: None,
+                parse_reliable: false, // keyword anchor; the surrounding body is fine but the anchor itself is text-matched
+                content_hash: None,
+                last_indexed_at: None,
+            });
+            result.edges.push(RawEdge {
+                from_qid: parent_for_template.to_string(),
+                to_qid: template_qid,
+                kind: EdgeKind::Contains,
+            });
+        }
+    }
+}
+```
+
+> **Implementer note on span expansion.** The `apply` node only covers `template Counter`. To get the *full* template span (including the `where`-block), walk up: `def.parent()` is typically the `top_splice` or a similar wrapper. If `parent()` doesn't span the body, the implementer may need to walk further or use the byte-range from the matched `def` plus the next-sibling's byte-end.
+
+- [ ] **Step 6: Comment out the template-emission block in `pass_d_templates_and_choices`, wire `pass_e_templates` in `extract_daml`**
+
+Both `pass_d` and `pass_e_templates` would emit a template node with the same qid (the qid is `<root>:<rel>:<qname>`, derived from the template name). Two emissions of the same qid produce a Neo4j constraint violation on write. The fix is to disable `pass_d`'s template-emission block before turning on `pass_e_templates`.
+
+In `pass_d_templates_and_choices`, locate the `for (i, (start_byte, cap)) in template_matches.iter().enumerate() { ... }` loop that emits Template nodes. Wrap the loop body in a comment block:
+
+```rust
+// Slice 10a Task 2: template emission moved to pass_e_templates (tree-sitter
+// based). Loop body preserved (commented out) to be deleted in Task 7.
+/*
+for (i, (start_byte, cap)) in template_matches.iter().enumerate() {
+    // ... original body ...
+}
+*/
+```
+
+The choice-emission block below it remains live until Task 3.
+
+In `extract_daml`, add the new call before the existing `pass_d_templates_and_choices` call:
+
+```rust
+pass_e_templates(&query, &tree, source, root_name, relative_path,
+                 module_qid_opt.as_deref(), &file_qid, &mut result);
+pass_d_templates_and_choices(source, root_name, relative_path,
+                             module_qid_opt.as_deref(), &file_qid, &mut result);
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -15
+```
+
+Expected: existing slice-9 template tests AND new tests pass. The `daml_template_span_is_byte_precise` test should now show end_line ≥ 7 (the byte-precise extent) where the slice-9 regex version showed end_line based on line approximations.
+
+- [ ] **Step 8: Build + clippy + fmt**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+# Regression guard: confirm slice-9 Daml integration test still SKIPs cleanly
+# (it's the existing end-to-end test the extractor's structural changes could
+# break). Without env vars set, it just exits ok.
+cargo test --test integration_daml_index 2>&1 | tail -3
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/extraction/languages/daml.rs src/extraction/languages/daml.scm tests/extraction_unit.rs
+git commit -m "feat(extraction): tree-sitter template detection (replaces regex; byte-precise spans)"
+```
+
+---
+
+### Task 3: Tree-sitter query — Choice anchor (TDD)
+
+**Files:**
+- Modify: `src/extraction/languages/daml.scm`
+- Modify: `src/extraction/languages/daml.rs`
+- Modify: `tests/extraction_unit.rs`
+
+Same pattern as Task 2 but for choices. Choices have a more complex shape than templates because the argument to `choice` is the choice's signature (`Increment : ContractId Counter`), not just a constructor.
+
+- [ ] **Step 1: Inspect choice parse shape**
+
+Add a `#[ignore]`d probe test in `tests/extraction_unit.rs` (reuses the `print_tree` helper if Task 2 left it in place; if Task 2 removed it per its instructions, paste it back temporarily):
+
+```rust
+#[test]
+#[ignore]
+fn probe_choice_parse_shape() {
+    let source = "module Foo where\n\ntemplate T\n  with p : Party\n  where\n    signatory p\n    choice Increment : ContractId T\n      controller p\n      do return ()\n";
+    let tree = codegraph_rs::extraction::parser::parse_daml(source).unwrap();
+    print_tree(tree.root_node(), 0);
+}
+```
+
+Run: `cargo test --test extraction_unit probe_choice_parse_shape -- --ignored --nocapture 2>&1 | head -80`
+
+Observe how `choice Increment : ContractId T` parses. Likely candidates:
+- The `choice` keyword and `Increment` form an `apply`; the `: ContractId T` part lands in a child of the apply.
+- Or: the whole `choice Increment : ContractId T` is a signature-shaped node where `choice` is a prefix.
+
+Document the actual shape in the `daml.scm` comment block. Write Step 4's query to match.
+
+**Probe test disposition:** REMOVE `probe_choice_parse_shape` (and `print_tree` if Task 2 left it) before Step 9's commit.
+
+- [ ] **Step 2: Append failing tests**
+
+```rust
+#[test]
+fn daml_choice_extracted_via_tree_sitter_query() {
+    let source = "module Foo where\n\ntemplate T\n  with p : Party\n  where\n    signatory p\n    choice Increment : ContractId T\n      controller p\n      do return ()\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let choices: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Choice).collect();
+    assert_eq!(choices.len(), 1, "expected 1 Choice");
+    assert_eq!(choices[0].name, "Increment");
+    assert_eq!(choices[0].qualified_name, "Foo.T.Increment");
+    assert!(!choices[0].parse_reliable);
+}
+
+#[test]
+fn daml_two_choices_in_template() {
+    let source = "module Foo where\n\ntemplate T\n  with p : Party\n  where\n    signatory p\n    choice A : ()\n      controller p\n      do return ()\n    choice B : Int\n      controller p\n      do return 0\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let choices: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Choice).collect();
+    let names: Vec<&str> = choices.iter().map(|c| c.name.as_str()).collect();
+    assert!(names.contains(&"A"));
+    assert!(names.contains(&"B"));
+}
+```
+
+- [ ] **Step 3: Run failing tests**
+
+Expected: existing regex pass already passes these (slice 9 emits choices). The tests are written to assert behavior — switch to tree-sitter shouldn't regress them.
+
+- [ ] **Step 4: Add the Choice query to `daml.scm`**
+
+Based on the probe shape from Step 1. Tentatively:
+
+```scheme
+; Choice anchor: `choice C : T ...`. Captures the keyword 'choice' as a variable;
+; the next sibling or argument holds the choice's name.
+((apply
+  function: (variable) @choice.kw
+  argument: (_) @choice.body) @choice.def
+  (#eq? @choice.kw "choice"))
+```
+
+Then in Rust, extract the choice name from the `@choice.body` capture by walking for the first `(variable)` or `(constructor)` child.
+
+If the actual parse uses a `signature`-shape inside, the query can be:
+
+```scheme
+((apply
+  function: (variable) @choice.kw
+  argument: (signature name: (variable) @choice.name)) @choice.def
+  (#eq? @choice.kw "choice"))
+```
+
+The implementer picks based on the probe.
+
+- [ ] **Step 5: Add `pass_e_choices` function with full implementation**
+
+In `src/extraction/languages/daml.rs`, add the helper `enclosing_template_qid` and the `pass_e_choices` function. Place both after `pass_e_templates` from Task 2.
+
+```rust
+/// Find the smallest Template node in `nodes` whose span contains (line, col).
+/// Used to assign the parent qid for choices, since choices are CONTAINS-children
+/// of their enclosing Template (not the Module).
+fn enclosing_template_qid(nodes: &[RawNode], line: u32, col: u32) -> Option<&str> {
+    let mut best: Option<&RawNode> = None;
+    for n in nodes {
+        if n.kind != NodeKind::Template { continue; }
+        let in_span = (n.start_line < line || (n.start_line == line && n.start_col <= col))
+            && (n.end_line > line || (n.end_line == line && n.end_col >= col));
+        if !in_span { continue; }
+        match best {
+            None => best = Some(n),
+            Some(b) => {
+                let n_size = (n.end_line - n.start_line) as i64;
+                let b_size = (b.end_line - b.start_line) as i64;
+                if n_size < b_size { best = Some(n); }
+            }
+        }
+    }
+    best.map(|n| n.qid.as_str())
+}
+
+/// Tree-sitter-based choice extraction. The choice's NAME comes from the
+/// `@choice.body` capture — the implementer must walk this subtree to find
+/// the first `(variable)` or `(constructor)` leaf (the choice's name).
+///
+/// The choice is CONTAINS-edged from the enclosing Template (not the Module).
+/// If no enclosing Template is found at the match's location, the choice is
+/// skipped — real Daml requires choices be inside templates.
+///
+/// **Signature note:** unlike `pass_e_templates` (which takes `module_qid`
+/// + `file_qid` because Templates parent under Module-or-File), this function
+/// takes neither — the Template parent is discovered via `enclosing_template_qid`
+/// against `result.nodes`. The same shape applies to `pass_e_viewtypes`
+/// (Interface parent) and `pass_e_fields` (Template/Choice/Interface/Exception
+/// parent). Different signatures by design.
+fn pass_e_choices(
+    query: &Query,
+    tree: &tree_sitter::Tree,
+    source: &str,
+    root_name: &str,
+    relative_path: &str,
+    result: &mut ExtractionResult,
+) {
+    let Some(def_idx) = query.capture_index_for_name("choice.def") else { return };
+    let Some(body_idx) = query.capture_index_for_name("choice.body") else { return };
+
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
+
+    while let Some(m) = matches.next() {
+        let mut def_node = None;
+        let mut body_node = None;
+        for cap in m.captures {
+            if cap.index == def_idx { def_node = Some(cap.node); }
+            else if cap.index == body_idx { body_node = Some(cap.node); }
+        }
+        let (Some(def), Some(body)) = (def_node, body_node) else { continue };
+
+        // Find the choice name by walking the body subtree for the first
+        // (variable) or (constructor) leaf. This handles both shapes:
+        // - `choice Increment : ContractId T` (body is a signature-shaped node)
+        // - `choice Inc` (body is a bare variable/constructor)
+        let choice_name = first_identifier_in_subtree(body, source.as_bytes())
+            .unwrap_or_default();
+        if choice_name.is_empty() { continue; }
+
+        // Find the enclosing Template.
+        let pos = def.start_position();
+        let line = (pos.row as u32) + 1;
+        let col = pos.column as u32;
+        let Some(template_qid) = enclosing_template_qid(&result.nodes, line, col) else {
+            continue;
+        };
+
+        // Build qualified_name: <template_qname>.<choice_name>.
+        let template_qname: String = template_qid.split(':').skip(2).collect::<Vec<_>>().join(":");
+        let qname = format!("{template_qname}.{choice_name}");
+        let qid = format!("{root_name}:{relative_path}:{qname}");
+
+        let end = def.end_position();
+        result.nodes.push(RawNode {
+            qid: qid.clone(),
+            kind: NodeKind::Choice,
+            name: choice_name,
+            qualified_name: qname,
+            root_name: root_name.to_string(),
+            relative_path: relative_path.to_string(),
+            language: "daml".to_string(),
+            start_line: line,
+            end_line: (end.row as u32) + 1,
+            start_col: col,
+            end_col: end.column as u32,
+            signature: Some(def.utf8_text(source.as_bytes()).unwrap_or("").trim().to_string()),
+            doc: None,
+            parse_reliable: false, // keyword anchor
+            content_hash: None,
+            last_indexed_at: None,
+        });
+        result.edges.push(RawEdge {
+            from_qid: template_qid.to_string(),
+            to_qid: qid,
+            kind: EdgeKind::Contains,
+        });
+    }
+}
+
+/// Walk a tree-sitter subtree depth-first and return the first identifier text
+/// (a variable or constructor). Returns None if none found.
+fn first_identifier_in_subtree(node: tree_sitter::Node, source: &[u8]) -> Option<String> {
+    if node.kind() == "variable" || node.kind() == "constructor" {
+        return Some(node.utf8_text(source).ok()?.trim().to_string());
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(s) = first_identifier_in_subtree(child, source) {
+            return Some(s);
+        }
+    }
+    None
+}
+```
+
+In `extract_daml`, wire the call AFTER `pass_e_templates`:
+
+```rust
+pass_e_templates(&query, &tree, source, root_name, relative_path,
+                 module_qid_opt.as_deref(), &file_qid, &mut result);
+pass_e_choices(&query, &tree, source, root_name, relative_path, &mut result);
+```
+
+- [ ] **Step 6: Comment out the choice-emission block in `pass_d_templates_and_choices`**
+
+Same pattern as Task 2 Step 6. Locate the `for ccap in choice_re.captures_iter(span_text) { ... }` loop inside `pass_d_templates_and_choices`. Wrap its body:
+
+```rust
+// Slice 10a Task 3: choice emission moved to pass_e_choices (tree-sitter
+// based). Loop body preserved (commented out) to be deleted in Task 7.
+/*
+for ccap in choice_re.captures_iter(span_text) {
+    // ... original body ...
+}
+*/
+```
+
+After this step, `pass_d_templates_and_choices` is a function with both internal loops commented out — effectively a no-op. The function call in `extract_daml` can stay (it just does nothing); Task 7 deletes the call and the function together.
+
+- [ ] **Step 7: Run tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -15
+```
+
+Expected: all choice tests (existing + new) pass.
+
+- [ ] **Step 8: Build + clippy + fmt + test**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+# Regression guard: confirm slice-9 Daml integration test still SKIPs cleanly
+# (it's the existing end-to-end test the extractor's structural changes could
+# break). Without env vars set, it just exits ok.
+cargo test --test integration_daml_index 2>&1 | tail -3
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/extraction/languages/daml.rs src/extraction/languages/daml.scm tests/extraction_unit.rs
+git commit -m "feat(extraction): tree-sitter choice detection; pass_d_templates_and_choices now empty"
+```
+
+---
+
+### Task 4: Tree-sitter query — Interface + Viewtype (TDD; new constructs)
+
+**Files:**
+- Modify: `src/extraction/languages/daml.scm`
+- Modify: `src/extraction/languages/daml.rs`
+- Modify: `tests/extraction_unit.rs`
+
+`interface I where ...` and `viewtype V` inside the interface body. Both are net-new (v1 didn't extract them at all).
+
+- [ ] **Step 1: Append failing tests**
+
+```rust
+#[test]
+fn daml_extracts_interface() {
+    let source = "module Foo where\n\ninterface Authorizable where\n  getOwner : Party\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let interfaces: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Interface).collect();
+    assert_eq!(interfaces.len(), 1);
+    assert_eq!(interfaces[0].name, "Authorizable");
+    assert_eq!(interfaces[0].qualified_name, "Foo.Authorizable");
+    assert!(!interfaces[0].parse_reliable);
+}
+
+#[test]
+fn daml_extracts_viewtype_inside_interface() {
+    let source = "module Foo where\n\ndata FooView = FooView { x : Int }\n\ninterface Bar where\n  viewtype FooView\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let viewtypes: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Viewtype).collect();
+    assert_eq!(viewtypes.len(), 1);
+    assert_eq!(viewtypes[0].name, "FooView");
+    assert_eq!(viewtypes[0].qualified_name, "Foo.Bar.FooView", "Viewtype qname nests under its Interface");
+    assert!(!viewtypes[0].parse_reliable);
+}
+
+#[test]
+fn daml_interface_contains_edge_from_module() {
+    use codegraph_rs::extraction::result::EdgeKind;
+    let source = "module Foo where\n\ninterface Bar where\n  x : Int\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let module_qid = &result.nodes.iter().find(|n| n.kind == NodeKind::Module).unwrap().qid;
+    let interface_qid = &result.nodes.iter().find(|n| n.kind == NodeKind::Interface).unwrap().qid;
+    assert!(result.edges.iter().any(|e|
+        e.kind == EdgeKind::Contains && e.from_qid == *module_qid && e.to_qid == *interface_qid));
+}
+
+#[test]
+fn daml_viewtype_contains_edge_from_interface() {
+    use codegraph_rs::extraction::result::EdgeKind;
+    let source = "module Foo where\n\ndata V = V {}\n\ninterface Bar where\n  viewtype V\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let interface_qid = &result.nodes.iter().find(|n| n.kind == NodeKind::Interface).unwrap().qid;
+    let viewtype_qid = &result.nodes.iter().find(|n| n.kind == NodeKind::Viewtype).unwrap().qid;
+    assert!(result.edges.iter().any(|e|
+        e.kind == EdgeKind::Contains && e.from_qid == *interface_qid && e.to_qid == *viewtype_qid));
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+cargo test --test extraction_unit daml_extracts_interface 2>&1 | tail -10
+```
+
+Expected: FAIL — interface extraction doesn't exist yet.
+
+- [ ] **Step 3: Add interface + viewtype queries to `daml.scm`**
+
+```scheme
+; Interface anchor: `interface I where ...`.
+((apply
+  function: (variable) @interface.kw
+  argument: (constructor) @interface.name) @interface.def
+  (#eq? @interface.kw "interface"))
+
+; Viewtype anchor: `viewtype V` (always nested under an interface).
+((apply
+  function: (variable) @viewtype.kw
+  argument: (constructor) @viewtype.name) @viewtype.def
+  (#eq? @viewtype.kw "viewtype"))
+```
+
+- [ ] **Step 4: Add full implementations for `pass_e_interfaces`, `enclosing_interface_qid`, and `pass_e_viewtypes`**
+
+In `src/extraction/languages/daml.rs`, add these three functions after `pass_e_choices` from Task 3:
+
+```rust
+/// Tree-sitter-based Interface extraction. Same shape as `pass_e_templates`
+/// (interfaces are top-level module children, just like templates).
+fn pass_e_interfaces(
+    query: &Query,
+    tree: &tree_sitter::Tree,
+    source: &str,
+    root_name: &str,
+    relative_path: &str,
+    module_qid: Option<&str>,
+    file_qid: &str,
+    result: &mut ExtractionResult,
+) {
+    let Some(def_idx) = query.capture_index_for_name("interface.def") else { return };
+    let Some(name_idx) = query.capture_index_for_name("interface.name") else { return };
+
+    let module_prefix = module_qid
+        .map(|q| q.split(':').skip(2).collect::<Vec<_>>().join(":"))
+        .unwrap_or_default();
+    let parent_for_interface: &str = module_qid.unwrap_or(file_qid);
+
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
+
+    while let Some(m) = matches.next() {
+        let mut def_node = None;
+        let mut name_node = None;
+        for cap in m.captures {
+            if cap.index == def_idx { def_node = Some(cap.node); }
+            else if cap.index == name_idx { name_node = Some(cap.node); }
+        }
+        let (Some(def), Some(name)) = (def_node, name_node) else { continue };
+
+        let interface_name = name.utf8_text(source.as_bytes()).unwrap_or("?").trim().to_string();
+        let qname = if module_prefix.is_empty() {
+            interface_name.clone()
+        } else {
+            format!("{module_prefix}.{interface_name}")
+        };
+        let interface_qid = format!("{root_name}:{relative_path}:{qname}");
+
+        let span_node = def.parent().unwrap_or(def);
+        let start = span_node.start_position();
+        let end = span_node.end_position();
+
+        result.nodes.push(RawNode {
+            qid: interface_qid.clone(),
+            kind: NodeKind::Interface,
+            name: interface_name,
+            qualified_name: qname,
+            root_name: root_name.to_string(),
+            relative_path: relative_path.to_string(),
+            language: "daml".to_string(),
+            start_line: (start.row as u32) + 1,
+            end_line: (end.row as u32) + 1,
+            start_col: start.column as u32,
+            end_col: end.column as u32,
+            signature: None,
+            doc: None,
+            parse_reliable: false,
+            content_hash: None,
+            last_indexed_at: None,
+        });
+        result.edges.push(RawEdge {
+            from_qid: parent_for_interface.to_string(),
+            to_qid: interface_qid,
+            kind: EdgeKind::Contains,
+        });
+    }
+}
+
+/// Same shape as `enclosing_template_qid` but filters `NodeKind::Interface`.
+fn enclosing_interface_qid(nodes: &[RawNode], line: u32, col: u32) -> Option<&str> {
+    let mut best: Option<&RawNode> = None;
+    for n in nodes {
+        if n.kind != NodeKind::Interface { continue; }
+        let in_span = (n.start_line < line || (n.start_line == line && n.start_col <= col))
+            && (n.end_line > line || (n.end_line == line && n.end_col >= col));
+        if !in_span { continue; }
+        match best {
+            None => best = Some(n),
+            Some(b) => {
+                let n_size = (n.end_line - n.start_line) as i64;
+                let b_size = (b.end_line - b.start_line) as i64;
+                if n_size < b_size { best = Some(n); }
+            }
+        }
+    }
+    best.map(|n| n.qid.as_str())
+}
+
+/// Tree-sitter-based Viewtype extraction. Viewtypes are CONTAINS-children of
+/// their enclosing Interface. If no enclosing Interface is found, the viewtype
+/// is skipped (defensive — real Daml requires viewtype inside interface).
+fn pass_e_viewtypes(
+    query: &Query,
+    tree: &tree_sitter::Tree,
+    source: &str,
+    root_name: &str,
+    relative_path: &str,
+    result: &mut ExtractionResult,
+) {
+    let Some(def_idx) = query.capture_index_for_name("viewtype.def") else { return };
+    let Some(name_idx) = query.capture_index_for_name("viewtype.name") else { return };
+
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
+
+    while let Some(m) = matches.next() {
+        let mut def_node = None;
+        let mut name_node = None;
+        for cap in m.captures {
+            if cap.index == def_idx { def_node = Some(cap.node); }
+            else if cap.index == name_idx { name_node = Some(cap.node); }
+        }
+        let (Some(def), Some(name)) = (def_node, name_node) else { continue };
+
+        let viewtype_name = name.utf8_text(source.as_bytes()).unwrap_or("?").trim().to_string();
+
+        let pos = def.start_position();
+        let line = (pos.row as u32) + 1;
+        let col = pos.column as u32;
+        let Some(interface_qid) = enclosing_interface_qid(&result.nodes, line, col) else {
+            continue;
+        };
+
+        let interface_qname: String = interface_qid.split(':').skip(2).collect::<Vec<_>>().join(":");
+        let qname = format!("{interface_qname}.{viewtype_name}");
+        let qid = format!("{root_name}:{relative_path}:{qname}");
+
+        let end = def.end_position();
+        result.nodes.push(RawNode {
+            qid: qid.clone(),
+            kind: NodeKind::Viewtype,
+            name: viewtype_name,
+            qualified_name: qname,
+            root_name: root_name.to_string(),
+            relative_path: relative_path.to_string(),
+            language: "daml".to_string(),
+            start_line: line,
+            end_line: (end.row as u32) + 1,
+            start_col: col,
+            end_col: end.column as u32,
+            signature: None,
+            doc: None,
+            parse_reliable: false,
+            content_hash: None,
+            last_indexed_at: None,
+        });
+        result.edges.push(RawEdge {
+            from_qid: interface_qid.to_string(),
+            to_qid: qid,
+            kind: EdgeKind::Contains,
+        });
+    }
+}
+```
+
+Wire calls in `extract_daml` AFTER `pass_e_choices`. **Order is mandatory:** `pass_e_interfaces` must come BEFORE `pass_e_viewtypes` — viewtypes look up their parent Interface via `enclosing_interface_qid(&result.nodes, ...)`, so the Interface nodes must already exist in `result.nodes` when viewtype extraction runs. If reversed, viewtype emission silently fails (no error, just zero Viewtype nodes).
+
+```rust
+// REQUIRED ORDER: interfaces before viewtypes (viewtypes look up parent Interface).
+pass_e_interfaces(&query, &tree, source, root_name, relative_path,
+                  module_qid_opt.as_deref(), &file_qid, &mut result);
+pass_e_viewtypes(&query, &tree, source, root_name, relative_path, &mut result);
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: 4 new tests pass.
+
+- [ ] **Step 6: Build + clippy + fmt**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+# Regression guard: confirm slice-9 Daml integration test still SKIPs cleanly
+# (it's the existing end-to-end test the extractor's structural changes could
+# break). Without env vars set, it just exits ok.
+cargo test --test integration_daml_index 2>&1 | tail -3
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/extraction/languages/daml.rs src/extraction/languages/daml.scm tests/extraction_unit.rs
+git commit -m "feat(extraction): Daml Interface and Viewtype extraction"
+```
+
+---
+
+### Task 5: Tree-sitter query — Exception (TDD; new construct)
+
+**Files:**
+- Modify: `src/extraction/languages/daml.scm`
+- Modify: `src/extraction/languages/daml.rs`
+- Modify: `tests/extraction_unit.rs`
+
+`exception E with ... where message ...` — same anchor shape as template, simpler body. Direct CONTAINS-child of the module.
+
+- [ ] **Step 1: Append failing test**
+
+```rust
+#[test]
+fn daml_extracts_exception() {
+    let source = "module Foo where\n\nexception InsufficientBalance with\n    actual : Int\n  where\n    message \"low balance\"\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let exceptions: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Exception).collect();
+    assert_eq!(exceptions.len(), 1);
+    assert_eq!(exceptions[0].name, "InsufficientBalance");
+    assert_eq!(exceptions[0].qualified_name, "Foo.InsufficientBalance");
+    assert!(!exceptions[0].parse_reliable);
+}
+
+#[test]
+fn daml_exception_contains_edge_from_module() {
+    use codegraph_rs::extraction::result::EdgeKind;
+    let source = "module Foo where\n\nexception E with x : Int where message \"\"\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let module_qid = &result.nodes.iter().find(|n| n.kind == NodeKind::Module).unwrap().qid;
+    let exception_qid = &result.nodes.iter().find(|n| n.kind == NodeKind::Exception).unwrap().qid;
+    assert!(result.edges.iter().any(|e|
+        e.kind == EdgeKind::Contains && e.from_qid == *module_qid && e.to_qid == *exception_qid));
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Expected: FAIL — no Exception extraction yet.
+
+- [ ] **Step 3: Add exception query to `daml.scm`**
+
+```scheme
+; Exception anchor: `exception E with ... where message ...`.
+((apply
+  function: (variable) @exception.kw
+  argument: (constructor) @exception.name) @exception.def
+  (#eq? @exception.kw "exception"))
+```
+
+- [ ] **Step 4: Add `pass_e_exceptions` with full implementation**
+
+In `src/extraction/languages/daml.rs`, add after `pass_e_viewtypes`:
+
+```rust
+/// Tree-sitter-based Exception extraction. Identical structure to
+/// `pass_e_templates` (module-direct child).
+fn pass_e_exceptions(
+    query: &Query,
+    tree: &tree_sitter::Tree,
+    source: &str,
+    root_name: &str,
+    relative_path: &str,
+    module_qid: Option<&str>,
+    file_qid: &str,
+    result: &mut ExtractionResult,
+) {
+    let Some(def_idx) = query.capture_index_for_name("exception.def") else { return };
+    let Some(name_idx) = query.capture_index_for_name("exception.name") else { return };
+
+    let module_prefix = module_qid
+        .map(|q| q.split(':').skip(2).collect::<Vec<_>>().join(":"))
+        .unwrap_or_default();
+    let parent_for_exception: &str = module_qid.unwrap_or(file_qid);
+
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
+
+    while let Some(m) = matches.next() {
+        let mut def_node = None;
+        let mut name_node = None;
+        for cap in m.captures {
+            if cap.index == def_idx { def_node = Some(cap.node); }
+            else if cap.index == name_idx { name_node = Some(cap.node); }
+        }
+        let (Some(def), Some(name)) = (def_node, name_node) else { continue };
+
+        let exception_name = name.utf8_text(source.as_bytes()).unwrap_or("?").trim().to_string();
+        let qname = if module_prefix.is_empty() {
+            exception_name.clone()
+        } else {
+            format!("{module_prefix}.{exception_name}")
+        };
+        let exception_qid = format!("{root_name}:{relative_path}:{qname}");
+
+        let span_node = def.parent().unwrap_or(def);
+        let start = span_node.start_position();
+        let end = span_node.end_position();
+
+        result.nodes.push(RawNode {
+            qid: exception_qid.clone(),
+            kind: NodeKind::Exception,
+            name: exception_name,
+            qualified_name: qname,
+            root_name: root_name.to_string(),
+            relative_path: relative_path.to_string(),
+            language: "daml".to_string(),
+            start_line: (start.row as u32) + 1,
+            end_line: (end.row as u32) + 1,
+            start_col: start.column as u32,
+            end_col: end.column as u32,
+            signature: None,
+            doc: None,
+            parse_reliable: false,
+            content_hash: None,
+            last_indexed_at: None,
+        });
+        result.edges.push(RawEdge {
+            from_qid: parent_for_exception.to_string(),
+            to_qid: exception_qid,
+            kind: EdgeKind::Contains,
+        });
+    }
+}
+```
+
+- [ ] **Step 5: Wire in `extract_daml`** after the interface pass.
+
+- [ ] **Step 6: Run tests, build, clippy, fmt**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/extraction/languages/daml.rs src/extraction/languages/daml.scm tests/extraction_unit.rs
+git commit -m "feat(extraction): Daml Exception extraction"
+```
+
+---
+
+### Task 6: Tree-sitter query — Field with disambiguation (TDD; most complex single task)
+
+**Files:**
+- Modify: `src/extraction/languages/daml.scm`
+- Modify: `src/extraction/languages/daml.rs`
+- Modify: `tests/extraction_unit.rs`
+
+This is the spec's critical disambiguation case. The `(signature)` query matches BOTH:
+1. With-block field bindings inside a Template/Choice/Interface/Exception keyword anchor
+2. Top-level function signatures (`helperFn : Int -> Int`)
+
+The Function extractor (slice 9 task 6) already handles case 2. The Field extractor must emit ONLY case 1.
+
+**Disambiguation rule (spec §3.2):** Only emit as Field if the signature's byte range is inside the byte range of a Template, Choice, Interface, or Exception node (which by this point have all been extracted by Tasks 2-5).
+
+- [ ] **Step 1: Append failing tests**
+
+```rust
+#[test]
+fn daml_template_fields_extracted() {
+    let source = "module Foo where\n\ntemplate Counter\n  with\n    owner : Party\n    count : Int\n  where\n    signatory owner\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let fields: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Field).collect();
+    assert_eq!(fields.len(), 2, "expected 2 Fields (owner, count); got {:?}", fields.iter().map(|f| &f.name).collect::<Vec<_>>());
+    let names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+    assert!(names.contains(&"owner"));
+    assert!(names.contains(&"count"));
+    for f in &fields {
+        assert!(f.parse_reliable, "Fields are grammar-clean (parse_reliable=true)");
+        assert!(f.qualified_name.starts_with("Foo.Counter."), "Field qname nests under Template; got {}", f.qualified_name);
+    }
+}
+
+#[test]
+fn daml_top_level_signature_not_emitted_as_field() {
+    let source = "module Foo where\n\nhelperFn : Int -> Int\nhelperFn x = x + 1\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let fields: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Field).collect();
+    assert!(fields.is_empty(), "top-level function signatures must NOT be emitted as Fields; got {:?}", fields);
+    let funcs: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Function).collect();
+    assert_eq!(funcs.len(), 1, "but Function should still be extracted");
+    assert_eq!(funcs[0].name, "helperFn");
+}
+
+#[test]
+fn daml_choice_fields_qualified_under_template_and_choice() {
+    let source = "module Foo where\n\ntemplate T\n  with p : Party\n  where\n    signatory p\n    choice Bump\n        : ContractId T\n      with\n        delta : Int\n      controller p\n      do return self\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let delta_field = result.nodes.iter().find(|n| n.kind == NodeKind::Field && n.name == "delta");
+    if let Some(field) = delta_field {
+        assert_eq!(field.qualified_name, "Foo.T.Bump.delta", "Choice field qname is 4 segments (Module.Template.Choice.field)");
+    }
+    // Note: choice argument extraction depends on haskell's parse of the
+    // `with` block inside a choice. This test is permissive — if the haskell
+    // grammar doesn't expose the choice's with-block as a query-able shape,
+    // the field may not be extracted. Document as a known limitation.
+}
+
+#[test]
+fn daml_interface_methods_extracted_as_fields() {
+    let source = "module Foo where\n\ninterface Bar where\n  getOwner : Party\n  getCount : Int\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let fields: Vec<_> = result.nodes.iter().filter(|n| n.kind == NodeKind::Field).collect();
+    let names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+    assert!(names.contains(&"getOwner"), "Interface method should be Field; got {:?}", names);
+    assert!(names.contains(&"getCount"));
+    for f in &fields {
+        assert!(f.qualified_name.starts_with("Foo.Bar."), "Interface field nests under Interface");
+    }
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Expected: FAIL — no Field extraction yet.
+
+- [ ] **Step 3: Add the `signature` query to `daml.scm`**
+
+```scheme
+; Field candidates: typed bindings `name : Type`. Note this also matches top-level
+; function signatures; the extractor disambiguates by checking the ancestor span
+; against already-emitted Template/Choice/Interface/Exception nodes.
+(signature name: (variable) @field.name type: (_) @field.type) @field.def
+```
+
+> **Daml-specific concern:** slice 6 found Daml's single-colon `:` lands in `top_splice/infix` (not `signature`). The implementer must run a probe test (similar to Task 2 Step 1) to confirm which node shape Daml field declarations actually use, and adjust the query accordingly. If they use `top_splice/infix`, the query might be:
+>
+> ```scheme
+> (top_splice (infix left_operand: (variable) @field.name (operator) right_operand: (_) @field.type)) @field.def
+> ```
+
+- [ ] **Step 4: Add `pass_e_fields` with ancestor-span disambiguation**
+
+```rust
+fn pass_e_fields(
+    query: &Query,
+    tree: &tree_sitter::Tree,
+    source: &str,
+    root_name: &str,
+    relative_path: &str,
+    result: &mut ExtractionResult,
+) {
+    let Some(def_idx) = query.capture_index_for_name("field.def") else { return };
+    let Some(name_idx) = query.capture_index_for_name("field.name") else { return };
+    let Some(type_idx) = query.capture_index_for_name("field.type") else { return };
+
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
+
+    while let Some(m) = matches.next() {
+        let mut def_node = None;
+        let mut name_node = None;
+        let mut type_node = None;
+        for cap in m.captures {
+            if cap.index == def_idx { def_node = Some(cap.node); }
+            else if cap.index == name_idx { name_node = Some(cap.node); }
+            else if cap.index == type_idx { type_node = Some(cap.node); }
+        }
+        if let (Some(def), Some(name), Some(type_n)) = (def_node, name_node, type_node) {
+            let field_name = name.utf8_text(source.as_bytes()).unwrap_or("?").trim().to_string();
+            let field_type = type_n.utf8_text(source.as_bytes()).unwrap_or("?").trim().to_string();
+            let pos = def.start_position();
+            let line = (pos.row as u32) + 1;
+            let col = pos.column as u32;
+
+            // Disambiguation: only emit if inside a Daml keyword-anchored construct.
+            let parent_qid = enclosing_daml_anchor_qid(&result.nodes, line, col);
+            let Some(parent_qid) = parent_qid else {
+                continue; // top-level signature; handled by Function extractor
+            };
+
+            // qualified_name: <parent_qname>.<field_name>.
+            // Extract the parent's qname from its qid (format: <root>:<rel>:<qname>).
+            let parent_qname: String = parent_qid
+                .split(':')
+                .skip(2)
+                .collect::<Vec<_>>()
+                .join(":");
+            let qname = format!("{parent_qname}.{field_name}");
+            let qid = format!("{root_name}:{relative_path}:{qname}");
+
+            let end = def.end_position();
+            result.nodes.push(RawNode {
+                qid: qid.clone(),
+                kind: NodeKind::Field,
+                name: field_name,
+                qualified_name: qname,
+                root_name: root_name.to_string(),
+                relative_path: relative_path.to_string(),
+                language: "daml".to_string(),
+                start_line: line,
+                end_line: (end.row as u32) + 1,
+                start_col: col,
+                end_col: end.column as u32,
+                signature: Some(field_type),
+                doc: None,
+                parse_reliable: true, // haskell parses the signature shape cleanly
+                content_hash: None,
+                last_indexed_at: None,
+            });
+            result.edges.push(RawEdge {
+                from_qid: parent_qid.to_string(),
+                to_qid: qid,
+                kind: EdgeKind::Contains,
+            });
+        }
+    }
+}
+
+/// Find the innermost Template/Choice/Interface/Exception that contains
+/// the given (line, col). Returns its qid, or None if no such ancestor.
+fn enclosing_daml_anchor_qid(nodes: &[RawNode], line: u32, col: u32) -> Option<&str> {
+    let mut best: Option<&RawNode> = None;
+    for n in nodes {
+        let is_anchor = matches!(
+            n.kind,
+            NodeKind::Template | NodeKind::Choice | NodeKind::Interface | NodeKind::Exception
+        );
+        if !is_anchor { continue; }
+        let in_span = (n.start_line < line || (n.start_line == line && n.start_col <= col))
+            && (n.end_line > line || (n.end_line == line && n.end_col >= col));
+        if !in_span { continue; }
+        match best {
+            None => best = Some(n),
+            Some(b) => {
+                let n_size = (n.end_line - n.start_line) as i64;
+                let b_size = (b.end_line - b.start_line) as i64;
+                if n_size < b_size { best = Some(n); }
+            }
+        }
+    }
+    best.map(|n| n.qid.as_str())
+}
+```
+
+- [ ] **Step 5: Wire `pass_e_fields` at the END of `extract_daml`**
+
+```rust
+// REQUIRED ORDER: pass_e_fields runs LAST. Field extraction uses
+// `enclosing_daml_anchor_qid(&result.nodes, ...)` to disambiguate
+// with-block fields from top-level signatures. All of Template, Choice,
+// Interface, Exception must be in `result.nodes` before this runs;
+// otherwise the disambiguation lookup misses and either drops Fields
+// or assigns them wrong parents.
+//
+// pass_e_viewtypes ordering doesn't matter relative to fields
+// (Viewtypes can't contain Fields).
+pass_e_fields(&query, &tree, source, root_name, relative_path, &mut result);
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -15
+```
+
+Expected: 4 new tests pass. If the choice-fields test (`daml_choice_fields_qualified_under_template_and_choice`) fails because the haskell grammar doesn't expose choice `with`-blocks as signature nodes, mark the inner assertion `if let Some(field) = delta_field { ... }` as permissive (already in test); document the limitation.
+
+- [ ] **Step 7: Build + clippy + fmt**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+# Regression guard: confirm slice-9 Daml integration test still SKIPs cleanly
+# (it's the existing end-to-end test the extractor's structural changes could
+# break). Without env vars set, it just exits ok.
+cargo test --test integration_daml_index 2>&1 | tail -3
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/extraction/languages/daml.rs src/extraction/languages/daml.scm tests/extraction_unit.rs
+git commit -m "feat(extraction): Daml Field extraction with ancestor-span disambiguation"
+```
+
+---
+
+### Task 7: Delete regex Pass D + tiny-daml fixture extension + integration test
+
+**Files:**
+- Modify: `src/extraction/languages/daml.rs` (delete `pass_d_templates_and_choices` and its helpers)
+- Modify: `Cargo.toml` (drop `regex` dep if no longer used; check `pass_c_exercise_choices` first)
+- Create: `tests/fixtures/tiny-daml/Splice/Authorization.daml`
+- Modify: `tests/integration_daml_index.rs`
+
+- [ ] **Step 1: Verify whether `regex` is still needed**
+
+```bash
+grep -rn "use regex\|regex::" src/
+```
+
+Expected: `regex` still used in `pass_c_exercise_choices` (slice 9 task 8). Keep the dep. Do NOT remove from Cargo.toml.
+
+- [ ] **Step 2: Delete `pass_d_templates_and_choices` and helpers**
+
+In `src/extraction/languages/daml.rs`, remove:
+- The `pass_d_templates_and_choices` function entirely.
+- The `byte_to_line` helper if it's only used by `pass_d` (check with `grep`; if `pass_c_exercise_choices` still uses it, keep).
+- The unused regex compilations (template_re, choice_re for pass_d).
+- The call to `pass_d_templates_and_choices` in `extract_daml`.
+
+Re-run all tests to make sure nothing breaks:
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: all extraction_unit tests pass.
+
+- [ ] **Step 3: Create `tests/fixtures/tiny-daml/Splice/Authorization.daml`**
+
+```daml
+module Splice.Authorization where
+
+import Splice.Counter
+
+-- Interface with a viewtype.
+interface Authorizable where
+  viewtype AuthorizableView
+  getOwner : Party
+
+data AuthorizableView = AuthorizableView { owner : Party }
+
+-- Template implementing the interface, with signatory + observer + a choice.
+template AuthorizedCounter
+  with
+    owner : Party
+    delegate : Party
+    count : Int
+  where
+    signatory owner
+    observer delegate
+    interface instance Authorizable for AuthorizedCounter where
+      view = AuthorizableView { owner = owner }
+      getOwner = owner
+
+    choice Bump : ContractId AuthorizedCounter
+      controller delegate
+      do
+        create this with count = count + 1
+
+-- An exception.
+exception InsufficientBalance with
+    actual : Int
+    required : Int
+  where
+    message "Insufficient balance"
+```
+
+> **Daml-compile verification (per spec §5.1):**
+>
+> **If `daml` CLI is installed:** run `which daml && daml damlc validate tests/fixtures/tiny-daml/Splice/Authorization.daml` (or `daml build --project-root <fixture-dir>`). If it fails on the `interface instance ... for ... where` syntax (pre-2.7 Daml), switch to the pre-2.7 top-level `instance` declaration form and re-test.
+>
+> **If `daml` is not installed:** add a comment at the top of `Authorization.daml` documenting the target version:
+>
+> ```daml
+> -- Targets Daml 2.7+. The `interface instance ... for ... where` syntax inside
+> -- a template body is the post-2.7 form; pre-2.7 uses a separate top-level
+> -- `instance` declaration. If you're on pre-2.7, this fixture won't typecheck —
+> -- but the codegraph-rs extractor doesn't care (it's regex/AST-anchored on the
+> -- keyword tokens, not the typechecker output). The integration test against
+> -- Neo4j is the real correctness gate; this fixture compiling cleanly is a
+> -- nice-to-have.
+> ```
+>
+> Then proceed without compile verification; the integration test (Task 7 Step 4) is the actual correctness gate.
+
+- [ ] **Step 4: Extend `tests/integration_daml_index.rs`**
+
+Read the existing test (slice 9). Update the assertions to include the new fixture:
+
+```rust
+let file_count: i64 = scalar(&conn, "MATCH (n:File) RETURN count(n) AS c").await;
+let module_count: i64 = scalar(&conn, "MATCH (n:Module) RETURN count(n) AS c").await;
+let template_count: i64 = scalar(&conn, "MATCH (n:Template) RETURN count(n) AS c").await;
+let choice_count: i64 = scalar(&conn, "MATCH (n:Choice) RETURN count(n) AS c").await;
+let function_count: i64 = scalar(&conn, "MATCH (n:Function) RETURN count(n) AS c").await;
+let type_alias_count: i64 = scalar(&conn, "MATCH (n:TypeAlias) RETURN count(n) AS c").await;
+let import_count: i64 = scalar(&conn, "MATCH (n:Import) RETURN count(n) AS c").await;
+let interface_count: i64 = scalar(&conn, "MATCH (n:Interface) RETURN count(n) AS c").await;
+let viewtype_count: i64 = scalar(&conn, "MATCH (n:Viewtype) RETURN count(n) AS c").await;
+let exception_count: i64 = scalar(&conn, "MATCH (n:Exception) RETURN count(n) AS c").await;
+let field_count: i64 = scalar(&conn, "MATCH (n:Field) RETURN count(n) AS c").await;
+
+assert_eq!(file_count, 4, "expected 4 File nodes (Math, Counter, Driver, Authorization)");
+assert_eq!(module_count, 4);
+assert_eq!(template_count, 2, "expected 2 Templates (Counter, AuthorizedCounter)");
+assert!(choice_count >= 3, "expected ≥3 Choices (Increment, Reset, Bump)");
+assert_eq!(interface_count, 1, "expected 1 Interface (Authorizable)");
+assert_eq!(viewtype_count, 1, "expected 1 Viewtype (AuthorizableView)");
+assert_eq!(exception_count, 1, "expected 1 Exception (InsufficientBalance)");
+// Expected Fields, broken down by source so the lower bound is defensible:
+//   - Counter (slice 9 fixture): owner, count                              -> 2
+//   - AuthorizedCounter (this slice): owner, delegate, count               -> 3
+//   - InsufficientBalance: actual, required                                -> 2
+//   - Authorizable interface: getOwner (method-as-field)                   -> 1
+//   - Bump choice with-block: usually none in this fixture                 -> 0-1
+// Minimum guaranteed: 8. If the haskell grammar declines to expose any of
+// the above (real risk per slice 6's single-colon finding), the bound drops.
+// Use >= 6 to tolerate up to two missed fields while still catching wholesale
+// extraction failures.
+assert!(field_count >= 6,
+    "expected ≥6 Fields across all templates/choices/interfaces/exceptions; got {field_count}");
+
+// Named-symbol assertions for new constructs.
+let auth_field_owner: i64 = scalar(&conn,
+    "MATCH (n:Field {qualified_name: 'Splice.Authorization.AuthorizedCounter.owner'}) RETURN count(n) AS c").await;
+assert_eq!(auth_field_owner, 1);
+
+let interface_name: String = string_scalar(&conn,
+    "MATCH (i:Interface) RETURN i.qualified_name AS c LIMIT 1").await;
+assert_eq!(interface_name, "Splice.Authorization.Authorizable");
+
+// All Templates carry parse_reliable=false.
+let unreliable_templates: i64 = scalar(&conn,
+    "MATCH (t:Template) WHERE t.parse_reliable = false RETURN count(t) AS c").await;
+assert_eq!(unreliable_templates, template_count, "all Templates parse_reliable=false");
+
+// Fields carry parse_reliable=true.
+let reliable_fields: i64 = scalar(&conn,
+    "MATCH (f:Field) WHERE f.parse_reliable = true RETURN count(f) AS c").await;
+assert_eq!(reliable_fields, field_count, "all Fields parse_reliable=true");
+
+// Embedding inheritance (spec §5.4): Interfaces are embed-eligible per the
+// updated EMBED_KINDS_CYPHER_LIST. Under the dual gate (CODEGRAPH_RS_TEST_NEO4J
+// + CODEGRAPH_RS_TEST_EMBEDDINGS), the embedding pipeline should populate
+// `n.embedding` on every Interface. We assert this without gating: when only
+// CODEGRAPH_RS_TEST_NEO4J is set, vectors::run skips (embeddings disabled
+// by config? no — the test fixture has the default config which enables
+// embeddings, but model load is skipped if CODEGRAPH_RS_TEST_EMBEDDINGS is
+// unset). The assertion is conditional on EMBEDDINGS being set:
+if std::env::var("CODEGRAPH_RS_TEST_EMBEDDINGS").as_deref() == Ok("1") {
+    let embedded_interfaces: i64 = scalar(&conn,
+        "MATCH (i:Interface) WHERE i.embedding IS NOT NULL RETURN count(i) AS c").await;
+    assert!(embedded_interfaces >= 1,
+        "interfaces should be embedded by slice 7's pipeline when CODEGRAPH_RS_TEST_EMBEDDINGS=1");
+}
+```
+
+Add the `string_scalar` helper if it doesn't already exist:
+
+```rust
+async fn string_scalar(conn: &codegraph_rs::db::Connection, cypher: &str) -> String {
+    let mut stream = conn.graph.execute(query(cypher)).await.unwrap();
+    let row = stream.next().await.unwrap().unwrap();
+    row.get::<String>("c").unwrap()
+}
+```
+
+- [ ] **Step 5: Verify SKIP path**
+
+```bash
+cargo test --test integration_daml_index 2>&1 | tail -10
+```
+
+Expected: 1 test, SKIPs (no env vars), result ok.
+
+- [ ] **Step 6: Build + clippy + fmt + full test suite (SKIP)**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -10
+```
+
+Expected: all tests pass.
+
+**Test count math.** Baseline: 97. New unit tests by task: Task 1 +4, Task 2 +2, Task 3 +2, Task 4 +4, Task 5 +2, Task 6 +4. Total new unit tests: 18. New integration test: 0 (extends existing `integration_daml_index`). **Final expected count: 115** (97 + 18).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/extraction/languages/daml.rs tests/fixtures/tiny-daml/Splice/Authorization.daml tests/integration_daml_index.rs
+git commit -m "feat(extraction): delete regex pass_d; add Authorization.daml fixture + extended integration assertions"
+```
+
+---
+
+### Task 8: README + slice-10a-daml-structure tag
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Read current README.md** to find the `## Status` section.
+
+- [ ] **Step 2: Bump the Status section**
+
+Replace the current Status block with:
+
+```markdown
+## Status
+
+In development. Currently implements **Slice 10a: Daml structure +
+fields** — workspace initialization, indexing, resolution, incremental
+sync, on-write embeddings, a stdio MCP server exposing 10 tools, and
+Rust + Daml extraction. The Daml extractor now uses tree-sitter
+queries (filtered by Daml keyword text) instead of regex for templates,
+choices, interfaces, viewtypes, exceptions; with-block fields are
+first-class CONTAINS-children of their parent Template/Choice/Interface.
+Authorization edges (signatory/controller/observer/implements/requires)
+land in slice 10b.
+
+Daml templates and choices still carry `parse_reliable = false` (the
+keyword anchors are text-matched against haskell's variable parses),
+but their internal fields carry `parse_reliable = true` and their spans
+are byte-precise (no longer line-approximated).
+```
+
+Quick start, Development sections need no changes.
+
+- [ ] **Step 3: Final test suite**
+
+```bash
+cargo test 2>&1 | tail -20
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+```
+
+Expected: all tests pass. Final test count target: **115** (97 baseline + 4 from Task 1 + 2 from Task 2 + 2 from Task 3 + 4 from Task 4 + 2 from Task 5 + 4 from Task 6).
+
+- [ ] **Step 4: Commit and tag**
+
+```bash
+git add README.md
+git commit -m "docs: update README for slice 10a (Daml structure + fields)"
+git tag slice-10a-daml-structure
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+git log --oneline | head -15
+git tag --list
+```
+
+Expected tags include `slice-10a-daml-structure`.
+
+---
+
+## Slice 10a Done
+
+- [ ] `cargo build` clean (no new dependencies; just code changes)
+- [ ] `cargo test` (no env vars) — all unit tests pass; integration tests SKIP cleanly
+- [ ] `CODEGRAPH_RS_TEST_NEO4J=1 cargo test -- --test-threads=1` — all tests pass, including extended `integration_daml_index` against the Authorization.daml fixture
+- [ ] `CODEGRAPH_RS_TEST_NEO4J=1 CODEGRAPH_RS_TEST_EMBEDDINGS=1 cargo test -- --test-threads=1` — embeddings test still passes; Interface/Viewtype/Exception nodes get 384-dim embeddings automatically
+- [ ] Manual: `codegraph-rs index` on a real Daml workspace (Splice or daml-finance) — verify in Neo4j Browser:
+  - `MATCH (i:Interface) RETURN count(i)` returns non-zero
+  - `MATCH (t:Template)-[:CONTAINS]->(f:Field) RETURN count(*)` returns non-zero
+  - `MATCH (t:Template) WHERE t.parse_reliable = false RETURN count(t)` matches total Template count
+  - `MATCH (f:Field) WHERE f.parse_reliable = true RETURN count(f)` matches total Field count
+- [ ] No regression of slice 9 functionality — existing Counter.daml fixture still produces the same Template, Choice, Function counts
+- [ ] `pass_d_templates_and_choices` regex function is gone
+
+When all check, slice 10a is complete. **Next slice: 10b (Daml authorization edges)** — signatory/controller/observer party-expression edges, implements/requires interface-relationship edges, the `scope_qid` resolution path.
+
+### Small follow-ups noted during this slice
+
+- **Interface methods may need NodeKind::Method instead of Field.** Currently `getOwner : Party` inside an interface is emitted as a Field, but semantically it's closer to a Method (function signature with no body). Slice 10b or 10c could split: Field for `with`-block bindings, Method for interface method signatures.
+- **Choice with-block extraction depends on grammar exposure.** If the haskell grammar doesn't expose the `with` block inside a choice as a queryable signature shape, the `daml_choice_fields_qualified_under_template_and_choice` test stays permissive. Worth probing the grammar in slice 10b to see if a regex fallback (similar to slice 9's exercise-choices pass) is needed.
+- **`pass_e_*` naming.** Slice 10a accumulates pass_e_templates / pass_e_choices / pass_e_interfaces / pass_e_viewtypes / pass_e_exceptions / pass_e_fields. The naming convention is messy at this point. A future cleanup slice could collapse these into a single `pass_e_daml_keyword_anchors` driven by a (keyword, NodeKind, parent-finder) table.

--- a/docs/superpowers/plans/2026-05-18-codegraph-rs-slice-10b-daml-edges.md
+++ b/docs/superpowers/plans/2026-05-18-codegraph-rs-slice-10b-daml-edges.md
@@ -1,0 +1,1602 @@
+# codegraph-rs Slice 10b — Daml authorization edges
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `signatory`/`controller`/`observer` party expressions, `implements` declarations, and `requires` declarations from Daml templates and interfaces. Resolve identifier-shaped operands to the Field Symbols of their enclosing Template (preferred) or workspace-wide Symbols (fallback). Add 5 new EdgeKinds (`SIGNATORY`, `CONTROLLER`, `OBSERVER`, `IMPLEMENTS`, `REQUIRES`), 5 new `UnresolvedKind` variants, a new `scope_qid` field on `UnresolvedRef`, and a new resolution Phase A.5 (scoped name match).
+
+**Architecture:** Mirror slice 10a's tree-sitter-and-tree-walk pattern: keyword-anchored `(apply function: (variable "signatory") argument: <expr>)` matches → walk the argument subtree for identifier leaves, filter wrapper names (`Set.fromList`, `fromOptional`, `$`, etc.) → emit one `UnresolvedRef` per identifier with `kind` set to the appropriate edge type, `source_qid` = enclosing Template/Choice/Interface, `scope_qid` = enclosing Template. Resolution gains a Phase A.5 between Phase A and Phase B that builds a `HashMap<qualified_name, qid>` once and resolves party refs by looking up `<scope_qname>.<unresolved_name>`. Falls through to Phase C on miss.
+
+**Tech Stack additions:** None. All primitives (tree-sitter, neo4rs, regex) are already in tree.
+
+**Source spec:** [`docs/superpowers/specs/2026-05-15-codegraph-rs-v2-daml-depth-design.md`](../specs/2026-05-15-codegraph-rs-v2-daml-depth-design.md) §2.2, §2.3, §3.3, §4, §5, §7.2.
+
+**Slice 10a baseline:** tag `slice-10a-daml-structure` at HEAD `d3df454` on `main`. 118 unit tests pass; live integration test against Neo4j passes (4 daml files → 31 nodes, 51 edges).
+
+---
+
+## What this slice does, conceptually
+
+1. **Add 5 new `EdgeKind` variants** (SIGNATORY, CONTROLLER, OBSERVER, IMPLEMENTS, REQUIRES). The `as_relationship_type()` method returns the Cypher names. The Neo4j schema is unchanged — relationship types are open.
+
+2. **Add 5 new `UnresolvedKind` variants** matching the new edges. Stored as a string in `UnresolvedRef.kind`.
+
+3. **Add `scope_qid: Option<String>` to `UnresolvedRef`.** For party-edge refs (Signatory/Controller/Observer), `scope_qid` is the enclosing Template's qid. The write path (`src/db/write.rs::write_unresolved_refs`) gains a new column. Old v1 records lack the property; reading returns `None` — additive at the Neo4j layer.
+
+4. **New extractor passes** in `src/extraction/languages/daml.rs`:
+   - `pass_e_party_edges` — handles signatory/controller/observer keyword anchors. Walks the argument subtree for identifier leaves, filters known wrapper names, emits one `UnresolvedRef` per leaf.
+   - `pass_e_interface_edges` — handles `implements` and `requires` keyword anchors. Single-constructor argument; emits one `UnresolvedRef` per match.
+
+5. **New resolution phase A.5** in `src/resolution/`:
+   - `phase_a5_scoped_match.rs` (new file). Builds a `HashMap<qualified_name, qid>` from `MATCH (s:Symbol) RETURN s.qualified_name, s.qid`. For each `UnresolvedRef` with `scope_qid: Some(s)` AND `kind` in {Signatory, Controller, Observer, Implements, Requires}, looks up `<scope_qname>.<unresolved_name>`. On hit, emits the corresponding edge. On miss, leaves the ref for Phase C (name-match fallback) to handle for party kinds; Implements/Requires don't fall back.
+
+6. **Resolution orchestrator wiring** (`src/resolution/mod.rs`): Phase A.5 runs between Phase A and Phase B. `ResolutionStats` gains counters for the new edge kinds.
+
+7. **Integration test extensions** assert SIGNATORY/CONTROLLER/OBSERVER/IMPLEMENTS edges land on the Authorization.daml fixture (REQUIRES is exercised by a small fixture addition since the current fixture doesn't have interface-requires-interface).
+
+8. **README bump + tag**.
+
+---
+
+## Out of scope for slice 10b
+
+- `interface instance ... for ... where` body extraction (the `view = ...` and method bodies inside an instance). The `interface instance` keyword DOES anchor an `IMPLEMENTS` edge; the body is not parsed.
+- `agreement`, `ensure`, `message` (template/exception body expressions) — keyword anchors only; future slice.
+- `key`/`maintainer` — deprecated in Daml 2.x, dropped per spec §1.3.
+- Resolution Phase C tightening for party kinds — current Phase C name-match handles cross-scope party refs adequately for v2.0.
+- Cross-package interface resolution (Daml multi-DAR scenarios).
+
+---
+
+## Critical implementation notes from slice 10a
+
+- The Daml extractor uses a mix of tree-sitter queries (`daml.scm`) and pure Rust tree walks (`pass_e_fields` discovered the parse shapes were too irregular for a clean SCM pattern).
+- A `PassCtx<'_>` struct consolidates common parameters (root_name, relative_path, file_qid, etc.) — verify the actual signature with `grep "struct PassCtx" src/extraction/languages/daml.rs` before writing new passes.
+- Helpers available: `enclosing_template_qid`, `enclosing_interface_qid`, `enclosing_daml_anchor_qid`, `first_identifier_in_subtree`.
+- The grammar parses Daml keywords as `(variable)` nodes inside ERROR-wrapped contexts. Templates have 3 parse shapes (A, B, C). Interfaces have 2 (simple ERROR-direct, nested apply chains). Expect signatory/controller/observer to also have multiple shapes.
+- A `Function` node named `"template"` was emitted spuriously by the Function extractor when complex templates parse as haskell `function` nodes. Slice 10a's bugfix added a keyword filter in `pass_c_definitions` to skip Daml-keyword function names. The same filter likely needs extension for `signatory`/`controller`/`observer`/`implements`/`requires` if probe shows they similarly leak through.
+
+---
+
+## File structure produced by this slice
+
+```
+codegraph-rs/
+  src/
+    extraction/
+      result.rs                                # MODIFY: EdgeKind variants (5), UnresolvedKind variants (5), scope_qid field
+    db/
+      write.rs                                 # MODIFY: write_unresolved_refs adds scope_qid column
+    extraction/
+      languages/
+        daml.rs                                # MODIFY: pass_e_party_edges + pass_e_interface_edges + keyword filter
+        daml.scm                               # MODIFY: signatory/controller/observer/implements/requires queries
+    resolution/
+      mod.rs                                   # MODIFY: orchestrate Phase A.5 + stats fields
+      phase_a5_scoped_match.rs                 # NEW: scoped party + implements/requires resolution
+  tests/
+    extraction_unit.rs                         # MODIFY: ~12 new unit tests
+    integration_daml_index.rs                  # MODIFY: Cypher assertions for new edge kinds
+  README.md                                    # MODIFY: bump Status to slice 10b
+```
+
+---
+
+### Task 1: New `EdgeKind` and `UnresolvedKind` variants
+
+**Files:**
+- Modify: `src/extraction/result.rs`
+- Modify: `tests/extraction_unit.rs`
+
+- [ ] **Step 1: Append failing tests to `tests/extraction_unit.rs`**
+
+```rust
+#[test]
+fn edgekind_signatory_relationship_type() {
+    assert_eq!(EdgeKind::Signatory.as_relationship_type(), "SIGNATORY");
+}
+
+#[test]
+fn edgekind_controller_relationship_type() {
+    assert_eq!(EdgeKind::Controller.as_relationship_type(), "CONTROLLER");
+}
+
+#[test]
+fn edgekind_observer_relationship_type() {
+    assert_eq!(EdgeKind::Observer.as_relationship_type(), "OBSERVER");
+}
+
+#[test]
+fn edgekind_implements_relationship_type() {
+    assert_eq!(EdgeKind::Implements.as_relationship_type(), "IMPLEMENTS");
+}
+
+#[test]
+fn edgekind_requires_relationship_type() {
+    assert_eq!(EdgeKind::Requires.as_relationship_type(), "REQUIRES");
+}
+
+#[test]
+fn unresolvedkind_signatory_str() {
+    assert_eq!(UnresolvedKind::Signatory.as_str(), "Signatory");
+}
+
+#[test]
+fn unresolvedkind_controller_str() {
+    assert_eq!(UnresolvedKind::Controller.as_str(), "Controller");
+}
+
+#[test]
+fn unresolvedkind_observer_str() {
+    assert_eq!(UnresolvedKind::Observer.as_str(), "Observer");
+}
+
+#[test]
+fn unresolvedkind_implements_str() {
+    assert_eq!(UnresolvedKind::Implements.as_str(), "Implements");
+}
+
+#[test]
+fn unresolvedkind_requires_str() {
+    assert_eq!(UnresolvedKind::Requires.as_str(), "Requires");
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+cd /Users/gyorgybalazsi/codegraph-rs
+cargo test --test extraction_unit 2>&1 | tail -10
+```
+
+Expected: compile errors — new variants not defined.
+
+- [ ] **Step 3: Add `EdgeKind` variants in `src/extraction/result.rs`**
+
+Read the existing `EdgeKind` enum. Add the five new variants after the existing ones (alphabetical or grouped — match the existing convention; slice 9's enum has `Contains, HasRef, Imports, Calls, References, TypeOf` so probably grouped by domain).
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EdgeKind {
+    Contains,
+    HasRef,
+    Imports,
+    Calls,
+    References,
+    TypeOf,
+    /// `signatory <party-expr>` on a Template. Source: Template, Target: Field or Symbol.
+    Signatory,
+    /// `controller <party-expr>` on a Choice. Source: Choice, Target: Field or Symbol.
+    Controller,
+    /// `observer <party-expr>` on a Template. Source: Template, Target: Field or Symbol.
+    Observer,
+    /// `interface instance I for T where ...` — Template implements Interface.
+    Implements,
+    /// `interface I requires J where ...` — Interface requires Interface.
+    Requires,
+}
+```
+
+Extend `as_relationship_type`:
+
+```rust
+impl EdgeKind {
+    pub fn as_relationship_type(self) -> &'static str {
+        match self {
+            EdgeKind::Contains => "CONTAINS",
+            EdgeKind::HasRef => "HAS_REF",
+            EdgeKind::Imports => "IMPORTS",
+            EdgeKind::Calls => "CALLS",
+            EdgeKind::References => "REFERENCES",
+            EdgeKind::TypeOf => "TYPE_OF",
+            EdgeKind::Signatory => "SIGNATORY",
+            EdgeKind::Controller => "CONTROLLER",
+            EdgeKind::Observer => "OBSERVER",
+            EdgeKind::Implements => "IMPLEMENTS",
+            EdgeKind::Requires => "REQUIRES",
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add `UnresolvedKind` variants in the same file**
+
+Find the `UnresolvedKind` enum. Add five new variants after the existing `Call, TypeRef, Import, Reference` (or whatever exists):
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UnresolvedKind {
+    Call,
+    TypeRef,
+    Import,
+    Reference,
+    Signatory,
+    Controller,
+    Observer,
+    Implements,
+    Requires,
+}
+```
+
+Extend `as_str`:
+
+```rust
+impl UnresolvedKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UnresolvedKind::Call => "Call",
+            UnresolvedKind::TypeRef => "TypeRef",
+            UnresolvedKind::Import => "Import",
+            UnresolvedKind::Reference => "Reference",
+            UnresolvedKind::Signatory => "Signatory",
+            UnresolvedKind::Controller => "Controller",
+            UnresolvedKind::Observer => "Observer",
+            UnresolvedKind::Implements => "Implements",
+            UnresolvedKind::Requires => "Requires",
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Build + clippy + fmt + test**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+```
+
+Expected: 128 tests pass (118 baseline + 10 new label tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/extraction/result.rs tests/extraction_unit.rs
+git commit -m "feat(extraction): add Signatory/Controller/Observer/Implements/Requires Edge+Unresolved kinds"
+```
+
+---
+
+### Task 2: `UnresolvedRef.scope_qid: Option<String>` field + DB write path
+
+**Files:**
+- Modify: `src/extraction/result.rs`
+- Modify: `src/db/write.rs`
+- Modify: `tests/extraction_unit.rs`
+
+The `UnresolvedRef` struct gains a new field `scope_qid: Option<String>`. The Neo4j write path (`write_unresolved_refs`) writes this as a new property. Reading is automatic (`row.get::<Option<String>>("scope_qid")`).
+
+- [ ] **Step 1: Append failing test**
+
+```rust
+#[test]
+fn unresolved_ref_scope_qid_default_is_none() {
+    let r = UnresolvedRef {
+        qid: "x".to_string(),
+        source_qid: "src".to_string(),
+        unresolved_name: "n".to_string(),
+        kind: UnresolvedKind::Call,
+        line: 1,
+        col: 0,
+        scope_qid: None,
+    };
+    assert_eq!(r.scope_qid, None);
+}
+
+#[test]
+fn unresolved_ref_scope_qid_can_be_set() {
+    let r = UnresolvedRef {
+        qid: "x".to_string(),
+        source_qid: "src".to_string(),
+        unresolved_name: "owner".to_string(),
+        kind: UnresolvedKind::Signatory,
+        line: 1,
+        col: 0,
+        scope_qid: Some("u:Foo.daml:Foo.Counter".to_string()),
+    };
+    assert_eq!(r.scope_qid.as_deref(), Some("u:Foo.daml:Foo.Counter"));
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+cargo test --test extraction_unit unresolved_ref_scope 2>&1 | tail -10
+```
+
+Expected: compile error — `scope_qid` field doesn't exist.
+
+- [ ] **Step 3: Add `scope_qid` to `UnresolvedRef`**
+
+In `src/extraction/result.rs`, find the `UnresolvedRef` struct:
+
+```rust
+#[derive(Debug, Clone)]
+pub struct UnresolvedRef {
+    pub qid: String,
+    pub source_qid: String,
+    pub unresolved_name: String,
+    pub kind: UnresolvedKind,
+    pub line: u32,
+    pub col: u32,
+    /// For party-edge refs (Signatory/Controller/Observer), this is the qid of
+    /// the enclosing Template. Resolution Phase A.5 uses it to scope name
+    /// lookup: `<scope_qid_qname>.<unresolved_name>` resolves first against
+    /// the Template's Field children. For other ref kinds (Call/TypeRef/Import/
+    /// Reference/Implements/Requires), typically `None`.
+    pub scope_qid: Option<String>,
+}
+```
+
+- [ ] **Step 4: Find all `UnresolvedRef { ... }` constructions in the codebase**
+
+Search:
+
+```bash
+grep -rn "UnresolvedRef {" src/ tests/
+```
+
+Each construction will fail to compile with the new field. Add `scope_qid: None` to every existing construction. There are constructions in:
+- `src/extraction/languages/daml.rs` (slice 9's pass_b_imports, pass_c_call_sites, pass_c_exercise_choices)
+- `src/extraction/languages/rust.rs` (slice 2's call-site extraction)
+
+For each, add `scope_qid: None,` as the last field.
+
+- [ ] **Step 5: Update `write_unresolved_refs` in `src/db/write.rs`**
+
+The Cypher batch currently looks like:
+
+```rust
+let cypher_text = "\
+    UNWIND $batch AS row \
+    MERGE (n:UnresolvedRef {qid: row.qid}) \
+    SET n.source_qid = row.source_qid, \
+        n.unresolved_name = row.unresolved_name, \
+        n.kind = row.kind, \
+        n.line = row.line, \
+        n.col = row.col";
+```
+
+Extend to include `scope_qid`:
+
+```rust
+let cypher_text = "\
+    UNWIND $batch AS row \
+    MERGE (n:UnresolvedRef {qid: row.qid}) \
+    SET n.source_qid = row.source_qid, \
+        n.unresolved_name = row.unresolved_name, \
+        n.kind = row.kind, \
+        n.line = row.line, \
+        n.col = row.col, \
+        n.scope_qid = row.scope_qid";
+```
+
+And update `ref_to_json`:
+
+```rust
+fn ref_to_json(r: &UnresolvedRef) -> Value {
+    let mut m = Map::new();
+    m.insert("qid".into(), r.qid.clone().into());
+    m.insert("source_qid".into(), r.source_qid.clone().into());
+    m.insert("unresolved_name".into(), r.unresolved_name.clone().into());
+    m.insert("kind".into(), r.kind.as_str().into());
+    m.insert("line".into(), r.line.into());
+    m.insert("col".into(), r.col.into());
+    m.insert(
+        "scope_qid".into(),
+        r.scope_qid.clone().map(Value::String).unwrap_or(Value::Null),
+    );
+    Value::Object(m)
+}
+```
+
+> **On Cypher `SET n.x = NULL`:** Neo4j removes the property when set to null. So v1-era reads of `n.scope_qid` on records written without it return `null`; Rust deserialization gives `Option::None`. Backwards-compatible.
+
+- [ ] **Step 6: Build + test**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+cargo test --test integration_daml_index 2>&1 | tail -3
+```
+
+Expected: 130 tests pass (128 + 2 new). All existing UnresolvedRef constructions updated.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/extraction/result.rs src/db/write.rs src/extraction/languages/daml.rs src/extraction/languages/rust.rs tests/extraction_unit.rs
+git commit -m "feat(extraction): add UnresolvedRef.scope_qid for party-scoped name resolution"
+```
+
+---
+
+### Task 3: `signatory`/`controller`/`observer` extraction with multi-party decomposition (TDD)
+
+**Files:**
+- Modify: `src/extraction/languages/daml.scm`
+- Modify: `src/extraction/languages/daml.rs`
+- Modify: `tests/extraction_unit.rs`
+
+The keyword pattern is `signatory <expr>`, `controller <expr>`, `observer <expr>`. Each emits one or more `UnresolvedRef`s by walking the argument subtree for identifier leaves. The same pass handles all three keywords (only the `UnresolvedKind` differs).
+
+The multi-party decomposition rule (spec §3.3):
+- Collect every `(variable)` and `(constructor)` leaf inside the argument subtree.
+- Filter out known wrapper identifiers: `Set`, `fromList`, `fromOptional`, `fromSome`, `concat`, `concatMap`, the `$` operator (it's parsed as `operator` not variable, so won't appear in our leaf walk).
+- For each remaining identifier, emit one `UnresolvedRef`.
+
+Examples:
+
+| Daml expression | Refs emitted |
+|---|---|
+| `signatory owner` | 1: `owner` |
+| `signatory [owner, delegate]` | 2: `owner`, `delegate` |
+| `signatory $ Set.fromList [a, b]` | 2: `a`, `b` (`Set`/`fromList` filtered) |
+| `signatory $ fromOptional [] mObservers` | 1: `mObservers` (`fromOptional` filtered) |
+
+- [ ] **Step 1: Append failing tests**
+
+```rust
+#[test]
+fn daml_extracts_signatory_single_identifier() {
+    use codegraph_rs::extraction::result::UnresolvedKind;
+    let source = "module Foo where\n\ntemplate Counter\n  with\n    owner : Party\n  where\n    signatory owner\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let sigs: Vec<_> = result.unresolved_refs.iter()
+        .filter(|r| r.kind == UnresolvedKind::Signatory).collect();
+    assert_eq!(sigs.len(), 1, "expected 1 Signatory ref; got {:?}", sigs.iter().map(|r| &r.unresolved_name).collect::<Vec<_>>());
+    assert_eq!(sigs[0].unresolved_name, "owner");
+    let template_qid = &result.nodes.iter().find(|n| n.kind == NodeKind::Template).unwrap().qid;
+    assert_eq!(sigs[0].scope_qid.as_deref(), Some(template_qid.as_str()),
+        "scope_qid should be the enclosing Template qid");
+}
+
+#[test]
+fn daml_extracts_controller_inside_choice() {
+    use codegraph_rs::extraction::result::UnresolvedKind;
+    let source = "module Foo where\n\ntemplate Counter\n  with\n    owner : Party\n  where\n    signatory owner\n    choice Inc : ()\n      controller owner\n      do return ()\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let ctrls: Vec<_> = result.unresolved_refs.iter()
+        .filter(|r| r.kind == UnresolvedKind::Controller).collect();
+    assert_eq!(ctrls.len(), 1);
+    assert_eq!(ctrls[0].unresolved_name, "owner");
+    let template_qid = &result.nodes.iter().find(|n| n.kind == NodeKind::Template).unwrap().qid;
+    assert_eq!(ctrls[0].scope_qid.as_deref(), Some(template_qid.as_str()),
+        "controller's scope_qid is the enclosing Template (not the Choice)");
+}
+
+#[test]
+fn daml_extracts_observer() {
+    use codegraph_rs::extraction::result::UnresolvedKind;
+    let source = "module Foo where\n\ntemplate Counter\n  with\n    owner : Party\n    obs : Party\n  where\n    signatory owner\n    observer obs\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let obs: Vec<_> = result.unresolved_refs.iter()
+        .filter(|r| r.kind == UnresolvedKind::Observer).collect();
+    assert_eq!(obs.len(), 1);
+    assert_eq!(obs[0].unresolved_name, "obs");
+}
+
+#[test]
+fn daml_multi_party_list_decomposed_into_two_refs() {
+    use codegraph_rs::extraction::result::UnresolvedKind;
+    let source = "module Foo where\n\ntemplate Counter\n  with\n    owner : Party\n    delegate : Party\n  where\n    signatory [owner, delegate]\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let sigs: Vec<_> = result.unresolved_refs.iter()
+        .filter(|r| r.kind == UnresolvedKind::Signatory).collect();
+    assert_eq!(sigs.len(), 2, "list signatory emits 2 refs");
+    let names: Vec<&str> = sigs.iter().map(|r| r.unresolved_name.as_str()).collect();
+    assert!(names.contains(&"owner"));
+    assert!(names.contains(&"delegate"));
+}
+
+#[test]
+fn daml_multi_party_set_fromlist_filters_wrappers() {
+    use codegraph_rs::extraction::result::UnresolvedKind;
+    let source = "module Foo where\n\ntemplate Counter\n  with\n    a : Party\n    b : Party\n  where\n    signatory Set.fromList [a, b]\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let sigs: Vec<_> = result.unresolved_refs.iter()
+        .filter(|r| r.kind == UnresolvedKind::Signatory).collect();
+    let names: Vec<&str> = sigs.iter().map(|r| r.unresolved_name.as_str()).collect();
+    assert!(names.contains(&"a"), "a should be extracted; got {names:?}");
+    assert!(names.contains(&"b"));
+    assert!(!names.contains(&"Set"), "Set should be filtered as wrapper");
+    assert!(!names.contains(&"fromList"), "fromList should be filtered as wrapper");
+}
+
+#[test]
+fn daml_signatory_emits_has_ref_edge() {
+    use codegraph_rs::extraction::result::{EdgeKind, UnresolvedKind};
+    let source = "module Foo where\n\ntemplate Counter\n  with\n    owner : Party\n  where\n    signatory owner\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let sig = result.unresolved_refs.iter()
+        .find(|r| r.kind == UnresolvedKind::Signatory && r.unresolved_name == "owner")
+        .expect("signatory ref must exist");
+    // The HAS_REF edge goes from the source_qid (enclosing Template) to the
+    // UnresolvedRef qid, same as Call refs in slice 9.
+    assert!(result.edges.iter().any(|e|
+        e.kind == EdgeKind::HasRef && e.from_qid == sig.source_qid && e.to_qid == sig.qid));
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Expected: FAIL — no party extraction yet.
+
+- [ ] **Step 3: Probe `signatory owner` parse shape**
+
+Slice 10a found Daml keywords parse in multiple ERROR-wrapped shapes. Probe `signatory`:
+
+```rust
+#[test]
+#[ignore]
+fn probe_signatory_parse_shape() {
+    let source = "module Foo where\n\ntemplate Counter\n  with p : Party\n  where\n    signatory owner\n";
+    let tree = codegraph_rs::extraction::parser::parse_daml(source).unwrap();
+    print_tree(tree.root_node(), 0);
+}
+
+#[test]
+#[ignore]
+fn probe_signatory_list_parse_shape() {
+    let source = "module Foo where\n\ntemplate Counter\n  with p : Party\n  where\n    signatory [a, b]\n";
+    let tree = codegraph_rs::extraction::parser::parse_daml(source).unwrap();
+    print_tree(tree.root_node(), 0);
+}
+```
+
+(`print_tree` is in `tests/extraction_unit.rs` from slice 10a tasks 2-6.)
+
+Run: `cargo test --test extraction_unit probe_signatory_parse_shape -- --ignored --nocapture 2>&1 | head -100`
+
+Expected: `signatory owner` likely appears as an apply (similar to slice 10a's choice probe), where `signatory` is a variable and `owner` is the argument. The list form likely produces a list literal as the argument.
+
+**REMOVE these probe tests before commit.**
+
+- [ ] **Step 4: Add the party queries to `daml.scm`**
+
+Based on probe shapes:
+
+```scheme
+; Signatory anchor: `signatory <expr>`. The argument subtree is walked at
+; extraction time for identifier leaves (multi-party decomposition).
+((apply
+  function: (variable) @signatory.kw
+  argument: (_) @signatory.target) @signatory.def
+  (#eq? @signatory.kw "signatory"))
+
+; Controller anchor (inside a choice body): `controller <expr>`.
+((apply
+  function: (variable) @controller.kw
+  argument: (_) @controller.target) @controller.def
+  (#eq? @controller.kw "controller"))
+
+; Observer anchor: `observer <expr>`.
+((apply
+  function: (variable) @observer.kw
+  argument: (_) @observer.target) @observer.def
+  (#eq? @observer.kw "observer"))
+```
+
+Adapt to the actual parse shape if probe shows different (e.g., ERROR-direct shapes like Task 4 for Interface).
+
+- [ ] **Step 5: Add `pass_e_party_edges` to `src/extraction/languages/daml.rs`**
+
+Place after `pass_e_fields` (slice 10a's last extraction pass):
+
+```rust
+/// Wrapper identifiers that should be filtered out of party-expression walks.
+/// These are Daml stdlib functions/types that appear in patterns like
+/// `signatory $ Set.fromList [a, b]` but are NOT party identifiers themselves.
+const PARTY_WRAPPER_FILTERS: &[&str] = &[
+    "Set", "fromList", "fromOptional", "fromSome",
+    "concat", "concatMap", "map", "filter",
+    // Note: `$` is parsed as `operator`, not `variable`, so it won't appear in
+    // identifier-leaf walks. No need to filter it explicitly.
+];
+
+/// Extract all `(variable)` and `(constructor)` identifier leaves from a
+/// subtree, filtering out known wrapper names. Used for multi-party
+/// expression decomposition.
+fn party_identifiers_in_subtree(
+    node: tree_sitter::Node,
+    source: &[u8],
+    out: &mut Vec<(String, tree_sitter::Point)>,
+) {
+    if node.kind() == "variable" || node.kind() == "constructor" {
+        if let Ok(text) = node.utf8_text(source) {
+            let name = text.trim().to_string();
+            // Filter known stdlib wrappers.
+            if !PARTY_WRAPPER_FILTERS.contains(&name.as_str()) {
+                // Also filter qualified-name segments — when parser sees
+                // `Set.fromList`, it may emit either a single dotted-name
+                // identifier or two separate constructors/variables. Split on
+                // '.' and emit each segment that isn't a known wrapper.
+                for segment in name.split('.') {
+                    let seg = segment.trim();
+                    if !seg.is_empty() && !PARTY_WRAPPER_FILTERS.contains(&seg) {
+                        out.push((seg.to_string(), node.start_position()));
+                    }
+                }
+            }
+        }
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        party_identifiers_in_subtree(child, source, out);
+    }
+}
+
+/// Tree-sitter-based extraction of signatory/controller/observer party
+/// expressions. Each keyword anchor emits one or more UnresolvedRef per
+/// identifier leaf in the argument subtree.
+///
+/// scope_qid is the enclosing Template qid (NOT the Choice for controllers
+/// — controllers' party names typically refer to Template fields, not
+/// Choice fields).
+fn pass_e_party_edges(
+    query: &Query,
+    tree: &tree_sitter::Tree,
+    source: &str,
+    ctx: &PassCtx<'_>,
+    result: &mut ExtractionResult,
+) {
+    // Process each keyword (signatory / controller / observer) with the same
+    // shape-walking logic. The only differences are the capture names and
+    // the emitted UnresolvedKind.
+    let keywords: &[(&str, &str, UnresolvedKind)] = &[
+        ("signatory.def", "signatory.target", UnresolvedKind::Signatory),
+        ("controller.def", "controller.target", UnresolvedKind::Controller),
+        ("observer.def", "observer.target", UnresolvedKind::Observer),
+    ];
+
+    for (def_name, target_name, kind) in keywords {
+        let Some(def_idx) = query.capture_index_for_name(def_name) else { continue };
+        let Some(target_idx) = query.capture_index_for_name(target_name) else { continue };
+
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
+
+        let mut pending: Vec<(tree_sitter::Node, tree_sitter::Node)> = Vec::new();
+        while let Some(m) = matches.next() {
+            let mut def_node = None;
+            let mut target_node = None;
+            for cap in m.captures {
+                if cap.index == def_idx { def_node = Some(cap.node); }
+                else if cap.index == target_idx { target_node = Some(cap.node); }
+            }
+            if let (Some(def), Some(target)) = (def_node, target_node) {
+                pending.push((def, target));
+            }
+        }
+
+        for (def, target) in pending {
+            // The enclosing scope is the Template (for signatory/observer)
+            // or the enclosing Template-of-the-Choice (for controller).
+            let pos = def.start_position();
+            let line = (pos.row as u32) + 1;
+            let col = pos.column as u32;
+            let template_qid = enclosing_template_qid(&result.nodes, line, col);
+            let Some(template_qid) = template_qid else { continue };
+            let template_qid = template_qid.to_string();
+
+            // source_qid for the ref differs by kind:
+            //   - signatory/observer: enclosing Template
+            //   - controller: enclosing Choice (the choice the controller belongs to)
+            let source_qid = if *kind == UnresolvedKind::Controller {
+                enclosing_choice_qid(&result.nodes, line, col)
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| template_qid.clone())
+            } else {
+                template_qid.clone()
+            };
+
+            // Walk the target subtree for identifier leaves.
+            let mut idents: Vec<(String, tree_sitter::Point)> = Vec::new();
+            party_identifiers_in_subtree(target, source.as_bytes(), &mut idents);
+
+            for (i, (name, pt)) in idents.iter().enumerate() {
+                let ref_line = (pt.row as u32) + 1;
+                let ref_col = pt.column as u32;
+                let qid = format!("{}:ref:{}:{}:{}:{}",
+                    source_qid, ref_line, ref_col, kind.as_str(), i);
+
+                result.unresolved_refs.push(UnresolvedRef {
+                    qid: qid.clone(),
+                    source_qid: source_qid.clone(),
+                    unresolved_name: name.clone(),
+                    kind: *kind,
+                    line: ref_line,
+                    col: ref_col,
+                    scope_qid: Some(template_qid.clone()),
+                });
+                result.edges.push(RawEdge {
+                    from_qid: source_qid.clone(),
+                    to_qid: qid,
+                    kind: EdgeKind::HasRef,
+                });
+            }
+        }
+    }
+}
+
+/// Find the smallest Choice node in `nodes` whose span contains (line, col).
+fn enclosing_choice_qid(nodes: &[RawNode], line: u32, col: u32) -> Option<&str> {
+    let mut best: Option<&RawNode> = None;
+    for n in nodes {
+        if n.kind != NodeKind::Choice { continue; }
+        let in_span = (n.start_line < line || (n.start_line == line && n.start_col <= col))
+            && (n.end_line > line || (n.end_line == line && n.end_col >= col));
+        if !in_span { continue; }
+        match best {
+            None => best = Some(n),
+            Some(b) => {
+                let n_size = (n.end_line - n.start_line) as i64;
+                let b_size = (b.end_line - b.start_line) as i64;
+                if n_size < b_size { best = Some(n); }
+            }
+        }
+    }
+    best.map(|n| n.qid.as_str())
+}
+```
+
+> **Adapt to `PassCtx<'_>`** — slice 10a tasks introduced this struct. Check the actual signature.
+
+> **Note on parse-shape variability**: if the probe shows `signatory owner` doesn't match the assumed `(apply function: (variable) argument: (variable))` shape, the implementer may need to add additional queries (Shape A/B/C style, like slice 10a tasks 2/4 did for templates/interfaces). The wrapper-filter and decomposition logic stays the same regardless.
+
+- [ ] **Step 6: Wire `pass_e_party_edges` in `extract_daml`**
+
+Add the call AFTER `pass_e_fields` (which is currently last):
+
+```rust
+pass_e_party_edges(&query, &tree, source, &ctx, &mut result);
+```
+
+(Adapt args to match the PassCtx pattern.)
+
+- [ ] **Step 7: Run tests**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -15
+```
+
+Expected: 6 new tests pass.
+
+- [ ] **Step 8: Build + clippy + fmt + regression check**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+cargo test --test integration_daml_index 2>&1 | tail -3
+```
+
+- [ ] **Step 9: REMOVE probe tests, then commit**
+
+```bash
+grep -n "probe_signatory_parse_shape\|probe_signatory_list_parse_shape" tests/extraction_unit.rs
+# Expected: no output
+
+git add src/extraction/languages/daml.rs src/extraction/languages/daml.scm tests/extraction_unit.rs
+git commit -m "feat(extraction): Daml signatory/controller/observer party-expression extraction"
+```
+
+---
+
+### Task 4: `implements`/`requires` extraction (TDD)
+
+**Files:**
+- Modify: `src/extraction/languages/daml.scm`
+- Modify: `src/extraction/languages/daml.rs`
+- Modify: `tests/extraction_unit.rs`
+
+`implements` appears inside an `interface instance I for T where ...` clause. The keyword sequence anchors on `implements` (or alternatively, `instance` followed by a constructor) — probe required.
+
+`requires` appears in `interface I requires J where ...`. Single-constructor argument.
+
+Both emit `UnresolvedRef` with a single target constructor name.
+
+- [ ] **Step 1: Append failing tests**
+
+```rust
+#[test]
+fn daml_extracts_implements_inside_interface_instance() {
+    use codegraph_rs::extraction::result::UnresolvedKind;
+    // The `interface instance Bar for T where ...` syntax (Daml 2.7+).
+    let source = "module Foo where\n\ninterface Bar where\n  getOwner : Party\n\ntemplate Counter\n  with owner : Party\n  where\n    signatory owner\n    interface instance Bar for Counter where\n      getOwner = owner\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let imps: Vec<_> = result.unresolved_refs.iter()
+        .filter(|r| r.kind == UnresolvedKind::Implements).collect();
+    assert_eq!(imps.len(), 1, "expected 1 Implements ref; got {:?}", imps.iter().map(|r| &r.unresolved_name).collect::<Vec<_>>());
+    assert_eq!(imps[0].unresolved_name, "Bar");
+    // source_qid is the enclosing Template (not Interface — the IMPLEMENTS edge
+    // comes FROM the Template).
+    let template_qid = &result.nodes.iter().find(|n| n.kind == NodeKind::Template).unwrap().qid;
+    assert_eq!(imps[0].source_qid, *template_qid);
+}
+
+#[test]
+fn daml_extracts_requires_between_interfaces() {
+    use codegraph_rs::extraction::result::UnresolvedKind;
+    let source = "module Foo where\n\ninterface Base where\n  getId : Int\n\ninterface Sub requires Base where\n  getName : Text\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let reqs: Vec<_> = result.unresolved_refs.iter()
+        .filter(|r| r.kind == UnresolvedKind::Requires).collect();
+    assert_eq!(reqs.len(), 1);
+    assert_eq!(reqs[0].unresolved_name, "Base");
+    // source_qid is the requiring Interface (Sub).
+    let sub_qid = &result.nodes.iter()
+        .find(|n| n.kind == NodeKind::Interface && n.name == "Sub")
+        .unwrap().qid;
+    assert_eq!(reqs[0].source_qid, *sub_qid);
+}
+
+#[test]
+fn daml_implements_emits_has_ref_edge() {
+    use codegraph_rs::extraction::result::{EdgeKind, UnresolvedKind};
+    let source = "module Foo where\n\ninterface Bar where\n  x : Int\n\ntemplate T\n  with owner : Party\n  where\n    signatory owner\n    interface instance Bar for T where\n      x = 1\n";
+    let result = extract_daml(source, "u", "Foo.daml").expect("ok");
+    let imp = result.unresolved_refs.iter()
+        .find(|r| r.kind == UnresolvedKind::Implements).expect("implements ref");
+    assert!(result.edges.iter().any(|e|
+        e.kind == EdgeKind::HasRef && e.from_qid == imp.source_qid && e.to_qid == imp.qid));
+}
+```
+
+- [ ] **Step 2: Probe `implements` and `requires` shapes**
+
+```rust
+#[test]
+#[ignore]
+fn probe_implements_parse_shape() {
+    let source = "module Foo where\n\ninterface Bar where\n  getOwner : Party\n\ntemplate Counter\n  with owner : Party\n  where\n    signatory owner\n    interface instance Bar for Counter where\n      getOwner = owner\n";
+    let tree = codegraph_rs::extraction::parser::parse_daml(source).unwrap();
+    print_tree(tree.root_node(), 0);
+}
+
+#[test]
+#[ignore]
+fn probe_requires_parse_shape() {
+    let source = "module Foo where\n\ninterface Base where\n  x : Int\n\ninterface Sub requires Base where\n  y : Int\n";
+    let tree = codegraph_rs::extraction::parser::parse_daml(source).unwrap();
+    print_tree(tree.root_node(), 0);
+}
+```
+
+Run and document the shapes. `implements` may show up as `variable "interface"` followed by `variable "instance"` followed by `constructor "Bar"` inside the same ERROR — the implementer must work out the right query.
+
+**REMOVE probe tests before commit.**
+
+- [ ] **Step 3: Add `implements` and `requires` queries to `daml.scm`**
+
+Likely shapes:
+
+```scheme
+; Implements: `interface instance Bar for T where ...` (Daml 2.7+).
+; The `interface instance` keyword pair is followed by a constructor.
+((apply
+  function: (variable) @implements.kw
+  argument: (constructor) @implements.interface) @implements.def
+  (#eq? @implements.kw "instance"))
+
+; Requires: `interface Sub requires Base where ...`.
+((apply
+  function: (variable) @requires.kw
+  argument: (constructor) @requires.interface) @requires.def
+  (#eq? @requires.kw "requires"))
+```
+
+Adapt to actual probe output. If the parse for `interface instance Bar for T` has `instance` as the keyword anchor with `Bar` as direct constructor argument, the query above works. If `for T` confuses the parse, more work needed.
+
+- [ ] **Step 4: Add `pass_e_interface_edges` to `daml.rs`**
+
+```rust
+/// Tree-sitter-based extraction of `interface instance ... for ... where ...`
+/// (implements) and `interface ... requires ... where ...` (requires) clauses.
+///
+/// implements: source_qid = enclosing Template, target = constructor name (Interface).
+/// requires:   source_qid = enclosing Interface, target = constructor name (Interface).
+fn pass_e_interface_edges(
+    query: &Query,
+    tree: &tree_sitter::Tree,
+    source: &str,
+    ctx: &PassCtx<'_>,
+    result: &mut ExtractionResult,
+) {
+    let keywords: &[(&str, &str, UnresolvedKind, bool)] = &[
+        // (def_capture, target_capture, kind, source_is_template)
+        ("implements.def", "implements.interface", UnresolvedKind::Implements, true),
+        ("requires.def", "requires.interface", UnresolvedKind::Requires, false),
+    ];
+
+    for (def_name, target_name, kind, source_is_template) in keywords {
+        let Some(def_idx) = query.capture_index_for_name(def_name) else { continue };
+        let Some(target_idx) = query.capture_index_for_name(target_name) else { continue };
+
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
+
+        let mut pending: Vec<(tree_sitter::Node, String, tree_sitter::Point)> = Vec::new();
+        while let Some(m) = matches.next() {
+            let mut def_node = None;
+            let mut target_node = None;
+            for cap in m.captures {
+                if cap.index == def_idx { def_node = Some(cap.node); }
+                else if cap.index == target_idx { target_node = Some(cap.node); }
+            }
+            if let (Some(def), Some(target)) = (def_node, target_node) {
+                if let Ok(name) = target.utf8_text(source.as_bytes()) {
+                    let target_name = name.trim().to_string();
+                    if !target_name.is_empty() {
+                        pending.push((def, target_name, target.start_position()));
+                    }
+                }
+            }
+        }
+
+        for (def, target_name, pt) in pending {
+            let pos = def.start_position();
+            let line = (pos.row as u32) + 1;
+            let col = pos.column as u32;
+
+            // source_qid lookup depends on the edge kind.
+            let source_qid_opt = if *source_is_template {
+                enclosing_template_qid(&result.nodes, line, col).map(str::to_string)
+            } else {
+                enclosing_interface_qid(&result.nodes, line, col).map(str::to_string)
+            };
+            let Some(source_qid) = source_qid_opt else { continue };
+
+            let ref_line = (pt.row as u32) + 1;
+            let ref_col = pt.column as u32;
+            let qid = format!("{}:ref:{}:{}:{}:0",
+                source_qid, ref_line, ref_col, kind.as_str());
+
+            result.unresolved_refs.push(UnresolvedRef {
+                qid: qid.clone(),
+                source_qid: source_qid.clone(),
+                unresolved_name: target_name,
+                kind: *kind,
+                line: ref_line,
+                col: ref_col,
+                scope_qid: None, // these resolve workspace-wide, not scoped
+            });
+            result.edges.push(RawEdge {
+                from_qid: source_qid,
+                to_qid: qid,
+                kind: EdgeKind::HasRef,
+            });
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Wire `pass_e_interface_edges` in `extract_daml`**
+
+Add the call AFTER `pass_e_party_edges`:
+
+```rust
+pass_e_interface_edges(&query, &tree, source, &ctx, &mut result);
+```
+
+- [ ] **Step 6: Run tests, build, clippy, fmt, regression check**
+
+```bash
+cargo test --test extraction_unit 2>&1 | tail -10
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+cargo test --test integration_daml_index 2>&1 | tail -3
+```
+
+Expected: 133 tests pass (130 + 3 new).
+
+- [ ] **Step 7: REMOVE probe tests, then commit**
+
+```bash
+grep -n "probe_implements_parse_shape\|probe_requires_parse_shape" tests/extraction_unit.rs
+# Expected: no output
+
+git add src/extraction/languages/daml.rs src/extraction/languages/daml.scm tests/extraction_unit.rs
+git commit -m "feat(extraction): Daml implements/requires interface-relationship extraction"
+```
+
+---
+
+### Task 5: Resolution Phase A.5 — scoped name match (TDD)
+
+**Files:**
+- Create: `src/resolution/phase_a5_scoped_match.rs`
+- Modify: `src/resolution/mod.rs` (just `pub mod phase_a5_scoped_match;` for now; wiring is Task 6)
+- Modify: `tests/resolution_unit.rs` (or wherever resolution unit tests live)
+
+Phase A.5 resolves `UnresolvedRef` records with `scope_qid: Some(s)` by looking up `<scope_qname>.<unresolved_name>` in a pre-built `HashMap<String, String>` (qualified_name → qid). On hit, it emits the appropriate edge (SIGNATORY/CONTROLLER/OBSERVER/IMPLEMENTS/REQUIRES) via Cypher.
+
+Note: Implements and Requires resolution doesn't use `scope_qid` — they look up the target qualified_name globally. But this slice's design keeps them in the same phase for symmetry (the spec frames "scoped name match" as the path; for implements/requires, "scoped" means "module-prefixed", which is equivalent to global since interfaces are top-level decls).
+
+For simplicity, Phase A.5 handles ALL five new edge kinds, with the lookup key varying:
+- Party kinds (Signatory/Controller/Observer): key = `<scope_qname>.<unresolved_name>`
+- Implements: key = `<module-of-scope-or-source-qid>.<unresolved_name>` first, then fall back to `<unresolved_name>` global
+- Requires: same as Implements
+
+Actually — keep it simpler. Two resolution strategies:
+
+1. **Scoped (party kinds)**: try `<scope_qname>.<unresolved_name>`. If miss, skip (Phase C handles fallback).
+2. **Global by name (Implements/Requires)**: look up any `Interface` symbol whose `qualified_name` ends with `.<unresolved_name>` or equals `<unresolved_name>`.
+
+- [ ] **Step 1: Create `src/resolution/phase_a5_scoped_match.rs` with failing test inline**
+
+Read `src/resolution/phase_b_import_driven.rs` and `src/resolution/phase_c_name_match.rs` first to understand the resolution-phase pattern (function signature, ResolutionStats, Cypher patterns, return type).
+
+Then create the new file:
+
+```rust
+//! Phase A.5 — Scoped name match for party-edge UnresolvedRef records.
+//!
+//! Runs AFTER Phase A (imports) and BEFORE Phase B (import-driven calls).
+//!
+//! For each UnresolvedRef with `kind` in {Signatory, Controller, Observer}:
+//!   - Look up `<scope_qid_qname>.<unresolved_name>` in the Symbol-by-qname map.
+//!   - On hit: MERGE the corresponding edge (SIGNATORY/CONTROLLER/OBSERVER).
+//!
+//! For Implements/Requires: target is a workspace-wide Interface by qname.
+//!   - Look up any Interface whose qname equals or ends with `.<unresolved_name>`.
+//!   - On hit: MERGE the IMPLEMENTS/REQUIRES edge.
+
+use anyhow::{Context, Result};
+use neo4rs::query;
+use std::collections::HashMap;
+
+use crate::db::Connection;
+
+/// Stats returned by Phase A.5.
+#[derive(Debug, Clone, Default)]
+pub struct PhaseA5Stats {
+    pub signatory_resolved: usize,
+    pub controller_resolved: usize,
+    pub observer_resolved: usize,
+    pub implements_resolved: usize,
+    pub requires_resolved: usize,
+    pub unresolved: usize,
+}
+
+/// Run Phase A.5. Returns counts of edges emitted by kind.
+pub async fn run(conn: &Connection) -> Result<PhaseA5Stats> {
+    // Build qualified_name → qid map (one round-trip).
+    let qname_map = build_qname_map(conn).await?;
+
+    // Pull all UnresolvedRef records whose kind is one of the 5 new kinds.
+    let refs = fetch_party_and_interface_refs(conn).await?;
+
+    let mut stats = PhaseA5Stats::default();
+
+    for r in refs {
+        let (cypher_text, edge_resolved) = match r.kind.as_str() {
+            "Signatory" | "Controller" | "Observer" => {
+                // Scoped lookup: <scope_qname>.<name>.
+                let Some(scope_qid) = &r.scope_qid else {
+                    stats.unresolved += 1;
+                    continue;
+                };
+                let scope_qname = scope_qid.split(':').skip(2).collect::<Vec<_>>().join(":");
+                let lookup_key = format!("{}.{}", scope_qname, r.unresolved_name);
+                let Some(target_qid) = qname_map.get(&lookup_key) else {
+                    stats.unresolved += 1;
+                    continue;
+                };
+                let rel = match r.kind.as_str() {
+                    "Signatory" => "SIGNATORY",
+                    "Controller" => "CONTROLLER",
+                    "Observer" => "OBSERVER",
+                    _ => unreachable!(),
+                };
+                let cypher = format!(
+                    "MATCH (s:Symbol {{qid: $source_qid}}) \
+                     MATCH (t:Symbol {{qid: $target_qid}}) \
+                     MERGE (s)-[:{}]->(t)",
+                    rel
+                );
+                (cypher, (r.source_qid.clone(), target_qid.clone(), r.kind.as_str().to_string()))
+            }
+            "Implements" | "Requires" => {
+                // Global lookup: any Interface whose qname ends with the unresolved name
+                // (or equals it for unqualified references).
+                let target_qid = find_interface_by_name(&qname_map, &r.unresolved_name);
+                let Some(target_qid) = target_qid else {
+                    stats.unresolved += 1;
+                    continue;
+                };
+                let rel = match r.kind.as_str() {
+                    "Implements" => "IMPLEMENTS",
+                    "Requires" => "REQUIRES",
+                    _ => unreachable!(),
+                };
+                let cypher = format!(
+                    "MATCH (s:Symbol {{qid: $source_qid}}) \
+                     MATCH (t:Symbol {{qid: $target_qid}}) \
+                     MERGE (s)-[:{}]->(t)",
+                    rel
+                );
+                (cypher, (r.source_qid.clone(), target_qid, r.kind.as_str().to_string()))
+            }
+            _ => continue,
+        };
+
+        // Emit the edge.
+        let (source_qid, target_qid, kind_str) = edge_resolved;
+        conn.graph
+            .execute(
+                query(&cypher_text)
+                    .param("source_qid", source_qid.clone())
+                    .param("target_qid", target_qid.clone()),
+            )
+            .await
+            .with_context(|| format!("MERGE edge {} from {} to {}", kind_str, source_qid, target_qid))?
+            .next()
+            .await
+            .ok();
+
+        match kind_str.as_str() {
+            "Signatory" => stats.signatory_resolved += 1,
+            "Controller" => stats.controller_resolved += 1,
+            "Observer" => stats.observer_resolved += 1,
+            "Implements" => stats.implements_resolved += 1,
+            "Requires" => stats.requires_resolved += 1,
+            _ => {}
+        }
+    }
+
+    Ok(stats)
+}
+
+async fn build_qname_map(conn: &Connection) -> Result<HashMap<String, String>> {
+    let mut stream = conn
+        .graph
+        .execute(query("MATCH (s:Symbol) RETURN s.qualified_name AS qname, s.qid AS qid"))
+        .await
+        .context("building qualified_name map")?;
+    let mut out = HashMap::new();
+    while let Some(row) = stream.next().await? {
+        let qname: Option<String> = row.get("qname").ok();
+        let qid: Option<String> = row.get("qid").ok();
+        if let (Some(qname), Some(qid)) = (qname, qid) {
+            out.insert(qname, qid);
+        }
+    }
+    Ok(out)
+}
+
+#[derive(Debug)]
+struct UnresolvedRefRow {
+    qid: String,
+    source_qid: String,
+    unresolved_name: String,
+    kind: String,
+    scope_qid: Option<String>,
+}
+
+async fn fetch_party_and_interface_refs(conn: &Connection) -> Result<Vec<UnresolvedRefRow>> {
+    let cypher = "\
+        MATCH (n:UnresolvedRef) \
+        WHERE n.kind IN ['Signatory','Controller','Observer','Implements','Requires'] \
+        RETURN n.qid AS qid, n.source_qid AS source_qid, n.unresolved_name AS name, \
+               n.kind AS kind, n.scope_qid AS scope_qid";
+    let mut stream = conn.graph.execute(query(cypher)).await.context("fetching party refs")?;
+    let mut out = Vec::new();
+    while let Some(row) = stream.next().await? {
+        out.push(UnresolvedRefRow {
+            qid: row.get("qid")?,
+            source_qid: row.get("source_qid")?,
+            unresolved_name: row.get("name")?,
+            kind: row.get("kind")?,
+            scope_qid: row.get::<Option<String>>("scope_qid").ok().flatten(),
+        });
+    }
+    Ok(out)
+}
+
+/// Find an Interface qid by its short name (e.g., "Authorizable") OR
+/// fully-qualified name (e.g., "Splice.Foo.Authorizable"). If multiple match,
+/// returns the first (workspace deduplication is best-effort here).
+fn find_interface_by_name(qname_map: &HashMap<String, String>, name: &str) -> Option<String> {
+    // Direct full-qname hit?
+    if let Some(qid) = qname_map.get(name) {
+        return Some(qid.clone());
+    }
+    // Suffix match: qname ends with `.<name>`.
+    let suffix = format!(".{}", name);
+    for (qname, qid) in qname_map.iter() {
+        if qname.ends_with(&suffix) {
+            return Some(qid.clone());
+        }
+    }
+    None
+}
+```
+
+> **Note on `UnresolvedRefRow.as_str()`:** the helper is just for `match`-on-string convenience; the field is already a String. Adjust if you prefer matching on `r.kind.as_str()` directly.
+
+- [ ] **Step 2: Declare the module**
+
+In `src/resolution/mod.rs`, add `pub mod phase_a5_scoped_match;` near the other phase declarations.
+
+- [ ] **Step 3: Build (no tests yet — this phase is hard to unit-test without a Neo4j fixture, deferred to Task 7's integration test)**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+cargo test --test integration_daml_index 2>&1 | tail -3
+```
+
+Expected: build clean, 133 tests still pass (no new tests; Phase A.5 is integration-tested in Task 7).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/resolution/phase_a5_scoped_match.rs src/resolution/mod.rs
+git commit -m "feat(resolution): add Phase A.5 — scoped name match for party + implements/requires"
+```
+
+---
+
+### Task 6: Wire Phase A.5 into the resolution orchestrator
+
+**Files:**
+- Modify: `src/resolution/mod.rs`
+
+The resolution orchestrator is the `resolve()` function (slice 9's `src/resolution/mod.rs`). It runs Phase A → Phase B → Phase C and returns `ResolutionStats`. Slice 10b adds Phase A.5 between A and B.
+
+- [ ] **Step 1: Read `src/resolution/mod.rs` and find the `resolve()` function**
+
+The existing structure is approximately:
+
+```rust
+pub async fn resolve(conn: &Connection) -> Result<ResolutionStats> {
+    let mut stats = ResolutionStats::default();
+    // Phase A — Imports
+    stats.imports_resolved = phase_a_imports::run(conn).await?;
+    // Phase B — Import-driven name match
+    let phase_b = phase_b_import_driven::run(conn).await?;
+    stats.calls_resolved_phase_b = phase_b.calls;
+    // ... etc.
+    // Phase C — Fallback name match
+    let phase_c = phase_c_name_match::run(conn).await?;
+    stats.calls_resolved_phase_c = phase_c.calls;
+    // ... etc.
+    Ok(stats)
+}
+```
+
+(Actual signature may differ; verify.)
+
+- [ ] **Step 2: Extend `ResolutionStats` with party/interface counters**
+
+In `src/resolution/mod.rs` (or wherever `ResolutionStats` is defined):
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct ResolutionStats {
+    pub imports_resolved: usize,
+    pub calls_resolved_phase_b: usize,
+    pub calls_resolved_phase_c: usize,
+    pub refs_resolved_phase_b: usize,
+    pub refs_resolved_phase_c: usize,
+    pub types_resolved_phase_b: usize,
+    pub types_resolved_phase_c: usize,
+    pub unresolved_ambiguous: usize,
+    pub unresolved_no_candidate: usize,
+    // New for slice 10b:
+    pub signatory_resolved: usize,
+    pub controller_resolved: usize,
+    pub observer_resolved: usize,
+    pub implements_resolved: usize,
+    pub requires_resolved: usize,
+    pub party_unresolved: usize,
+}
+```
+
+Add helper methods if useful:
+
+```rust
+impl ResolutionStats {
+    pub fn total_resolved(&self) -> usize {
+        // existing implementation ...
+        // include new counters
+        self.imports_resolved
+            + self.calls_resolved_phase_b + self.calls_resolved_phase_c
+            + self.refs_resolved_phase_b + self.refs_resolved_phase_c
+            + self.types_resolved_phase_b + self.types_resolved_phase_c
+            + self.signatory_resolved + self.controller_resolved + self.observer_resolved
+            + self.implements_resolved + self.requires_resolved
+    }
+}
+```
+
+Adjust based on the actual existing `total_resolved()` body.
+
+- [ ] **Step 3: Wire Phase A.5 in `resolve()`**
+
+```rust
+pub async fn resolve(conn: &Connection) -> Result<ResolutionStats> {
+    let mut stats = ResolutionStats::default();
+
+    // Phase A — Imports
+    stats.imports_resolved = phase_a_imports::run(conn).await?;
+
+    // Phase A.5 — Scoped party + implements/requires (new in slice 10b)
+    let phase_a5 = phase_a5_scoped_match::run(conn).await?;
+    stats.signatory_resolved = phase_a5.signatory_resolved;
+    stats.controller_resolved = phase_a5.controller_resolved;
+    stats.observer_resolved = phase_a5.observer_resolved;
+    stats.implements_resolved = phase_a5.implements_resolved;
+    stats.requires_resolved = phase_a5.requires_resolved;
+    stats.party_unresolved = phase_a5.unresolved;
+
+    // Phase B — Import-driven name match (existing)
+    let phase_b = phase_b_import_driven::run(conn).await?;
+    // ... existing wiring ...
+
+    // Phase C — Fallback name match (existing)
+    let phase_c = phase_c_name_match::run(conn).await?;
+    // ... existing wiring ...
+
+    Ok(stats)
+}
+```
+
+- [ ] **Step 4: Update the `info!` log line in `cli::index` or wherever resolution stats are reported**
+
+Find the line in `src/cli/index.rs` (or `src/sync/mod.rs`) that prints resolution stats:
+
+```rust
+info!(
+    "resolution stats: imports={}, calls(B/C)={}/{}, refs(B/C)={}/{}, types(B/C)={}/{}, ambiguous={}, no_candidate={}",
+    stats.imports_resolved, ...
+);
+```
+
+Add the new counters:
+
+```rust
+info!(
+    "resolution stats: imports={}, calls(B/C)={}/{}, refs(B/C)={}/{}, types(B/C)={}/{}, \
+     party(sig/ctrl/obs)={}/{}/{}, iface(impl/req)={}/{}, ambiguous={}, no_candidate={}",
+    stats.imports_resolved,
+    stats.calls_resolved_phase_b, stats.calls_resolved_phase_c,
+    stats.refs_resolved_phase_b, stats.refs_resolved_phase_c,
+    stats.types_resolved_phase_b, stats.types_resolved_phase_c,
+    stats.signatory_resolved, stats.controller_resolved, stats.observer_resolved,
+    stats.implements_resolved, stats.requires_resolved,
+    stats.unresolved_ambiguous, stats.unresolved_no_candidate,
+);
+```
+
+Do the same in `src/sync/mod.rs` if it has its own resolution-stats log line.
+
+- [ ] **Step 5: Build, clippy, fmt, test, regression check**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+cargo test --test integration_daml_index 2>&1 | tail -3
+```
+
+Expected: 133 tests still pass (no new tests — orchestrator wiring is integration-tested in Task 7).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/resolution/mod.rs src/cli/index.rs src/sync/mod.rs
+git commit -m "feat(resolution): wire Phase A.5 into resolve() + extend ResolutionStats"
+```
+
+---
+
+### Task 7: Integration test extensions for SIGNATORY/CONTROLLER/OBSERVER/IMPLEMENTS edges
+
+**Files:**
+- Modify: `tests/fixtures/tiny-daml/Splice/Authorization.daml` (add a `requires` clause)
+- Modify: `tests/integration_daml_index.rs`
+
+The slice 10a Authorization.daml fixture already has signatory/controller/observer/implements clauses. We add one `requires` clause for completeness. Then assert all 5 new edge kinds land via Cypher queries.
+
+- [ ] **Step 1: Extend the fixture with a `requires` clause**
+
+Edit `tests/fixtures/tiny-daml/Splice/Authorization.daml`. Find the existing `interface Authorizable where ...` block. Add a second interface that requires it:
+
+```daml
+-- Subinterface that requires Authorizable.
+interface Owned requires Authorizable where
+  getOwnerParty : Party
+```
+
+Place after the `data AuthorizableView = ...` block and before `template AuthorizedCounter`.
+
+- [ ] **Step 2: Extend the integration test assertions**
+
+Read `tests/integration_daml_index.rs`. Find the existing assertions block. Add:
+
+```rust
+// New for slice 10b: authorization edges.
+
+// Authorization edges — exact counts based on the fixture content.
+let signatory_edges: i64 = scalar(&conn,
+    "MATCH (t:Template)-[:SIGNATORY]->() RETURN count(*) AS c").await;
+assert!(signatory_edges >= 2,
+    "expected ≥2 SIGNATORY edges (Counter→owner, AuthorizedCounter→owner); got {signatory_edges}");
+
+let controller_edges: i64 = scalar(&conn,
+    "MATCH (c:Choice)-[:CONTROLLER]->() RETURN count(*) AS c").await;
+assert!(controller_edges >= 3,
+    "expected ≥3 CONTROLLER edges (Increment/Reset/Bump); got {controller_edges}");
+
+let observer_edges: i64 = scalar(&conn,
+    "MATCH (t:Template)-[:OBSERVER]->() RETURN count(*) AS c").await;
+assert!(observer_edges >= 1,
+    "expected ≥1 OBSERVER edge (AuthorizedCounter→delegate); got {observer_edges}");
+
+let implements_edges: i64 = scalar(&conn,
+    "MATCH (t:Template)-[:IMPLEMENTS]->(i:Interface) RETURN count(*) AS c").await;
+assert_eq!(implements_edges, 1,
+    "expected 1 IMPLEMENTS edge (AuthorizedCounter→Authorizable)");
+
+let requires_edges: i64 = scalar(&conn,
+    "MATCH (i:Interface)-[:REQUIRES]->(j:Interface) RETURN count(*) AS c").await;
+assert_eq!(requires_edges, 1,
+    "expected 1 REQUIRES edge (Owned→Authorizable)");
+
+// Named edge assertions.
+
+// AuthorizedCounter has signatory owner.
+let sig_owner: i64 = scalar(&conn,
+    "MATCH (t:Template {qualified_name: 'Splice.Authorization.AuthorizedCounter'})\
+     -[:SIGNATORY]->(f:Field {name: 'owner'}) RETURN count(*) AS c").await;
+assert_eq!(sig_owner, 1, "AuthorizedCounter should have SIGNATORY → owner field");
+
+// Bump choice has controller delegate.
+let bump_ctrl: i64 = scalar(&conn,
+    "MATCH (c:Choice {qualified_name: 'Splice.Authorization.AuthorizedCounter.Bump'})\
+     -[:CONTROLLER]->(f:Field {name: 'delegate'}) RETURN count(*) AS c").await;
+assert_eq!(bump_ctrl, 1, "Bump should have CONTROLLER → delegate field");
+
+// AuthorizedCounter implements Authorizable.
+let auth_impl: i64 = scalar(&conn,
+    "MATCH (t:Template {qualified_name: 'Splice.Authorization.AuthorizedCounter'})\
+     -[:IMPLEMENTS]->(i:Interface {qualified_name: 'Splice.Authorization.Authorizable'}) \
+     RETURN count(*) AS c").await;
+assert_eq!(auth_impl, 1);
+
+// Owned requires Authorizable.
+let owned_req: i64 = scalar(&conn,
+    "MATCH (sub:Interface {qualified_name: 'Splice.Authorization.Owned'})\
+     -[:REQUIRES]->(base:Interface {qualified_name: 'Splice.Authorization.Authorizable'}) \
+     RETURN count(*) AS c").await;
+assert_eq!(owned_req, 1);
+```
+
+- [ ] **Step 3: Verify SKIP path**
+
+```bash
+cargo test --test integration_daml_index 2>&1 | tail -10
+```
+
+Expected: 1 test, SKIPs cleanly (no env vars), result ok.
+
+- [ ] **Step 4: Build + clippy + fmt**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test 2>&1 | tail -5
+```
+
+Expected: 133 tests pass (no new unit tests; integration test still SKIPs).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/fixtures/tiny-daml/Splice/Authorization.daml tests/integration_daml_index.rs
+git commit -m "test(extraction): integration assertions for SIGNATORY/CONTROLLER/OBSERVER/IMPLEMENTS/REQUIRES edges"
+```
+
+---
+
+### Task 8: README + slice-10b-daml-edges tag
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Read current README.md** to find the `## Status` section.
+
+- [ ] **Step 2: Bump the Status section**
+
+Replace with:
+
+```markdown
+## Status
+
+In development. Currently implements **Slice 10b: Daml authorization
+edges** — workspace initialization, indexing, resolution, incremental
+sync, on-write embeddings, a stdio MCP server exposing 10 tools, Rust
++ Daml extraction with structural fidelity (templates, choices,
+interfaces, viewtypes, exceptions, fields), AND authorization edges
+(`signatory`/`controller`/`observer` party edges from templates/choices
+to their Field targets, `implements` from templates to interfaces,
+`requires` between interfaces).
+
+Resolution gained a new Phase A.5 (scoped name match) that builds a
+`HashMap<qualified_name, qid>` once and resolves party-edge refs by
+`<scope_qname>.<unresolved_name>` lookup. Implements/Requires resolve
+against workspace-wide Interface symbols by qualified-name suffix
+match.
+
+Daml v2.0 depth is complete; v2.1+ slices may add file watchers,
+framework-specific resolvers, cross-package indexing, or a real
+`tree-sitter-daml` grammar swap when one becomes available.
+```
+
+Quick start and Development sections need no changes.
+
+- [ ] **Step 3: Final test suite**
+
+```bash
+cargo test 2>&1 | tail -20
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+```
+
+Expected: 133 tests pass total.
+
+- [ ] **Step 4: Commit and tag**
+
+```bash
+git add README.md
+git commit -m "docs: update README for slice 10b (Daml authorization edges)"
+git tag slice-10b-daml-edges
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+git log --oneline | head -15
+git tag --list | grep slice
+```
+
+Expected tags include `slice-10b-daml-edges`. Full list:
+`slice-1-walking-skeleton`, `slice-2-rust-extraction`, `slice-3-resolution`, `slice-5-sync`, `slice-6-mcp`, `slice-7-embeddings`, `slice-8-semantic-search`, `slice-9-daml`, `slice-10a-daml-structure`, `slice-10b-daml-edges`.
+
+---
+
+## Slice 10b Done
+
+- [ ] `cargo build` clean
+- [ ] `cargo test` (no env vars) — 133 tests pass, all integration tests SKIP cleanly
+- [ ] `CODEGRAPH_RS_TEST_NEO4J=1 cargo test -- --test-threads=1` — all tests pass, including extended `integration_daml_index` with new edge assertions
+- [ ] `CODEGRAPH_RS_TEST_NEO4J=1 CODEGRAPH_RS_TEST_EMBEDDINGS=1 cargo test -- --test-threads=1` — embeddings unchanged; new edge kinds visible to MCP traversal tools
+- [ ] Manual: in Neo4j Browser, on a real Daml workspace (Splice/daml-finance):
+  - `MATCH (t:Template)-[:SIGNATORY]->(f) RETURN labels(f), count(*)` returns mostly `[Symbol, Field]` targets (some `[Symbol, Variable]` if party expressions reference non-field workspace symbols)
+  - `MATCH (c:Choice)-[:CONTROLLER]->(f:Field) RETURN c.qualified_name, f.qualified_name LIMIT 10` shows choice-to-party authorization
+  - `MATCH (a:Template)-[:IMPLEMENTS]->(b:Interface) RETURN a.qualified_name, b.qualified_name` shows template-interface relationships
+- [ ] Manual: `_callers` MCP tool on a Field returns the Templates that have SIGNATORY edges to it
+- [ ] Manual: `_impact` MCP tool traverses through SIGNATORY/CONTROLLER/OBSERVER/IMPLEMENTS/REQUIRES (these are reverse-transitive-closure candidates per spec §10 — verify by checking `src/graph/traverse.rs::impact` includes them)
+- [ ] Resolution stats log line includes party + interface counts
+- [ ] No regression of slice 10a functionality
+
+When all check, **v2.0 Daml-depth push is complete**.
+
+### Small follow-ups noted during this slice
+
+- **`_impact` MCP tool edge-kind list.** Spec §10 defines impact as "Reverse-transitive closure of CALLS/REFERENCES/TYPE_OF". Slice 10b adds 5 new edge kinds that arguably should be included in impact analysis (changing a signatory field affects who can create the contract). Worth a small follow-up to extend `src/graph/traverse.rs::impact`'s relationship list.
+- **`pass_e_party_edges` segment-splitting.** The current implementation splits dotted identifiers on `.` to handle `Set.fromList` cases where the parser emits them as a single dotted token. If the grammar emits them as separate tokens, the splitting is a no-op. Worth probing with a real Splice/daml-finance file to confirm.
+- **`find_interface_by_name` suffix match ambiguity.** If two interfaces in the workspace share a short name (`Authorizable` in module A and module B), the function returns the first hit found. For Daml-finance scale, ambiguity is rare; if it bites in practice, the fix is to require fully-qualified names in `implements`/`requires` clauses or to enumerate candidates and require disambiguation.
+- **Phase A.5 fallback to Phase C.** Currently, party-kind refs that miss Phase A.5 are counted as unresolved and Phase C doesn't re-process them. If we want fallback (per spec §4.2), Phase C needs to know about the new kinds. Defer to v2.1.

--- a/docs/superpowers/plans/2026-05-18-codegraph-rs-slice-10b-daml-edges.md
+++ b/docs/superpowers/plans/2026-05-18-codegraph-rs-slice-10b-daml-edges.md
@@ -336,11 +336,11 @@ Search:
 grep -rn "UnresolvedRef {" src/ tests/
 ```
 
-Each construction will fail to compile with the new field. Add `scope_qid: None` to every existing construction. There are constructions in:
+Each construction will fail to compile with the new field. Add `scope_qid: None,` as the last field of every existing struct literal. Known sites:
 - `src/extraction/languages/daml.rs` (slice 9's pass_b_imports, pass_c_call_sites, pass_c_exercise_choices)
 - `src/extraction/languages/rust.rs` (slice 2's call-site extraction)
 
-For each, add `scope_qid: None,` as the last field.
+**The build is the safety net.** If `grep` misses any construction site (e.g., one inside a macro or written with `..Default::default()`), the next `cargo build` in Step 6 will surface a compile error pointing at the missed site. Add `scope_qid: None,` to whatever the compiler flags.
 
 - [ ] **Step 5: Update `write_unresolved_refs` in `src/db/write.rs`**
 
@@ -462,9 +462,11 @@ fn daml_extracts_controller_inside_choice() {
         .filter(|r| r.kind == UnresolvedKind::Controller).collect();
     assert_eq!(ctrls.len(), 1);
     assert_eq!(ctrls[0].unresolved_name, "owner");
-    let template_qid = &result.nodes.iter().find(|n| n.kind == NodeKind::Template).unwrap().qid;
-    assert_eq!(ctrls[0].scope_qid.as_deref(), Some(template_qid.as_str()),
-        "controller's scope_qid is the enclosing Template (not the Choice)");
+    // Controller scope_qid is the enclosing Choice (more specific). Phase A.5
+    // falls back to the parent Template if `<choice_qname>.<name>` misses.
+    let choice_qid = &result.nodes.iter().find(|n| n.kind == NodeKind::Choice).unwrap().qid;
+    assert_eq!(ctrls[0].scope_qid.as_deref(), Some(choice_qid.as_str()),
+        "controller's scope_qid is the enclosing Choice; Phase A.5 falls back to Template parent");
 }
 
 #[test]
@@ -682,15 +684,19 @@ fn pass_e_party_edges(
             let Some(template_qid) = template_qid else { continue };
             let template_qid = template_qid.to_string();
 
-            // source_qid for the ref differs by kind:
-            //   - signatory/observer: enclosing Template
-            //   - controller: enclosing Choice (the choice the controller belongs to)
-            let source_qid = if *kind == UnresolvedKind::Controller {
-                enclosing_choice_qid(&result.nodes, line, col)
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| template_qid.clone())
+            // source_qid AND scope_qid depend on kind:
+            //   - signatory/observer: source = Template, scope = Template
+            //   - controller: source = Choice (the containing choice), scope = Choice
+            //     (Phase A.5 will fall back to the enclosing Template when
+            //     `<choice_qname>.<name>` misses — choices with `with` blocks
+            //     have Choice fields that controllers can reference.)
+            let (source_qid, scope_qid) = if *kind == UnresolvedKind::Controller {
+                match enclosing_choice_qid(&result.nodes, line, col).map(str::to_string) {
+                    Some(c) => (c.clone(), c),
+                    None => (template_qid.clone(), template_qid.clone()),
+                }
             } else {
-                template_qid.clone()
+                (template_qid.clone(), template_qid.clone())
             };
 
             // Walk the target subtree for identifier leaves.
@@ -710,7 +716,7 @@ fn pass_e_party_edges(
                     kind: *kind,
                     line: ref_line,
                     col: ref_col,
-                    scope_qid: Some(template_qid.clone()),
+                    scope_qid: Some(scope_qid.clone()),
                 });
                 result.edges.push(RawEdge {
                     from_qid: source_qid.clone(),
@@ -873,13 +879,27 @@ Run and document the shapes. `implements` may show up as `variable "interface"` 
 
 - [ ] **Step 3: Add `implements` and `requires` queries to `daml.scm`**
 
+**Write the queries to match the shapes Step 2 actually observed.** The examples below are placeholders for the most common shape; don't paste them blindly.
+
 Likely shapes:
 
 ```scheme
 ; Implements: `interface instance Bar for T where ...` (Daml 2.7+).
-; The `interface instance` keyword pair is followed by a constructor.
+; The `interface instance` keyword pair may parse as:
+;   - Two siblings (variable "interface", variable "instance") in an ERROR — Shape A
+;   - A nested apply chain (apply (variable "interface") (apply (variable "instance") (constructor)))
+;     in an ERROR — Shape B (likely, given slice 10a templates exhibited similar curried shapes)
+; Pick the query form matching Step 2's probe.
+
+; Shape A (flat siblings):
 ((apply
   function: (variable) @implements.kw
+  argument: (constructor) @implements.interface) @implements.def
+  (#eq? @implements.kw "instance"))
+
+; Shape B (nested):
+((apply
+  function: (apply argument: (variable) @implements.kw)
   argument: (constructor) @implements.interface) @implements.def
   (#eq? @implements.kw "instance"))
 
@@ -890,7 +910,7 @@ Likely shapes:
   (#eq? @requires.kw "requires"))
 ```
 
-Adapt to actual probe output. If the parse for `interface instance Bar for T` has `instance` as the keyword anchor with `Bar` as direct constructor argument, the query above works. If `for T` confuses the parse, more work needed.
+If Step 2's probe shows neither Shape A nor Shape B matches, write a custom query OR fall back to a pure Rust tree walk (the pattern slice 10a Task 6 used for Fields when the parse shapes were too irregular for SCM).
 
 - [ ] **Step 4: Add `pass_e_interface_edges` to `daml.rs`**
 
@@ -994,7 +1014,7 @@ cargo test 2>&1 | tail -5
 cargo test --test integration_daml_index 2>&1 | tail -3
 ```
 
-Expected: 133 tests pass (130 + 3 new).
+Expected: 139 tests pass (136 + 3 new).
 
 - [ ] **Step 7: REMOVE probe tests, then commit**
 
@@ -1042,11 +1062,22 @@ Then create the new file:
 //!
 //! For each UnresolvedRef with `kind` in {Signatory, Controller, Observer}:
 //!   - Look up `<scope_qid_qname>.<unresolved_name>` in the Symbol-by-qname map.
+//!   - For Controllers, falls back to parent-Template scope on miss.
 //!   - On hit: MERGE the corresponding edge (SIGNATORY/CONTROLLER/OBSERVER).
 //!
 //! For Implements/Requires: target is a workspace-wide Interface by qname.
 //!   - Look up any Interface whose qname equals or ends with `.<unresolved_name>`.
 //!   - On hit: MERGE the IMPLEMENTS/REQUIRES edge.
+//!
+//! **Idempotency caveat.** MERGE is idempotent for the same `(source, target)`
+//! pair, but if a Template's signatory expression changes from `owner` to
+//! `creator` and sync re-runs resolution, the OLD edge to the `owner` Field
+//! is not deleted — only the new edge to `creator` is added. The Template
+//! ends up with two SIGNATORY edges. This is a known limitation of the v1
+//! resolution model (spec §7 says "Resolution as idempotent rebuild" but
+//! Phase B/C have the same staleness issue with CALLS/REFERENCES edges).
+//! A v2.1 follow-up could prepend a DETACH-DELETE pass that clears all
+//! resolution-derived edges before rebuilding.
 
 use anyhow::{Context, Result};
 use neo4rs::query;
@@ -1079,13 +1110,31 @@ pub async fn run(conn: &Connection) -> Result<PhaseA5Stats> {
         let (cypher_text, edge_resolved) = match r.kind.as_str() {
             "Signatory" | "Controller" | "Observer" => {
                 // Scoped lookup: <scope_qname>.<name>.
+                //
+                // For Controllers, scope_qid is the enclosing Choice; if the
+                // scoped lookup misses, fall back one level to the parent
+                // Template's qname. The parent qname is the scope_qname with
+                // its last dotted segment stripped (`Foo.T.Bump` → `Foo.T`).
+                // Signatory/Observer always use Template scope, so no fallback
+                // hop is needed.
                 let Some(scope_qid) = &r.scope_qid else {
                     stats.unresolved += 1;
                     continue;
                 };
                 let scope_qname = scope_qid.split(':').skip(2).collect::<Vec<_>>().join(":");
-                let lookup_key = format!("{}.{}", scope_qname, r.unresolved_name);
-                let Some(target_qid) = qname_map.get(&lookup_key) else {
+                let primary_key = format!("{}.{}", scope_qname, r.unresolved_name);
+                let target_qid = qname_map.get(&primary_key).cloned().or_else(|| {
+                    // Fallback for Controllers: try the parent Template's scope.
+                    if r.kind == "Controller" {
+                        if let Some(idx) = scope_qname.rfind('.') {
+                            let parent_qname = &scope_qname[..idx];
+                            let fallback_key = format!("{}.{}", parent_qname, r.unresolved_name);
+                            return qname_map.get(&fallback_key).cloned();
+                        }
+                    }
+                    None
+                });
+                let Some(target_qid) = target_qid else {
                     stats.unresolved += 1;
                     continue;
                 };
@@ -1235,7 +1284,7 @@ cargo test 2>&1 | tail -5
 cargo test --test integration_daml_index 2>&1 | tail -3
 ```
 
-Expected: build clean, 133 tests still pass (no new tests; Phase A.5 is integration-tested in Task 7).
+Expected: build clean, 139 tests still pass (no new tests; Phase A.5 is integration-tested in Task 7).
 
 - [ ] **Step 4: Commit**
 
@@ -1365,16 +1414,23 @@ info!(
 Add the new counters:
 
 ```rust
+// The single info! line is too long to read in a terminal — split into
+// two logical lines (still emitted as two separate log records, which the
+// user sees as adjacent lines).
 info!(
-    "resolution stats: imports={}, calls(B/C)={}/{}, refs(B/C)={}/{}, types(B/C)={}/{}, \
-     party(sig/ctrl/obs)={}/{}/{}, iface(impl/req)={}/{}, ambiguous={}, no_candidate={}",
+    "resolution stats: imports={}, calls(B/C)={}/{}, refs(B/C)={}/{}, types(B/C)={}/{}",
     stats.imports_resolved,
     stats.calls_resolved_phase_b, stats.calls_resolved_phase_c,
     stats.refs_resolved_phase_b, stats.refs_resolved_phase_c,
     stats.types_resolved_phase_b, stats.types_resolved_phase_c,
+);
+info!(
+    "resolution stats (auth): party(sig/ctrl/obs)={}/{}/{}, iface(impl/req)={}/{}, \
+     ambiguous={}, no_candidate={}, party_unresolved={}",
     stats.signatory_resolved, stats.controller_resolved, stats.observer_resolved,
     stats.implements_resolved, stats.requires_resolved,
     stats.unresolved_ambiguous, stats.unresolved_no_candidate,
+    stats.party_unresolved,
 );
 ```
 
@@ -1390,7 +1446,7 @@ cargo test 2>&1 | tail -5
 cargo test --test integration_daml_index 2>&1 | tail -3
 ```
 
-Expected: 133 tests still pass (no new tests — orchestrator wiring is integration-tested in Task 7).
+Expected: 139 tests still pass (no new tests — orchestrator wiring is integration-tested in Task 7).
 
 - [ ] **Step 6: Commit**
 
@@ -1421,9 +1477,26 @@ interface Owned requires Authorizable where
 
 Place after the `data AuthorizableView = ...` block and before `template AuthorizedCounter`.
 
-- [ ] **Step 2: Extend the integration test assertions**
+> **Inherited assertions update required.** Adding `interface Owned` bumps the slice 10a `interface_count` from 1 to 2 and adds one more Field (`getOwnerParty`). Step 2 below updates those inherited assertions.
 
-Read `tests/integration_daml_index.rs`. Find the existing assertions block. Add:
+- [ ] **Step 2: Update inherited slice 10a count assertions**
+
+In `tests/integration_daml_index.rs`, find these existing assertions and update them:
+
+```rust
+// Was: assert_eq!(interface_count, 1, "expected 1 Interface (Authorizable)");
+assert_eq!(interface_count, 2, "expected 2 Interfaces (Authorizable, Owned)");
+```
+
+The `field_count >= 6` assertion stays (the count goes from 8 to 9, still satisfies the bound). The doc-comment breakdown above the field_count assertion should add a line:
+```
+//   - Owned interface: getOwnerParty                                       -> 1
+// New minimum guaranteed: 9.
+```
+
+- [ ] **Step 3: Extend the integration test assertions**
+
+Read `tests/integration_daml_index.rs`. Find the existing assertions block. After the inherited-update from Step 2, add:
 
 ```rust
 // New for slice 10b: authorization edges.
@@ -1483,7 +1556,7 @@ let owned_req: i64 = scalar(&conn,
 assert_eq!(owned_req, 1);
 ```
 
-- [ ] **Step 3: Verify SKIP path**
+- [ ] **Step 4: Verify SKIP path**
 
 ```bash
 cargo test --test integration_daml_index 2>&1 | tail -10
@@ -1491,7 +1564,7 @@ cargo test --test integration_daml_index 2>&1 | tail -10
 
 Expected: 1 test, SKIPs cleanly (no env vars), result ok.
 
-- [ ] **Step 4: Build + clippy + fmt**
+- [ ] **Step 5: Build + clippy + fmt**
 
 ```bash
 cargo build 2>&1 | tail -3
@@ -1500,9 +1573,9 @@ cargo fmt --check
 cargo test 2>&1 | tail -5
 ```
 
-Expected: 133 tests pass (no new unit tests; integration test still SKIPs).
+Expected: 139 tests pass (no new unit tests; integration test still SKIPs).
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add tests/fixtures/tiny-daml/Splice/Authorization.daml tests/integration_daml_index.rs
@@ -1555,7 +1628,7 @@ cargo clippy --all-targets -- -D warnings
 cargo fmt --check
 ```
 
-Expected: 133 tests pass total.
+Expected: 139 tests pass total.
 
 - [ ] **Step 4: Commit and tag**
 
@@ -1580,7 +1653,7 @@ Expected tags include `slice-10b-daml-edges`. Full list:
 ## Slice 10b Done
 
 - [ ] `cargo build` clean
-- [ ] `cargo test` (no env vars) — 133 tests pass, all integration tests SKIP cleanly
+- [ ] `cargo test` (no env vars) — 139 tests pass, all integration tests SKIP cleanly
 - [ ] `CODEGRAPH_RS_TEST_NEO4J=1 cargo test -- --test-threads=1` — all tests pass, including extended `integration_daml_index` with new edge assertions
 - [ ] `CODEGRAPH_RS_TEST_NEO4J=1 CODEGRAPH_RS_TEST_EMBEDDINGS=1 cargo test -- --test-threads=1` — embeddings unchanged; new edge kinds visible to MCP traversal tools
 - [ ] Manual: in Neo4j Browser, on a real Daml workspace (Splice/daml-finance):

--- a/docs/superpowers/specs/2026-04-22-codegraph-rs-design.md
+++ b/docs/superpowers/specs/2026-04-22-codegraph-rs-design.md
@@ -121,11 +121,11 @@ codegraph-rs/
 CLI -> config::load
     -> extraction::walker      (iterate workspace roots, find source files)
     -> extraction::parser      (rayon: parse each file with tree-sitter)
-    -> raw {nodes, structural_edges, unresolved_refs}
+    -> ExtractionResult{ nodes, edges, unresolved_refs }
     -> db::write_extraction    (Cypher UNWIND/MERGE for nodes + UnresolvedRef
-                                + structural edges: CONTAINS, EXTENDS,
-                                IMPLEMENTS produced directly from AST)
-    -> resolution              (UnresolvedRefs -> CALLS, IMPORTS-targets,
+                                + structural edges: CONTAINS, HAS_REF, EXTENDS,
+                                IMPLEMENTS, EXPORTS produced directly from AST)
+    -> resolution              (UnresolvedRefs -> IMPORTS, then CALLS,
                                 REFERENCES, TYPE_OF — derived from
                                 UnresolvedRef records, not extraction)
     -> db::write_resolution    (resolution-produced edges in batches)
@@ -133,8 +133,8 @@ CLI -> config::load
 ```
 
 Edges fall into two cleanly separated buckets:
-- **Structural edges** (produced by extraction, derivable from a single file's AST): `CONTAINS`, `EXTENDS`, `IMPLEMENTS`, `EXPORTS`, `INSTANTIATES`, `DECORATES`, `OVERRIDES`, `RETURNS`, `TYPE_OF` (when the type is in the same file).
-- **Resolution-derived edges** (produced by resolution from `UnresolvedRef` records, may cross files): `CALLS`, `IMPORTS` (target side), `REFERENCES`, cross-file `TYPE_OF`.
+- **Structural edges** (produced by extraction, derivable from a single file's AST): `CONTAINS`, `HAS_REF`, `EXTENDS`, `IMPLEMENTS`, `EXPORTS`, `INSTANTIATES`, `DECORATES`, `OVERRIDES`, `RETURNS`, `TYPE_OF` (when the type is in the same file).
+- **Resolution-derived edges** (produced by resolution from `UnresolvedRef` records, may cross files; carry the `confidence` property): `CALLS`, `IMPORTS`, `REFERENCES`, cross-file `TYPE_OF`.
 
 ### Query dataflow
 
@@ -160,16 +160,24 @@ Every code node gets two labels: `Symbol` (supertype) plus its specific kind. `(
 
 The word "module" in this spec means the Neo4j label `Module` (a graph node) unless preceded by a language qualifier like "Rust module" or "Daml module."
 
-| Kind label | Use |
-|---|---|
-| `File` | A source file |
-| `Module`, `Namespace` | Container |
-| `Function`, `Method` | Callable |
-| `Class`, `Struct`, `Interface`, `Trait`, `Enum`, `TypeAlias` | Types (v1: only `Struct`, `Trait`, `Enum`, `TypeAlias` produced; others reserved for future languages) |
-| `Property`, `Field`, `Variable`, `Constant`, `Parameter`, `EnumMember` | Values |
-| `Import`, `Export` | Module boundaries |
-| `UnresolvedRef` | Permanent record of an unresolved name reference (see §7) |
-| `Template`, `Choice` | Daml-specific (reserved; populated only when `tree-sitter-daml` ships) |
+| Kind label | Use | v1 produces? |
+|---|---|---|
+| `File` | A source file | yes |
+| `Module` | Rust module / Daml module / Haskell module | yes |
+| `Namespace` | Reserved for languages with namespace constructs | no |
+| `Function` | Top-level callable | yes |
+| `Method` | Callable attached to a type (Rust impl methods, Daml class methods) | yes |
+| `Struct` | Product type (Rust `struct`, Daml `data` record-like) | yes |
+| `Trait` | Rust `trait` | yes |
+| `Enum` | Sum type (Rust `enum`, Daml `data` ADT) | yes |
+| `TypeAlias` | Rust `type T = ...`, Daml `type T = ...` | yes |
+| `Class`, `Interface` | Reserved for future languages (Java, Python, etc.) | no |
+| `Variable`, `Constant`, `Parameter`, `Field` | Values | yes (where extracted) |
+| `Property`, `EnumMember` | Reserved | no |
+| `Import` | Source-side import statement (Rust `use`, Daml `import`) | yes |
+| `Export` | Symbol exported from a module (Rust `pub use`, Daml export list) | yes |
+| `UnresolvedRef` | Permanent record of an unresolved name reference (see §7) | yes |
+| `Template`, `Choice` | Daml-specific (reserved; populated only when `tree-sitter-daml` ships) | no |
 
 **Note on `impl` blocks (Rust) and instance declarations (Daml/Haskell):** v1 does NOT emit a separate `Impl` node. Methods inside `impl Foo { fn bar() }` are emitted as `Method` nodes whose `qualified_name` carries the type prefix (`crate::module::Foo::bar`), and whose `CONTAINS` parent is the source file. The type-to-method relationship is captured implicitly by the `qualified_name` and can be derived by querying for methods whose `qualified_name` starts with `<TypeQualName>::`.
 
@@ -262,7 +270,7 @@ Edges may carry small property sets. v1 uses:
 
 | Edge type | Property | Values | Meaning |
 |---|---|---|---|
-| `CALLS`, `REFERENCES`, `TYPE_OF` (etc., resolution-produced) | `confidence` | `"import_resolved"` \| `"name_match"` | How the resolver derived this edge (see §7) |
+| `CALLS`, `IMPORTS`, `REFERENCES`, `TYPE_OF` (resolution-derived edges) | `confidence` | `"import_resolved"` \| `"name_match"` | How the resolver derived this edge (see §7). The presence of `confidence` is the marker the resolution rebuild uses to find edges to drop |
 
 Other edge types carry no properties in v1.
 
@@ -286,6 +294,18 @@ This relies on Neo4j Enterprise Edition for multi-database support, which is wha
 ### Database creation and privileges
 
 `codegraph-rs init` (and `codegraph-rs index` if the database does not yet exist) issues `CREATE DATABASE <name> IF NOT EXISTS` against Neo4j's `system` database. This requires the configured Neo4j user to have the `CREATE DATABASE` privilege. The Neo4j Desktop default `neo4j` admin user has this privilege; users with restricted accounts must either grant the privilege or pre-create the database manually.
+
+### `init` order of operations
+
+`codegraph-rs init` is fail-fast: it does *not* leave half-initialized state on disk if Neo4j setup fails. Sequence:
+
+1. Read or prompt for Neo4j details (URI, username, password).
+2. Open a Bolt connection. On failure → print error, exit nonzero, write nothing.
+3. Issue `CREATE DATABASE <name> IF NOT EXISTS` and verify the database is reachable. On failure (typically missing privilege) → print actionable error, exit nonzero, write nothing.
+4. Apply the schema constraints and indexes from §4 to the new database.
+5. Only now: write `<workspace_dir>/.codegraph/config.toml` and `<workspace_dir>/.codegraph/secrets.toml`. Add `secrets.toml` to a fresh `.gitignore` if one doesn't already cover it.
+
+`init` operates on the directory passed via `--workspace`, defaulting to cwd. The upward `.codegraph/` discovery (used by `index`, `sync`, `serve`, `query`, `status`) does not apply to `init` — `init` creates the directory it's pointed at, not an ancestor's.
 
 ### Database naming
 
@@ -329,7 +349,7 @@ languages = ["rust", "daml"]     # optional whitelist; default: all detected
 
 [embeddings]
 enabled = true
-model = "bge-small-en-v1.5"      # only valid value in v1
+model = "bge-small-en-v1.5"      # field exists for forward-compat; v1 accepts only this value
 ```
 
 Custom file-pattern excludes go in `<workspace_dir>/.codegraph/.codegraphignore`, which uses gitignore syntax. There is no inline TOML escape hatch — keeping all ignore rules in one place avoids confusion about precedence.
@@ -449,14 +469,20 @@ An `UnresolvedRef` is connected to its source by `(source)-[:HAS_REF]->(:Unresol
 
 Resolution runs **after all files are extracted/written**, so every candidate target exists. During incremental sync, resolution runs after the changed/added/deleted files have been processed.
 
-### Two-stage resolver
+Resolution is itself ordered, because some stages depend on edges produced by earlier stages:
 
-**Stage 1 — Import-driven (high confidence)**
+1. **Phase A — Resolve imports.** Process every `UnresolvedRef` with `kind="import"`. For each, look up the named module in the workspace and create the `IMPORTS` edge. This phase has no dependencies on other resolution outputs.
+2. **Phase B — Stage 1 (import-driven) for non-imports.** With `IMPORTS` edges now present, process `UnresolvedRef`s of `kind="call" | "type_ref" | "reference"`.
+3. **Phase C — Stage 2 (name-match fallback) for whatever Phase B did not resolve.**
 
-For each `UnresolvedRef`:
-1. Look at the source file's `IMPORTS` edges.
-2. Walk from each imported module/file to its `EXPORTS` or `CONTAINS` children.
-3. Match by name. If exactly one candidate → create a resolution edge of the appropriate type (`CALLS` for `kind="call"`, etc.) from `source_qid` to the candidate, with `confidence: "import_resolved"`.
+### Stage 1 — Import-driven (Phase B, high confidence)
+
+For each non-import `UnresolvedRef`:
+1. Look at the source file's `IMPORTS` edges (created in Phase A).
+2. From each imported `Module`, gather candidates via:
+   - `(:Module)-[:CONTAINS]->(candidate)` — symbols defined directly in the module.
+   - `(:Module)-[:EXPORTS]->(candidate)` — symbols re-exported by the module (e.g., Rust `pub use`).
+3. Match by name. If exactly one candidate → create a resolution edge of the appropriate type (`CALLS` for `kind="call"`, `REFERENCES` for `kind="reference"`, `TYPE_OF` for `kind="type_ref"`) from `source_qid` to the candidate, with `confidence: "import_resolved"`.
 
 Rust specifics:
 - `use crate::util::foo;` → resolves `foo` calls to `crate::util::foo`.
@@ -468,9 +494,9 @@ Daml specifics (via Haskell grammar):
 - Calls resolve through imports in scope.
 - Cross-root works naturally: both roots populate the same Neo4j database; module qualified names are globally unique.
 
-**Stage 2 — Name-match fallback (lower confidence)**
+### Stage 2 — Name-match fallback (Phase C, lower confidence)
 
-For `UnresolvedRef`s not resolved by stage 1:
+For `UnresolvedRef`s not resolved by Stage 1:
 - Exact name match against `qualified_name` across the whole workspace.
 - If exactly one candidate → resolution edge created with `confidence: "name_match"`.
 - If multiple candidates → no edge created; record candidates on the `UnresolvedRef` node:
@@ -495,15 +521,20 @@ A Daml file under `splice/` with `import Utility.Foo` must resolve to a module i
 
 `codegraph-rs index` and `codegraph-rs sync` invoke the same resolution routine. The routine:
 
-1. Drops all existing edges with a `confidence` property:
+1. Drops all existing resolution-derived edges, restricted by relationship type (Neo4j has type-level indexes; the predicate filters by `confidence` to avoid touching any non-resolution edges that may share a type in the future):
    ```cypher
-   MATCH ()-[r WHERE r.confidence IS NOT NULL]-()
+   MATCH ()-[r:CALLS|IMPORTS|REFERENCES|TYPE_OF]->()
+   WHERE r.confidence IS NOT NULL
    DELETE r
    ```
-2. Walks every `UnresolvedRef` and applies stages 1 then 2.
-3. Updates `unresolved_reason` and `candidate_qids` on each ref accordingly.
+2. Resets `candidate_qids` and `unresolved_reason` on every `UnresolvedRef` node so stale state doesn't carry over.
+3. Runs Phase A → Phase B → Phase C from "Order" above.
 
 Because `UnresolvedRef`s are permanent, resolution is idempotent — running it twice produces the same edges.
+
+### `UnresolvedRef.qid` stability note
+
+`UnresolvedRef.qid` includes `<line>:<col>`, which would normally make it position-dependent. This is intentional and safe because **`UnresolvedRef`s are always co-created and co-deleted with their source `Symbol`** — they never need to survive a position shift. When file A is re-extracted, all of A's previous `UnresolvedRef`s are deleted via `HAS_REF` cascade and a fresh set is emitted. No external graph state references `UnresolvedRef.qid` directly.
 
 ### Performance
 
@@ -590,7 +621,7 @@ Neo4j stores 384-dim float32 vectors inline. ~1.5 KB per embedded symbol. A 50k-
 ### Not in v1
 
 - Embedding of full function bodies.
-- Custom or alternate models (config supports `model = "..."` but only one valid value).
+- Accepting any embedding model other than `bge-small-en-v1.5`. The config field is reserved for forward compat; v1 rejects other values.
 - Cross-encoder reranking.
 
 ## 9. Sync (incremental updates)
@@ -679,6 +710,13 @@ A Claude Code session does not know any `qid` values up front. The expected patt
 ### Tool surface
 
 All prefixed `codegraph_rs_` so they coexist with the TS-version tools without naming collision in Claude Code.
+
+Common parameter conventions:
+- `qid: string` — a `Symbol` qid as defined in §4.
+- `root: string` — a workspace root **`name`** as declared in `[[workspace.roots]]` (e.g., `"splice"`), not a filesystem path.
+- `kinds: string[]` — values from the kind-label table in §4 (e.g., `["Function", "Method"]`).
+- `depth: number` — graph traversal hop limit; default 2 unless noted.
+- `limit: number` — result count cap; default 10 for searches, larger for context tools.
 
 | Tool | Inputs | Returns |
 |---|---|---|

--- a/docs/superpowers/specs/2026-04-22-codegraph-rs-design.md
+++ b/docs/superpowers/specs/2026-04-22-codegraph-rs-design.md
@@ -1,0 +1,725 @@
+# codegraph-rs — Design Spec
+
+**Status:** Draft (pre-implementation)
+**Date:** 2026-04-22
+**Target repository:** `../codegraph-rs` (sibling of the current `codegraph` repo)
+
+## 1. Goal and motivation
+
+Reimplement the existing TypeScript CodeGraph project in Rust, backed by Neo4j as the graph database. The new tool fully replaces the TypeScript version; both will run side-by-side during transition.
+
+Drivers:
+
+- **Author preference for Rust** over TypeScript for this kind of work (AST walking, graph traversal, parallelism).
+- **Neo4j visualization** (Neo4j Browser/Bloom) for understanding what the graph contains, which the SQLite-backed TS version cannot offer.
+- **Daml language support** as a new feature (Daml is the BitSafe team's primary language). Daml support could be added to the TS version, but is bundled into the rewrite because the rewrite is happening anyway.
+
+Non-goals:
+
+- Maintaining TypeScript compatibility or interop.
+- Keeping the SQLite storage path.
+- Day-one parity with every TS-version feature.
+
+## 2. Scope
+
+### In scope for v1
+
+| Module | Status |
+|---|---|
+| Tree-sitter extraction | Yes |
+| Neo4j-backed storage | Yes |
+| Reference resolution (imports + name match) | Yes |
+| Graph queries (callers, callees, impact, traversal) | Yes |
+| Vector embeddings via `fastembed-rs` + Neo4j vector index | Yes |
+| Context builder | Yes |
+| Incremental sync | Yes |
+| MCP server (stdio) | Yes |
+| Workspace config | Yes |
+
+### Out of scope for v1
+
+- Visualizer web UI (Neo4j Browser replaces it).
+- Framework-specific resolvers (React, Express, Laravel, etc.) — the resolver pipeline is generic; framework knowledge is added later as needed.
+- Auto-installed git hooks for sync — sync is user-invoked.
+- Interactive installer wizard — `init` accepts CLI flags.
+- Languages other than Rust and Daml (Python, Go, Java, etc. arrive in later versions).
+
+### Languages at v1 launch
+
+- **Rust** — via `tree-sitter-rust` crate.
+- **Daml** — via `tree-sitter-haskell` crate (Daml syntax is close to Haskell). This produces correct nodes for modules, types, functions, imports, but cannot see template- or choice-specific structure. Bringing up a real `tree-sitter-daml` grammar is a separate project tracked outside this spec.
+
+## 3. High-level architecture
+
+### Crate layout
+
+A single crate (`codegraph-rs`) with internal modules. No premature workspace splitting. The compile-time and API-design overhead of multiple crates is not justified for v1; can be extracted later when a real consumer appears.
+
+```
+codegraph-rs/
+  Cargo.toml
+  src/
+    main.rs             # CLI entry (clap)
+    lib.rs              # public re-exports
+
+    config/             # workspace config types and loading
+      mod.rs
+      workspace.rs
+
+    db/                 # Neo4j Bolt client wrapper
+      mod.rs
+      schema.rs         # constraints, indexes, vector index setup
+      queries.rs        # parameterized Cypher queries
+
+    extraction/         # tree-sitter -> raw nodes/edges
+      mod.rs
+      walker.rs
+      parser.rs
+      languages/
+        rust.rs
+        rust.scm        # tree-sitter capture queries
+        daml.rs
+        daml.scm
+
+    resolution/         # unresolved refs -> resolved edges
+      mod.rs
+      imports.rs
+      calls.rs
+
+    vectors/            # fastembed-rs orchestration
+      mod.rs
+      embedder.rs
+
+    graph/              # read-side: traversals, callers/callees, impact
+      mod.rs
+      traversal.rs
+
+    context/            # context bundles for MCP tools
+      mod.rs
+
+    sync/               # incremental updates
+      mod.rs
+
+    mcp/                # MCP server
+      mod.rs
+      tools.rs
+      transport.rs
+
+  tests/                # integration tests against a real Neo4j
+  benches/              # indexing throughput benchmarks
+```
+
+### Runtime
+
+- **Async runtime:** `tokio`. Required by `neo4rs` (Neo4j Bolt client) and `rmcp` (MCP SDK).
+- **CPU-bound work:** `rayon`. Parallel parsing across files, with results flowing through a `tokio::mpsc` channel into the async DB writer.
+- **Single process.** No sidecars, no embedded JVM. The tool is one binary that talks to an external Neo4j over Bolt.
+
+### Indexing dataflow
+
+```
+CLI -> config::load
+    -> extraction::walker      (iterate workspace roots, find source files)
+    -> extraction::parser      (rayon: parse each file with tree-sitter)
+    -> raw {nodes, edges, unresolved_refs}
+    -> db::write               (Cypher UNWIND/MERGE batches, ~500 per batch)
+    -> resolution              (second pass: resolve unresolved refs)
+    -> db::write_edges
+    -> vectors::embed          (fastembed-rs batches; write to Neo4j vector index)
+```
+
+### Query dataflow
+
+```
+Claude Code stdin -> mcp::transport
+                  -> mcp::tools::<tool>
+                  -> graph::traversal | vectors::search
+                  -> db::queries (parameterized Cypher)
+                  -> JSON response on stdout
+```
+
+## 4. Neo4j schema
+
+### Conventions
+
+- **Labels:** PascalCase (`Function`, `Class`, `File`)
+- **Relationship types:** UPPER_SNAKE_CASE (`CALLS`, `IMPORTS`)
+- **Properties:** snake_case (`qualified_name`, `start_line`)
+
+### Node labels
+
+Every code node gets two labels: `Symbol` (supertype) plus its specific kind. `(:Symbol:Function)` makes "any symbol" queries trivial while preserving kind-specific filtering.
+
+| Kind label | Use |
+|---|---|
+| `File` | A source file |
+| `Module`, `Namespace` | Container |
+| `Function`, `Method` | Callable |
+| `Class`, `Struct`, `Interface`, `Trait`, `Protocol`, `Enum`, `TypeAlias` | Types |
+| `Property`, `Field`, `Variable`, `Constant`, `Parameter`, `EnumMember` | Values |
+| `Import`, `Export` | Module boundaries |
+| `Template`, `Choice` | Daml-specific (reserved; populated only when `tree-sitter-daml` ships) |
+
+### Relationship types
+
+| Type | Meaning |
+|---|---|
+| `CONTAINS` | Lexical parent/child (`File`-`Function`, `Module`-`Class`, etc.) |
+| `CALLS` | Call from one callable to another |
+| `IMPORTS` | File or module imports another module |
+| `EXPORTS` | Symbol exported from a module |
+| `EXTENDS`, `IMPLEMENTS`, `OVERRIDES` | Inheritance / impl |
+| `REFERENCES` | Generic symbol reference |
+| `TYPE_OF`, `RETURNS` | Type relationships |
+| `INSTANTIATES` | Constructor or factory invocation |
+| `DECORATES` | Decorator or attribute |
+| `HAS_CHOICE`, `SIGNATORY`, `CONTROLLER`, `OBSERVER` | Daml-specific (reserved) |
+
+### Common properties
+
+```
+qid                TEXT     UNIQUE     "<root>:<rel_path>:<qualified_name>:<start_line>"
+name               TEXT                short identifier
+qualified_name     TEXT                fully-qualified identifier
+root_name          TEXT                workspace root this symbol belongs to
+relative_path      TEXT                path of containing file, relative to root
+language           TEXT
+start_line         INTEGER
+end_line           INTEGER
+start_col          INTEGER
+end_col            INTEGER
+signature          TEXT NULL           callables: param + return type as text
+doc                TEXT NULL           leading doc comment if any
+embedding          LIST<FLOAT> NULL    384-dim vector (set on embed-eligible nodes)
+```
+
+### File-specific properties
+
+```
+content_hash       TEXT                BLAKE3 hash of file contents (for sync diffing)
+last_indexed_at    INTEGER             unix timestamp
+```
+
+### Indexes and constraints
+
+```cypher
+CREATE CONSTRAINT symbol_qid_unique
+  FOR (n:Symbol) REQUIRE n.qid IS UNIQUE;
+
+CREATE INDEX symbol_name_idx
+  FOR (n:Symbol) ON (n.name);
+
+CREATE INDEX symbol_qualified_idx
+  FOR (n:Symbol) ON (n.qualified_name);
+
+CREATE FULLTEXT INDEX symbol_fts
+  FOR (n:Symbol) ON EACH [n.name, n.qualified_name, n.signature, n.doc];
+
+CREATE VECTOR INDEX symbol_embedding
+  FOR (n:Symbol) ON n.embedding
+  OPTIONS {
+    indexConfig: {
+      `vector.dimensions`: 384,
+      `vector.similarity_function`: 'cosine'
+    }
+  };
+```
+
+- **384 dims** matches `fastembed-rs`'s default `BAAI/bge-small-en-v1.5` model.
+- **Full-text index** replaces the SQLite FTS5 table.
+- **Vector index** lives on the same node — embedding is a property, not a separate row.
+
+### Identity scheme
+
+`qid = "<root_name>:<relative_path>:<qualified_name>:<start_line>"` — deterministic, stable, cross-root-safe. On reindex, MERGE by `qid` is naturally idempotent.
+
+## 5. Workspace model and database isolation
+
+### Workspace = one logical graph
+
+A **workspace** is one logical project that may span multiple source root folders. Examples:
+
+- A multi-root Daml workspace combining `splice/` and `utility/` into one connected graph, so a `Utility.Foo` import inside `splice/` becomes a real `IMPORTS` edge in the graph.
+- A single-root Rust workspace (e.g., codegraph-rs dogfooding itself) is the degenerate case.
+
+One workspace maps to one Neo4j database. Database-per-workspace, not database-per-root, gives:
+
+- Hard isolation between workspaces (e.g., the codegraph-rs source graph is fully separate from the daml-stack graph).
+- No per-query filtering boilerplate inside Cypher.
+- Cheap drop/reindex of one workspace via `DROP DATABASE`.
+
+This relies on Neo4j Enterprise Edition for multi-database support, which is what Neo4j Desktop installs by default — free for local development use.
+
+### Workspace config file
+
+Canonical path: `<workspace_dir>/.codegraph/config.toml`.
+
+CLI discovery: walk upward from cwd until a `.codegraph/config.toml` is found, or use `--workspace <path>` to specify explicitly. Same pattern as `git` finding `.git/`.
+
+Example (multi-root Daml workspace):
+
+```toml
+schema_version = 1
+
+[workspace]
+name = "daml-stack"
+
+[workspace.neo4j]
+uri = "bolt://localhost:7687"
+database = "codegraph_daml_stack"
+username = "neo4j"
+# password lives in .codegraph/secrets.toml or env
+
+[[workspace.roots]]
+name = "splice"
+path = "../splice"               # relative to this config file
+
+[[workspace.roots]]
+name = "utility"
+path = "../utility"
+
+[indexing]
+languages = ["rust", "daml"]     # optional whitelist
+ignore_extra = ["target/**", ".daml/**"]
+
+[embeddings]
+enabled = true
+model = "bge-small-en-v1.5"      # only valid value in v1
+```
+
+Single-root self-host config is the obvious shrink of the above.
+
+### Secrets
+
+- `.codegraph/secrets.toml` holds `neo4j_password = "..."`. Auto-gitignored by `codegraph-rs init`.
+- Environment variable `CODEGRAPH_RS_NEO4J_PASSWORD` overrides the file.
+- If neither is present, `codegraph-rs` prompts on stdin in interactive CLI mode. Never prompts in `serve` mode.
+
+### Validation
+
+- Config parsed with `serde` + `toml`. Schema errors produce human-friendly messages pointing at the offending field.
+- `schema_version` required; unknown versions fail fast.
+- Root paths canonicalized at load time; non-existent roots are a hard error.
+- Neo4j connectivity verified before indexing — fail fast if the DBMS isn't running.
+
+## 6. Extraction pipeline
+
+### File discovery
+
+- `ignore` crate (the walker behind ripgrep). Honors `.gitignore`, `.ignore`, and a workspace-level `.codegraphignore`.
+- Walks all roots in parallel; each root contributes files with its `root_name` baked in.
+- Language detected by extension: `.rs` → Rust, `.daml` → Daml.
+
+### Parsing
+
+- One `tree_sitter::Parser` per worker thread (`thread_local!`) since parsers are not `Sync`.
+- Grammars loaded at startup from linked crates: `tree_sitter_rust::LANGUAGE`, `tree_sitter_haskell::LANGUAGE`.
+- `.daml` files are mapped to the Haskell language in `languages/daml.rs` — a one-line mapping that flips to `tree_sitter_daml::LANGUAGE` when that crate exists.
+
+### Per-language extractors
+
+A trait abstracts the extraction step:
+
+```rust
+pub trait LanguageExtractor: Send + Sync {
+    fn extract(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        file_id: &str,
+        root_name: &str,
+    ) -> ExtractionResult;
+}
+
+pub struct ExtractionResult {
+    pub nodes: Vec<RawNode>,
+    pub edges: Vec<RawEdge>,
+    pub unresolved_refs: Vec<UnresolvedRef>,
+}
+```
+
+- `languages/rust.rs` maps Rust AST nodes — `function_item` → `Function`, `struct_item` → `Struct`, `impl_item` → `Impl` (whose contained methods inherit the impl context), `use_declaration` → `Import`, `call_expression` → captures an `UnresolvedRef`.
+- `languages/daml.rs` maps Haskell-grammar nodes — `function` → `Function`, `decl/type_synonym` → `TypeAlias`, `data_type` → `Struct`, `module` → `Module`, `import` → `Import`. Templates, choices, and signatories are not extracted in v1; the Haskell grammar does not see them.
+- Each extractor uses tree-sitter `.scm` query files (capture queries) to locate interesting AST nodes declaratively rather than hand-walking.
+
+### Parallelism and writes
+
+- `rayon` par-iter drives the file list; each file emits one `ExtractionResult`.
+- Results stream into a `tokio::mpsc` channel feeding the async DB writer.
+- DB writer batches nodes/edges in groups of ~500 and writes via `UNWIND $batch AS row MERGE ...` — one round-trip per batch, not per node.
+- File `content_hash` (BLAKE3) and `last_indexed_at` are written when extraction completes for that file.
+
+### UnresolvedRef
+
+Captures "this call/reference needs resolution":
+
+```rust
+pub struct UnresolvedRef {
+    pub source_qid: String,         // the caller / referencer
+    pub unresolved_name: String,    // "foo", "Module.foo", "crate::util::foo"
+    pub kind: UnresolvedKind,       // Call, Import, TypeRef, etc.
+    pub line: u32,
+    pub col: u32,
+}
+```
+
+Stored as `(:UnresolvedRef)` nodes with an edge to the source, then consumed in the resolution pass.
+
+### Error handling
+
+- Parse failures on individual files: log + skip, do not abort the run.
+- Tree-sitter `ERROR` nodes inside a file: extraction continues over valid portions; logged at debug level.
+
+### Not in v1
+
+- Framework-specific enrichment (no React, Express, Laravel resolvers).
+- Tree-sitter incremental parsing — v1 reparses changed files whole-file.
+
+## 7. Resolution pipeline
+
+### Problem
+
+After extraction, the graph has `Function` nodes and `UnresolvedRef` nodes. A call site that invokes `foo()` knows only the string `"foo"`. Resolution turns those into `(:Function)-[:CALLS]->(:Function)` edges.
+
+### Order
+
+Resolution runs **after all files are extracted and written**, so every candidate target already exists in the graph.
+
+### Two-stage resolver
+
+**Stage 1 — Import-driven (high confidence)**
+
+For each unresolved ref:
+1. Look at the source file's `IMPORTS` edges.
+2. Walk from each imported module/file to its `EXPORTS` or `CONTAINS` children.
+3. Match by name. If exactly one candidate, create the resolved edge.
+
+Rust specifics:
+- `use crate::util::foo;` → resolves `foo` calls to `crate::util::foo`.
+- `use crate::util;` then `util::foo()` → walks module prefix.
+- `mod` declarations build the module tree; path segments traverse it.
+
+Daml specifics (via Haskell grammar):
+- `import Utility.Foo` → file imports module.
+- Calls resolve through imports in scope.
+- Cross-root works naturally: both roots populate the same Neo4j database, module-qualified names are globally unique.
+
+**Stage 2 — Name-match fallback (lower confidence)**
+
+For refs unresolved after stage 1:
+- Exact name match across the whole workspace.
+- If exactly one candidate → edge created with `confidence: "name_match"` property.
+- If multiple candidates → leave as a persistent `(:UnresolvedRef)` with all candidates recorded.
+
+Confidence is a relationship property; queries can filter on it but most won't.
+
+### Cross-root module resolution
+
+Workspace has roots `splice` and `utility`. A Daml file under `splice/` with `import Utility.Foo` must resolve to a module inside `utility/`.
+
+- The resolver looks up modules by their **qualified-name string** (e.g., `"Utility.Foo"`) across the full workspace, ignoring the `root_name` boundary. If exactly one `Module` node has that `qualified_name`, the import resolves there.
+- The resolver does not parse `Cargo.toml` or `daml.yaml` to derive package boundaries in v1; resolution is purely on extracted qualified names.
+- Ambiguity (same `qualified_name` in two roots) → leave unresolved, log warning.
+
+### Cleanup
+
+After resolution completes, `(:UnresolvedRef)` nodes that produced an edge are deleted. Unresolved remainders stay (with a `reason` property) for debugging.
+
+### Not in v1
+
+- Framework resolvers.
+- Generic / type-aware dispatch reasoning.
+- Cross-crate / external dependency indexing.
+
+## 8. Vector embeddings
+
+### Model
+
+- `fastembed-rs` with `BAAI/bge-small-en-v1.5` (384 dims, ~130 MB ONNX file, ~50 ms per short doc on CPU).
+- Auto-downloaded on first use to `~/.cache/codegraph-rs/fastembed/`.
+- Single model across all languages.
+
+### What gets embedded
+
+Not every node — embedding `Variable` nodes named `i` is noise. v1 embeds:
+
+- `Function`, `Method`
+- `Class`, `Struct`, `Interface`, `Trait`, `Protocol`, `Enum`
+- `TypeAlias`
+- `Module`
+- `Template`, `Choice` (when `tree-sitter-daml` ships)
+
+Leaf values (`Variable`, `Constant`, `Parameter`, `Field`, `EnumMember`) are not embedded.
+
+### Composed text
+
+```
+<kind>: <qualified_name>
+<signature>
+<doc>
+```
+
+Example:
+
+```
+function: crate::util::parse_config
+fn parse_config(path: &Path) -> Result<Config, ConfigError>
+Parse a config file from disk, returning the parsed settings or a descriptive error.
+```
+
+Body content is intentionally not included — keeps the embedding focused on intent rather than implementation detail.
+
+### When
+
+During indexing, after extraction and resolution. Batched at 128 texts per `fastembed-rs::embed()` call. Written via parameterized Cypher that targets the existing nodes by `qid`.
+
+### Search
+
+```cypher
+CALL db.index.vector.queryNodes('symbol_embedding', $k, $queryVec)
+  YIELD node, score
+WHERE node.root_name IN $roots         // optional
+RETURN node, score
+ORDER BY score DESC
+```
+
+Query vector produced by embedding the user query text with the same model. `$k` defaults to 10. Optional root filter scopes to a subset of roots.
+
+### Sync re-embedding
+
+- Changed file → contained embedded-kind nodes are re-extracted, re-resolved, re-embedded. Old embeddings overwritten.
+- Unchanged file → embeddings untouched.
+
+### Storage
+
+Neo4j stores 384-dim float32 vectors inline. ~1.5 KB per embedded symbol. A 50k-symbol workspace ≈ 75 MB. Acceptable.
+
+### Not in v1
+
+- Embedding of full function bodies.
+- Custom or alternate models (config supports `model = "..."` but only one valid value).
+- Cross-encoder reranking.
+
+## 9. Sync (incremental updates)
+
+### Principle
+
+`codegraph-rs sync` is idempotent and diff-driven. Same end state as a full reindex, but only touches what changed.
+
+### Detection
+
+For each root in the workspace:
+1. Walk the filesystem with the `ignore` crate. Collect `{relative_path, content_hash}` using BLAKE3.
+2. Query Neo4j: `MATCH (f:File {root_name: $root}) RETURN f.relative_path, f.content_hash`.
+3. Diff:
+   - **Added** — in filesystem, not in DB.
+   - **Changed** — in both, hashes differ.
+   - **Deleted** — in DB, not in filesystem.
+
+### Per-bucket actions
+
+**Added** — extract → write nodes/edges → queue for resolution + embedding.
+
+**Changed** — delete the file's nodes and contents, then re-extract:
+
+```cypher
+MATCH (f:File {root_name: $root, relative_path: $rel})
+OPTIONAL MATCH (f)-[:CONTAINS*]->(child)
+DETACH DELETE f, child
+```
+
+Then re-extract.
+
+**Deleted** — same `DETACH DELETE` pattern, no re-extraction.
+
+### Resolution after partial changes
+
+After the changed/added set is re-extracted, run resolution **globally** — not just for affected files. A newly added function may satisfy previously-unresolved refs from elsewhere. Resolution is cheap; correctness here matters more than speed.
+
+### Embedding after changes
+
+- Newly extracted symbols → embedded in the same batch as initial indexing.
+- Unchanged symbols → keep existing embeddings.
+
+### Workspace-level sync
+
+One `codegraph-rs sync` iterates roots in sequence. Parallel-root sync is not v1.
+
+### Consistency
+
+- No transactional sync. If the process crashes mid-sync, the next run recovers via the same diff.
+- No locking against concurrent sync sessions on the same workspace — documented as "don't run two at once."
+
+### Not in v1
+
+- Git hooks / file watchers.
+- Tree-sitter incremental reparse.
+
+## 10. MCP server
+
+### SDK
+
+- `rmcp` — official Rust MCP SDK from Anthropic. Active, first-party, supports stdio transport out of the box.
+- Avoids hand-rolling JSON-RPC framing, the initialize handshake, and tool listing.
+
+### Lifecycle
+
+- `codegraph-rs serve` launches the MCP server on stdio.
+- On startup: locate workspace config, open Neo4j connection (Bolt, auth from config), preload the `fastembed-rs` model.
+- Shutdown: close the Bolt connection cleanly on stdin EOF or SIGTERM.
+
+### Tool surface
+
+All prefixed `codegraph_rs_` so they coexist with the TS-version tools without naming collision in Claude Code.
+
+| Tool | Inputs | Returns |
+|---|---|---|
+| `codegraph_rs_search` | `query: string`, `kinds?: string[]`, `root?: string`, `limit?: number` | Symbol matches via FTS + name prefix |
+| `codegraph_rs_semantic_search` | `query: string`, `root?: string`, `limit?: number` | Top-k semantic matches with score |
+| `codegraph_rs_callers` | `qid: string`, `depth?: number` | Functions calling this symbol up to `depth` hops |
+| `codegraph_rs_callees` | `qid: string`, `depth?: number` | Functions called by this symbol |
+| `codegraph_rs_impact` | `qid: string`, `depth?: number` | Reverse-transitive closure |
+| `codegraph_rs_node` | `qid: string` | Full details + source snippet |
+| `codegraph_rs_files` | `root?: string` | Indexed files with counts |
+| `codegraph_rs_context` | `task: string`, `limit?: number` | Curated bundle: semantic hits + neighborhoods |
+| `codegraph_rs_explore` | `topic: string`, `depth?: number` | Multi-hop expansion around seed symbols |
+| `codegraph_rs_status` | — | Node/edge/file counts, embedding coverage, last sync time |
+
+### Implementation pattern
+
+Each tool is a thin adapter: validate input → call a method on `graph::*`, `vectors::*`, or `context::*` → serialize JSON.
+
+```rust
+#[tool(name = "codegraph_rs_callers")]
+async fn callers(&self, args: CallersArgs) -> Result<CallersResponse> {
+    let results = self.graph.callers(&args.qid, args.depth.unwrap_or(2)).await?;
+    Ok(CallersResponse::from(results))
+}
+```
+
+Heavy logic stays in non-MCP modules; `mcp/tools.rs` stays thin.
+
+### Responses
+
+- Stable JSON structs (`serde::Serialize`); schemas published via MCP `inputSchema`/`outputSchema`.
+- Source snippets read on demand from disk using stored `relative_path` + `root_name`. Files are not stored in Neo4j.
+
+### Errors
+
+- Neo4j unreachable → structured MCP error with actionable message ("Neo4j Desktop not running; start the DBMS and retry"). Server stays up.
+- Unknown `qid` → structured error with fuzzy-match suggestion.
+- Input validation errors → tool-level errors, not server-level.
+
+### Not in v1
+
+- Streaming responses.
+- Auth / multi-client.
+- Background reindex during `serve` — user runs `codegraph-rs sync` separately.
+
+## 11. CLI surface
+
+```
+codegraph-rs init                  scaffold .codegraph/, prompt for Neo4j details
+codegraph-rs index                 full build
+codegraph-rs sync                  incremental
+codegraph-rs status                stats
+codegraph-rs query <text>          codegraph_rs_search from terminal
+codegraph-rs serve                 MCP stdio server
+```
+
+All commands accept `--workspace <path>`. No `codegraph-rs hooks install` in v1.
+
+## 12. Distribution
+
+- `cargo install codegraph-rs` is the v1 distribution channel. Users need a Rust toolchain first.
+- No pre-built binaries, no Homebrew formula in v1. Both can be added later with minimal change.
+- Neo4j is **not** distributed with the tool. Documentation directs users to install Neo4j Desktop (free for local development) and provides a "first 5 minutes" walkthrough.
+
+## 13. Testing
+
+### Unit tests
+
+- `config/` — TOML parsing edge cases, schema version mismatch, missing roots, path canonicalization.
+- `extraction/walker` — gitignore honoring, root-scoped iteration, extension → language mapping.
+- `extraction/languages/*` — small inline Rust/Daml snippets, run extractor, assert on `RawNode`/`RawEdge` shape and counts. One fixture per language.
+- `resolution/` — synthetic in-memory graph + unresolved-ref lists. No Neo4j needed.
+- `graph/traversal` — in-memory graph, assert traversal results.
+- `vectors/embedder` — gated on `CODEGRAPH_RS_TEST_EMBEDDINGS=1` since loading the model is slow and downloads weights. Default-off in CI.
+
+### Integration tests (real Neo4j)
+
+- Test fixture spins up a fresh dedicated database (`codegraph_test_<pid>`).
+- Tests annotated `#[tokio::test]` with `#[ignore]` unless `CODEGRAPH_RS_TEST_NEO4J=1` is set.
+- Each test:
+  1. Writes a small codebase into a `tempfile::tempdir()`.
+  2. Runs the full indexing pipeline against the test DB.
+  3. Asserts via Cypher.
+- Checked-in fixtures under `tests/fixtures/`:
+  - `tiny-rust/` — 3-file Rust project with cross-module calls.
+  - `tiny-daml/` — Daml project mirroring real Daml shape.
+  - `multi-root/` — two roots with cross-root imports; used for the workspace integration test.
+
+### End-to-end MCP test
+
+A single integration test launches the MCP server in-process, sends JSON-RPC requests through an in-memory channel pair, and asserts response shapes. Covers initialize → list_tools → call_tool for each tool → shutdown.
+
+### CI
+
+GitHub Actions, two jobs:
+
+- **Fast** (always runs): unit tests + compile + clippy. No Neo4j.
+- **Slow** (on PR label or nightly): integration tests + MCP test. Uses a `neo4j:5.x-enterprise` service container with CI-only license acceptance.
+
+Plus `cargo deny` for license/advisory checks.
+
+## 14. Risks and open questions
+
+### Risks
+
+| Risk | Mitigation |
+|---|---|
+| `tree-sitter-haskell` parse quality on real Daml templates is poor enough to produce misleading `Function` nodes from template bodies | Accept as v1 limitation. Tag affected nodes with a `tree_sitter_reliable` property. Document the gap in README until `tree-sitter-daml` ships |
+| `fastembed-rs` model download (~130 MB) can fail on slow connections | Fail with clear retry message; document cache location; plan a `codegraph-rs prepare` command in v2 |
+| `neo4rs` driver maturity / Bolt edge cases | Pin a known-good version. Wrap behind `db/` so the driver can be swapped locally |
+| Neo4j Enterprise licensing for users distributing the tool or running in CI | v1 documents "use Neo4j Desktop (free for local dev)"; CI accepts license explicitly. Tool itself never bundles Neo4j |
+| Parallelism bug surface (rayon + tokio + tree-sitter thread-locals) | Narrow join points: rayon collects, channel hands off, tokio writes. No shared mutable state across tasks |
+| `codegraph_rs_explore` response sizes growing unmanageable | Default response budget (~50 KB) with `limit` parameter and a "truncated — use more specific query" marker |
+| Pre-1.0 dependencies (`fastembed-rs`, `rmcp` may evolve) | Pin specific versions in `Cargo.toml`. Wrap behind module boundaries |
+
+### Open questions
+
+1. **Eager vs deferred initial embedding generation.** *Proposed:* run eagerly during the first index; add `--skip-embeddings` for impatient bootstrapping.
+2. **`codegraph-rs init` ergonomics.** *Proposed:* interactive by default; `--non-interactive` plus flags for scripting.
+3. **Tree-sitter grammar pinning.** *Proposed:* pin in `Cargo.toml` only; do not surface in workspace config.
+
+## 15. Out of scope (intentionally deferred)
+
+- Visualizer web UI (Neo4j Browser replaces it).
+- Framework-specific resolvers.
+- Auto-installed git hooks.
+- Languages other than Rust and Daml.
+- Pre-built binaries / Homebrew distribution.
+- A real `tree-sitter-daml` grammar — separate project; can swap into `extraction/languages/daml.rs` with a one-line change when ready.
+- Per-root language overrides.
+- Body-content embeddings, custom embedding models, cross-encoder reranking.
+- Cross-crate / cross-package external dependency indexing.
+
+## 16. Decisions log
+
+Decisions made during the brainstorming phase, in chronological order:
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Full replacement of TS version | User intent |
+| 2 | Storage: Neo4j Desktop (Enterprise), Bolt protocol | Visualization driver + multi-database support, accepted install friction |
+| 3 | Embeddings: `fastembed-rs` + Neo4j vector index | Single store, native vector index in Neo4j, pure-Rust embedding lib |
+| 4 | v1 modules: extraction, db, graph, mcp, sync, resolution, vectors, context | Drop visualizer, framework resolvers, installer wizard for v1 |
+| 5 | v1 languages: Rust + Daml | Rust = author preference + dogfooding; Daml = primary user language |
+| 6 | Tree-sitter binding: native `tree-sitter` crate | Rust ecosystem standard; faster than WASM |
+| 7 | Daml grammar in v1: `tree-sitter-haskell` (proxy) | Real `tree-sitter-daml` is a separate project; Haskell covers ~80% |
+| 8 | Multi-project = workspace with multiple source roots | User wants cross-project Daml graph (splice + utility) |
+| 9 | Database isolation: one Neo4j database per workspace | Hard isolation, clean queries; supported by Neo4j Enterprise |
+| 10 | MCP tool naming: `codegraph_rs_*` | Coexist with TS version's `codegraph_*` tools without collision |
+| 11 | Distribution: `cargo install` | Simplest for v1; users have Rust if they're using Rust tooling |
+| 12 | Crate layout: single crate, internal modules | Premature workspace splitting adds friction without payoff |
+| 13 | Considered Grafeo (embedded Rust graph DB) and rejected | Spike showed Cypher and persistence work, but Grafeo lacks mature visualization (a stated user driver), persistent vector index, and proper concurrent-process semantics. Pre-1.0 maturity adds risk |

--- a/docs/superpowers/specs/2026-04-22-codegraph-rs-design.md
+++ b/docs/superpowers/specs/2026-04-22-codegraph-rs-design.md
@@ -121,12 +121,20 @@ codegraph-rs/
 CLI -> config::load
     -> extraction::walker      (iterate workspace roots, find source files)
     -> extraction::parser      (rayon: parse each file with tree-sitter)
-    -> raw {nodes, edges, unresolved_refs}
-    -> db::write               (Cypher UNWIND/MERGE batches, ~500 per batch)
-    -> resolution              (second pass: resolve unresolved refs)
-    -> db::write_edges
-    -> vectors::embed          (fastembed-rs batches; write to Neo4j vector index)
+    -> raw {nodes, structural_edges, unresolved_refs}
+    -> db::write_extraction    (Cypher UNWIND/MERGE for nodes + UnresolvedRef
+                                + structural edges: CONTAINS, EXTENDS,
+                                IMPLEMENTS produced directly from AST)
+    -> resolution              (UnresolvedRefs -> CALLS, IMPORTS-targets,
+                                REFERENCES, TYPE_OF — derived from
+                                UnresolvedRef records, not extraction)
+    -> db::write_resolution    (resolution-produced edges in batches)
+    -> vectors::embed          (fastembed-rs batches; SET embedding via Cypher)
 ```
+
+Edges fall into two cleanly separated buckets:
+- **Structural edges** (produced by extraction, derivable from a single file's AST): `CONTAINS`, `EXTENDS`, `IMPLEMENTS`, `EXPORTS`, `INSTANTIATES`, `DECORATES`, `OVERRIDES`, `RETURNS`, `TYPE_OF` (when the type is in the same file).
+- **Resolution-derived edges** (produced by resolution from `UnresolvedRef` records, may cross files): `CALLS`, `IMPORTS` (target side), `REFERENCES`, cross-file `TYPE_OF`.
 
 ### Query dataflow
 
@@ -148,17 +156,22 @@ Claude Code stdin -> mcp::transport
 
 ### Node labels
 
-Every code node gets two labels: `Symbol` (supertype) plus its specific kind. `(:Symbol:Function)` makes "any symbol" queries trivial while preserving kind-specific filtering.
+Every code node gets two labels: `Symbol` (supertype) plus its specific kind. `(:Symbol:Function)` makes "any symbol" queries trivial while preserving kind-specific filtering. **Extractors must always emit both labels** — single-label nodes are a bug.
+
+The word "module" in this spec means the Neo4j label `Module` (a graph node) unless preceded by a language qualifier like "Rust module" or "Daml module."
 
 | Kind label | Use |
 |---|---|
 | `File` | A source file |
 | `Module`, `Namespace` | Container |
 | `Function`, `Method` | Callable |
-| `Class`, `Struct`, `Interface`, `Trait`, `Protocol`, `Enum`, `TypeAlias` | Types |
+| `Class`, `Struct`, `Interface`, `Trait`, `Enum`, `TypeAlias` | Types (v1: only `Struct`, `Trait`, `Enum`, `TypeAlias` produced; others reserved for future languages) |
 | `Property`, `Field`, `Variable`, `Constant`, `Parameter`, `EnumMember` | Values |
 | `Import`, `Export` | Module boundaries |
+| `UnresolvedRef` | Permanent record of an unresolved name reference (see §7) |
 | `Template`, `Choice` | Daml-specific (reserved; populated only when `tree-sitter-daml` ships) |
+
+**Note on `impl` blocks (Rust) and instance declarations (Daml/Haskell):** v1 does NOT emit a separate `Impl` node. Methods inside `impl Foo { fn bar() }` are emitted as `Method` nodes whose `qualified_name` carries the type prefix (`crate::module::Foo::bar`), and whose `CONTAINS` parent is the source file. The type-to-method relationship is captured implicitly by the `qualified_name` and can be derived by querying for methods whose `qualified_name` starts with `<TypeQualName>::`.
 
 ### Relationship types
 
@@ -173,12 +186,13 @@ Every code node gets two labels: `Symbol` (supertype) plus its specific kind. `(
 | `TYPE_OF`, `RETURNS` | Type relationships |
 | `INSTANTIATES` | Constructor or factory invocation |
 | `DECORATES` | Decorator or attribute |
+| `HAS_REF` | From a `Symbol` to its `UnresolvedRef` records (structural; produced during extraction) |
 | `HAS_CHOICE`, `SIGNATORY`, `CONTROLLER`, `OBSERVER` | Daml-specific (reserved) |
 
 ### Common properties
 
 ```
-qid                TEXT     UNIQUE     "<root>:<rel_path>:<qualified_name>:<start_line>"
+qid                TEXT     UNIQUE     "<root>:<rel_path>:<qualified_name>[#<n>]"
 name               TEXT                short identifier
 qualified_name     TEXT                fully-qualified identifier
 root_name          TEXT                workspace root this symbol belongs to
@@ -191,6 +205,8 @@ end_col            INTEGER
 signature          TEXT NULL           callables: param + return type as text
 doc                TEXT NULL           leading doc comment if any
 embedding          LIST<FLOAT> NULL    384-dim vector (set on embed-eligible nodes)
+parse_reliable     BOOLEAN             false on Daml `template`/`choice`/`signatory`
+                                       blocks where the Haskell grammar misparses
 ```
 
 ### File-specific properties
@@ -231,7 +247,24 @@ CREATE VECTOR INDEX symbol_embedding
 
 ### Identity scheme
 
-`qid = "<root_name>:<relative_path>:<qualified_name>:<start_line>"` — deterministic, stable, cross-root-safe. On reindex, MERGE by `qid` is naturally idempotent.
+```
+qid = "<root_name>:<relative_path>:<qualified_name>[#<ordinal>]"
+```
+
+- `qualified_name` is the language-specific fully qualified identifier (e.g., `crate::util::parse_config`, `Splice.Foo.bar`, `Splice.Foo.Bar::baz` for a method on a type).
+- The `#<ordinal>` suffix is omitted unless the same `(root, relative_path, qualified_name)` triple has multiple symbols — extremely rare in Rust and Daml since both languages disallow same-name overloads at one scope. When a collision is detected during extraction, the extractor assigns `#1`, `#2`, … by source-order.
+- **`start_line` is deliberately NOT in the qid.** Including it would invalidate every downstream symbol's qid whenever a function is added above it in the same file, cascading edge invalidation across the graph. Position lives in the `start_line`/`end_line` properties only.
+- On reindex, MERGE by `qid` is naturally idempotent.
+
+### Edge properties
+
+Edges may carry small property sets. v1 uses:
+
+| Edge type | Property | Values | Meaning |
+|---|---|---|---|
+| `CALLS`, `REFERENCES`, `TYPE_OF` (etc., resolution-produced) | `confidence` | `"import_resolved"` \| `"name_match"` | How the resolver derived this edge (see §7) |
+
+Other edge types carry no properties in v1.
 
 ## 5. Workspace model and database isolation
 
@@ -250,6 +283,19 @@ One workspace maps to one Neo4j database. Database-per-workspace, not database-p
 
 This relies on Neo4j Enterprise Edition for multi-database support, which is what Neo4j Desktop installs by default — free for local development use.
 
+### Database creation and privileges
+
+`codegraph-rs init` (and `codegraph-rs index` if the database does not yet exist) issues `CREATE DATABASE <name> IF NOT EXISTS` against Neo4j's `system` database. This requires the configured Neo4j user to have the `CREATE DATABASE` privilege. The Neo4j Desktop default `neo4j` admin user has this privilege; users with restricted accounts must either grant the privilege or pre-create the database manually.
+
+### Database naming
+
+Neo4j 5 database names must:
+- be 3–63 characters,
+- start with an ASCII letter,
+- contain only ASCII letters, digits, dots, and dashes (**no underscores**, no other special characters).
+
+Spec convention for generated database names: `codegraph-<workspace-name>` with the workspace name lowercased and any non-conforming characters replaced by `-`.
+
 ### Workspace config file
 
 Canonical path: `<workspace_dir>/.codegraph/config.toml`.
@@ -266,7 +312,7 @@ name = "daml-stack"
 
 [workspace.neo4j]
 uri = "bolt://localhost:7687"
-database = "codegraph_daml_stack"
+database = "codegraph-daml-stack"   # see Database naming above
 username = "neo4j"
 # password lives in .codegraph/secrets.toml or env
 
@@ -279,13 +325,14 @@ name = "utility"
 path = "../utility"
 
 [indexing]
-languages = ["rust", "daml"]     # optional whitelist
-ignore_extra = ["target/**", ".daml/**"]
+languages = ["rust", "daml"]     # optional whitelist; default: all detected
 
 [embeddings]
 enabled = true
 model = "bge-small-en-v1.5"      # only valid value in v1
 ```
+
+Custom file-pattern excludes go in `<workspace_dir>/.codegraph/.codegraphignore`, which uses gitignore syntax. There is no inline TOML escape hatch — keeping all ignore rules in one place avoids confusion about precedence.
 
 Single-root self-host config is the obvious shrink of the above.
 
@@ -338,7 +385,7 @@ pub struct ExtractionResult {
 }
 ```
 
-- `languages/rust.rs` maps Rust AST nodes — `function_item` → `Function`, `struct_item` → `Struct`, `impl_item` → `Impl` (whose contained methods inherit the impl context), `use_declaration` → `Import`, `call_expression` → captures an `UnresolvedRef`.
+- `languages/rust.rs` maps Rust AST nodes — `function_item` → `Function`, `struct_item` → `Struct`, `enum_item` → `Enum`, `trait_item` → `Trait`, `type_item` → `TypeAlias`, `mod_item` → `Module`, `use_declaration` → `Import`, `call_expression` → captures an `UnresolvedRef`. `impl_item` is not a node itself; its methods are emitted as `Method` nodes whose `qualified_name` includes the impl'd type (`<crate>::<mod>::<Type>::<method>`) and whose `CONTAINS` parent is the source file (see §4 note on `impl` blocks).
 - `languages/daml.rs` maps Haskell-grammar nodes — `function` → `Function`, `decl/type_synonym` → `TypeAlias`, `data_type` → `Struct`, `module` → `Module`, `import` → `Import`. Templates, choices, and signatories are not extracted in v1; the Haskell grammar does not see them.
 - Each extractor uses tree-sitter `.scm` query files (capture queries) to locate interesting AST nodes declaratively rather than hand-walking.
 
@@ -351,19 +398,17 @@ pub struct ExtractionResult {
 
 ### UnresolvedRef
 
-Captures "this call/reference needs resolution":
+Captures "this call/reference needs resolution." Stored as a permanent `(:UnresolvedRef)` node connected to its source by `(:Symbol)-[:HAS_REF]->(:UnresolvedRef)`. The full schema is in §4 / §7 — extraction emits these records and never touches the resolution-derived edges that depend on them.
 
 ```rust
 pub struct UnresolvedRef {
     pub source_qid: String,         // the caller / referencer
     pub unresolved_name: String,    // "foo", "Module.foo", "crate::util::foo"
-    pub kind: UnresolvedKind,       // Call, Import, TypeRef, etc.
+    pub kind: UnresolvedKind,       // Call, Import, TypeRef, Reference
     pub line: u32,
     pub col: u32,
 }
 ```
-
-Stored as `(:UnresolvedRef)` nodes with an edge to the source, then consumed in the resolution pass.
 
 ### Error handling
 
@@ -377,22 +422,41 @@ Stored as `(:UnresolvedRef)` nodes with an edge to the source, then consumed in 
 
 ## 7. Resolution pipeline
 
-### Problem
+### Core idea: `UnresolvedRef` is the durable record of source-code intent
 
-After extraction, the graph has `Function` nodes and `UnresolvedRef` nodes. A call site that invokes `foo()` knows only the string `"foo"`. Resolution turns those into `(:Function)-[:CALLS]->(:Function)` edges.
+Every cross-symbol reference produced by extraction (a function call, an import, a type reference, etc.) is materialized as a permanent `(:UnresolvedRef)` node. These nodes are **the source of truth for what the source code says**, independent of whether the resolver currently has a target for them.
+
+Resolution-derived edges (`CALLS`, `IMPORTS`-target, `REFERENCES`, cross-file `TYPE_OF`) are **derived/cached** from `UnresolvedRef` records. They are recomputed whenever the source records or the candidate targets change.
+
+This shape makes incremental sync correct: when file B is re-extracted with potentially different `qid`s, B's `UnresolvedRef` records are deleted and re-created, but file A's `UnresolvedRef` records (which referenced symbols *in* B) are untouched. Re-running resolution recreates the cross-file edges against B's new symbols.
+
+### `UnresolvedRef` schema
+
+```
+qid                TEXT  UNIQUE  "<source_qid>:ref:<line>:<col>:<ord>"
+source_qid         TEXT          the caller / referencer
+unresolved_name    TEXT          "foo", "Module.foo", "crate::util::foo"
+kind               TEXT          "call" | "import" | "type_ref" | "reference"
+line               INTEGER
+col                INTEGER
+candidate_qids     LIST<TEXT>    set when stage-2 finds >1 candidate (else NULL)
+unresolved_reason  TEXT NULL     "no_candidate" | "ambiguous" | NULL when resolved
+```
+
+An `UnresolvedRef` is connected to its source by `(source)-[:HAS_REF]->(:UnresolvedRef)`. The `HAS_REF` edges are structural and produced during extraction. They do not require resolution.
 
 ### Order
 
-Resolution runs **after all files are extracted and written**, so every candidate target already exists in the graph.
+Resolution runs **after all files are extracted/written**, so every candidate target exists. During incremental sync, resolution runs after the changed/added/deleted files have been processed.
 
 ### Two-stage resolver
 
 **Stage 1 — Import-driven (high confidence)**
 
-For each unresolved ref:
+For each `UnresolvedRef`:
 1. Look at the source file's `IMPORTS` edges.
 2. Walk from each imported module/file to its `EXPORTS` or `CONTAINS` children.
-3. Match by name. If exactly one candidate, create the resolved edge.
+3. Match by name. If exactly one candidate → create a resolution edge of the appropriate type (`CALLS` for `kind="call"`, etc.) from `source_qid` to the candidate, with `confidence: "import_resolved"`.
 
 Rust specifics:
 - `use crate::util::foo;` → resolves `foo` calls to `crate::util::foo`.
@@ -402,28 +466,49 @@ Rust specifics:
 Daml specifics (via Haskell grammar):
 - `import Utility.Foo` → file imports module.
 - Calls resolve through imports in scope.
-- Cross-root works naturally: both roots populate the same Neo4j database, module-qualified names are globally unique.
+- Cross-root works naturally: both roots populate the same Neo4j database; module qualified names are globally unique.
 
 **Stage 2 — Name-match fallback (lower confidence)**
 
-For refs unresolved after stage 1:
-- Exact name match across the whole workspace.
-- If exactly one candidate → edge created with `confidence: "name_match"` property.
-- If multiple candidates → leave as a persistent `(:UnresolvedRef)` with all candidates recorded.
+For `UnresolvedRef`s not resolved by stage 1:
+- Exact name match against `qualified_name` across the whole workspace.
+- If exactly one candidate → resolution edge created with `confidence: "name_match"`.
+- If multiple candidates → no edge created; record candidates on the `UnresolvedRef` node:
 
-Confidence is a relationship property; queries can filter on it but most won't.
+  ```cypher
+  MATCH (r:UnresolvedRef {qid: $ref_qid})
+  SET r.candidate_qids = $candidate_qids,
+      r.unresolved_reason = 'ambiguous'
+  ```
+
+- If zero candidates → set `unresolved_reason = 'no_candidate'`.
 
 ### Cross-root module resolution
 
-Workspace has roots `splice` and `utility`. A Daml file under `splice/` with `import Utility.Foo` must resolve to a module inside `utility/`.
+A Daml file under `splice/` with `import Utility.Foo` must resolve to a module inside `utility/`.
 
-- The resolver looks up modules by their **qualified-name string** (e.g., `"Utility.Foo"`) across the full workspace, ignoring the `root_name` boundary. If exactly one `Module` node has that `qualified_name`, the import resolves there.
+- The resolver looks up modules by their **qualified-name string** (e.g., `"Utility.Foo"`) across the full workspace, ignoring `root_name` boundaries. If exactly one `Module` node has that `qualified_name`, the import resolves there.
 - The resolver does not parse `Cargo.toml` or `daml.yaml` to derive package boundaries in v1; resolution is purely on extracted qualified names.
-- Ambiguity (same `qualified_name` in two roots) → leave unresolved, log warning.
+- Ambiguity (same `qualified_name` in two roots) → recorded as ambiguous.
 
-### Cleanup
+### Resolution as idempotent rebuild
 
-After resolution completes, `(:UnresolvedRef)` nodes that produced an edge are deleted. Unresolved remainders stay (with a `reason` property) for debugging.
+`codegraph-rs index` and `codegraph-rs sync` invoke the same resolution routine. The routine:
+
+1. Drops all existing edges with a `confidence` property:
+   ```cypher
+   MATCH ()-[r WHERE r.confidence IS NOT NULL]-()
+   DELETE r
+   ```
+2. Walks every `UnresolvedRef` and applies stages 1 then 2.
+3. Updates `unresolved_reason` and `candidate_qids` on each ref accordingly.
+
+Because `UnresolvedRef`s are permanent, resolution is idempotent — running it twice produces the same edges.
+
+### Performance
+
+- v1: full global resolution pass on every `index` and `sync`. For an `UnresolvedRef` count `R`, complexity is roughly `O(R × log N)` where `N` is the candidate count per name (small in practice). Expect <2s for a 50k-symbol workspace.
+- v2 candidate optimization: scope re-resolution to refs whose source file or candidate set changed. Out of v1 scope.
 
 ### Not in v1
 
@@ -444,7 +529,7 @@ After resolution completes, `(:UnresolvedRef)` nodes that produced an edge are d
 Not every node — embedding `Variable` nodes named `i` is noise. v1 embeds:
 
 - `Function`, `Method`
-- `Class`, `Struct`, `Interface`, `Trait`, `Protocol`, `Enum`
+- `Class`, `Struct`, `Interface`, `Trait`, `Enum`
 - `TypeAlias`
 - `Module`
 - `Template`, `Choice` (when `tree-sitter-daml` ships)
@@ -471,7 +556,15 @@ Body content is intentionally not included — keeps the embedding focused on in
 
 ### When
 
-During indexing, after extraction and resolution. Batched at 128 texts per `fastembed-rs::embed()` call. Written via parameterized Cypher that targets the existing nodes by `qid`.
+During indexing, after extraction and resolution. Batched at 128 texts per `fastembed-rs::embed()` call. Each batch is written with one Cypher round-trip:
+
+```cypher
+UNWIND $batch AS row
+MATCH (n:Symbol {qid: row.qid})
+SET n.embedding = row.embedding
+```
+
+where `row.embedding` is a `LIST<FLOAT>` of length 384.
 
 ### Search
 
@@ -518,23 +611,28 @@ For each root in the workspace:
 
 ### Per-bucket actions
 
-**Added** — extract → write nodes/edges → queue for resolution + embedding.
+**Added** — extract → write nodes, structural edges, and `UnresolvedRef`s. (Resolution runs centrally afterwards.)
 
-**Changed** — delete the file's nodes and contents, then re-extract:
+**Changed** — delete the file's nodes and everything it contains, including its `UnresolvedRef` records. Other files' `UnresolvedRef` records (which may reference symbols in this file) are NOT touched:
 
 ```cypher
 MATCH (f:File {root_name: $root, relative_path: $rel})
-OPTIONAL MATCH (f)-[:CONTAINS*]->(child)
-DETACH DELETE f, child
+OPTIONAL MATCH (f)-[:CONTAINS*]->(child:Symbol)
+OPTIONAL MATCH (child)-[:HAS_REF]->(ref:UnresolvedRef)
+DETACH DELETE f, child, ref
 ```
 
-Then re-extract.
+The second `OPTIONAL MATCH` reaches each Symbol's own `UnresolvedRef` records (those representing references *from* this file's symbols). Cross-file references — `UnresolvedRef` nodes whose `source_qid` lives in a different file but happen to name a symbol in this file — are unaffected; the global resolution rebuild that follows will recreate cross-file edges against the new targets.
 
-**Deleted** — same `DETACH DELETE` pattern, no re-extraction.
+Then re-extract this file, producing new node `qid`s as needed.
+
+**Deleted** — same `DETACH DELETE`, no re-extraction.
 
 ### Resolution after partial changes
 
-After the changed/added set is re-extracted, run resolution **globally** — not just for affected files. A newly added function may satisfy previously-unresolved refs from elsewhere. Resolution is cheap; correctness here matters more than speed.
+After the changed/added/deleted set is processed, run the global resolution rebuild from §7 ("Resolution as idempotent rebuild"). All resolution-derived edges are dropped and recomputed from the surviving `UnresolvedRef` records against the now-current candidate set.
+
+This is the mechanism that fixes cross-file edges when a callee's `qid` changes (e.g., file B is edited): file A's `UnresolvedRef` records still describe the original source-code intent, and resolution recreates the `CALLS` edges from A to B's new symbols.
 
 ### Embedding after changes
 
@@ -548,7 +646,7 @@ One `codegraph-rs sync` iterates roots in sequence. Parallel-root sync is not v1
 ### Consistency
 
 - No transactional sync. If the process crashes mid-sync, the next run recovers via the same diff.
-- No locking against concurrent sync sessions on the same workspace — documented as "don't run two at once."
+- No locking against concurrent invocations of `codegraph-rs index` or `codegraph-rs sync` on the same workspace — running two at once will cause MERGE conflicts and corrupted intermediate state. Documented as "don't run two at once." A v2 lockfile (`<workspace>/.codegraph/.lock` via `flock`) is planned.
 
 ### Not in v1
 
@@ -567,6 +665,16 @@ One `codegraph-rs sync` iterates roots in sequence. Parallel-root sync is not v1
 - `codegraph-rs serve` launches the MCP server on stdio.
 - On startup: locate workspace config, open Neo4j connection (Bolt, auth from config), preload the `fastembed-rs` model.
 - Shutdown: close the Bolt connection cleanly on stdin EOF or SIGTERM.
+
+### Typical tool flow
+
+A Claude Code session does not know any `qid` values up front. The expected pattern is:
+
+1. `codegraph_rs_search` or `codegraph_rs_semantic_search` to find seed symbols by name or topic — these return `qid`s.
+2. `codegraph_rs_node` for full details of a specific `qid`.
+3. `codegraph_rs_callers` / `_callees` / `_impact` / `_context` / `_explore` for relationship traversal.
+
+`codegraph_rs_status` and `codegraph_rs_files` are introspection tools and do not require `qid` inputs.
 
 ### Tool surface
 
@@ -619,15 +727,16 @@ Heavy logic stays in non-MCP modules; `mcp/tools.rs` stays thin.
 ## 11. CLI surface
 
 ```
-codegraph-rs init                  scaffold .codegraph/, prompt for Neo4j details
+codegraph-rs init                  scaffold .codegraph/, prompt for Neo4j details,
+                                   create the Neo4j database (CREATE DATABASE)
 codegraph-rs index                 full build
 codegraph-rs sync                  incremental
 codegraph-rs status                stats
-codegraph-rs query <text>          codegraph_rs_search from terminal
+codegraph-rs query <text>          codegraph_rs_search from terminal (FTS / name search only)
 codegraph-rs serve                 MCP stdio server
 ```
 
-All commands accept `--workspace <path>`. No `codegraph-rs hooks install` in v1.
+All commands accept `--workspace <path>`. The CLI exposes only `query` for terminal use; richer queries (semantic, callers, callees, impact) are reachable only via the MCP interface, intentionally — that surface is designed for AI assistants, not humans. No `codegraph-rs hooks install` in v1.
 
 ## 12. Distribution
 
@@ -648,7 +757,7 @@ All commands accept `--workspace <path>`. No `codegraph-rs hooks install` in v1.
 
 ### Integration tests (real Neo4j)
 
-- Test fixture spins up a fresh dedicated database (`codegraph_test_<pid>`).
+- Test fixture spins up a fresh dedicated database (`codegraph-test-<pid>` — dashes per Neo4j 5 naming rules in §5).
 - Tests annotated `#[tokio::test]` with `#[ignore]` unless `CODEGRAPH_RS_TEST_NEO4J=1` is set.
 - Each test:
   1. Writes a small codebase into a `tempfile::tempdir()`.
@@ -678,7 +787,7 @@ Plus `cargo deny` for license/advisory checks.
 
 | Risk | Mitigation |
 |---|---|
-| `tree-sitter-haskell` parse quality on real Daml templates is poor enough to produce misleading `Function` nodes from template bodies | Accept as v1 limitation. Tag affected nodes with a `tree_sitter_reliable` property. Document the gap in README until `tree-sitter-daml` ships |
+| `tree-sitter-haskell` parse quality on real Daml templates is poor enough to produce misleading `Function` nodes from template bodies | Accept as v1 limitation. Set `parse_reliable = false` on nodes extracted from inside template/choice/signatory blocks (see §4 schema). Document the gap in README until `tree-sitter-daml` ships |
 | `fastembed-rs` model download (~130 MB) can fail on slow connections | Fail with clear retry message; document cache location; plan a `codegraph-rs prepare` command in v2 |
 | `neo4rs` driver maturity / Bolt edge cases | Pin a known-good version. Wrap behind `db/` so the driver can be swapped locally |
 | Neo4j Enterprise licensing for users distributing the tool or running in CI | v1 documents "use Neo4j Desktop (free for local dev)"; CI accepts license explicitly. Tool itself never bundles Neo4j |
@@ -722,4 +831,5 @@ Decisions made during the brainstorming phase, in chronological order:
 | 10 | MCP tool naming: `codegraph_rs_*` | Coexist with TS version's `codegraph_*` tools without collision |
 | 11 | Distribution: `cargo install` | Simplest for v1; users have Rust if they're using Rust tooling |
 | 12 | Crate layout: single crate, internal modules | Premature workspace splitting adds friction without payoff |
-| 13 | Considered Grafeo (embedded Rust graph DB) and rejected | Spike showed Cypher and persistence work, but Grafeo lacks mature visualization (a stated user driver), persistent vector index, and proper concurrent-process semantics. Pre-1.0 maturity adds risk |
+| 13 | `qid` excludes `start_line`; permanent `(:UnresolvedRef)` records as source-of-truth | Found during spec review: line-shift edits and cross-file edges would silently corrupt the graph if `qid` depended on position or if unresolved refs were transient |
+| 14 | No separate `Impl` node for Rust `impl` blocks | Methods carry the type prefix in `qualified_name`; structural simplicity over a parallel hierarchy |

--- a/docs/superpowers/specs/2026-05-15-codegraph-rs-v2-daml-depth-design.md
+++ b/docs/superpowers/specs/2026-05-15-codegraph-rs-v2-daml-depth-design.md
@@ -1,0 +1,425 @@
+# codegraph-rs v2.0 — Daml-depth design
+
+**Status:** Approved, awaiting implementation plan.
+**Baseline:** v1 shipped at `slice-9-daml` (HEAD `b3fdc0a` on `main`, 97 tests pass).
+**Scope:** Two sequential slices (10a, 10b) deepening Daml extraction. v2.1+ items deferred.
+
+---
+
+## 1. Goal and scope
+
+### 1.1 Goal
+
+Make Daml extraction in `codegraph-rs` deep enough to answer the questions a real Daml engineer actually asks:
+
+- *"Who can exercise this choice?"*
+- *"Which templates implement this interface?"*
+- *"What's the authorization model around this contract?"*
+- *"Which fields back the signatory expression of this template?"*
+
+v1 emits Templates and Choices but they are regex-anchored opaque blobs with line-approximate spans, `parse_reliable: false`, and no internal structure. v2 makes them first-class graph citizens: byte-precise spans, internal field children, and party-shaped edges to the Symbols that back signatory/controller/observer expressions.
+
+### 1.2 Scope — two sequential slices
+
+| Slice | Scope | Tag |
+|---|---|---|
+| **10a — Daml structure + fields** | Replace regex `pass_d_templates_and_choices` with tree-sitter queries that filter `(variable)` nodes by Daml keyword. Add NodeKinds: `Interface`, `Viewtype`, `Exception`, `Field`. Fields are CONTAINS-children of their parent Template / Choice / Interface. | `slice-10a-daml-structure` |
+| **10b — Daml authorization edges** | Extract `signatory` / `controller` / `observer` party expressions; resolve to Field Symbols (or free Symbols if literal Party). Extract `implements` / `requires` relationships between Templates and Interfaces. Add 5 new EdgeKinds + 5 new UnresolvedKinds. | `slice-10b-daml-edges` |
+
+Each slice is independently shippable, ~7-9 tasks, passing its own integration test gate. v1's pain point ("templates are regex-only opaque blobs") is gone after 10a alone.
+
+### 1.3 Out of scope for v2.0
+
+- **Contract keys / maintainers.** Deprecated in Daml 2.x in favor of interface-based contract lookups. The original slice 10c plan is dropped.
+- **File watchers, framework-specific resolvers, cross-crate dep indexing, web visualizer, LSP server.** Potential v2.1+ slices; the user's chosen v2 direction is *depth, not breadth*.
+- **A real `tree-sitter-daml` grammar.** Confirmed unavailable: crates.io has no `tree-sitter-daml` crate; the prominent Daml editor tooling (DLC-link/zed-daml-lsp) uses tree-sitter-haskell as a proxy, identical to our approach. Spec §2 already defers grammar work to "a separate project tracked outside this spec".
+
+---
+
+## 2. New schema additions
+
+### 2.1 New NodeKinds (slice 10a)
+
+| NodeKind | Daml construct | qualified_name shape | parse_reliable | Embed-eligible? |
+|---|---|---|---|---|
+| `Interface` | `interface I where ...` | `Module.I` | false (keyword anchor) | yes (add to `EMBED_KINDS_CYPHER_LIST`) |
+| `Viewtype` | `viewtype V` inside an interface body | `Module.I.V` | false (keyword anchor) | yes |
+| `Exception` | `exception E with ... where message ...` | `Module.E` | false (keyword anchor) | yes |
+| `Field` | `with`-block typed bindings inside a Template / Choice / Interface (e.g., `owner : Party`) | `Module.Template.field_name` | true (haskell parses `name : type` as a signature) | no (fields are not embed-eligible per spec §8 — they're leaf state) |
+
+Templates and Choices remain `parse_reliable: false`. The *keyword anchors* are still detected by text-matching against haskell's `(variable)` nodes; only the surrounding structure (constructor names, with-block field signatures) is grammar-clean. Everything *inside* a template body — signatory expressions, choice signatures, field types — gets `parse_reliable: true`.
+
+Slice 7's `EMBED_KINDS_CYPHER_LIST` constants in `src/graph/status.rs` and `src/vectors/query.rs` each gain three entries: `'Interface', 'Viewtype', 'Exception'`. The embedding pipeline picks them up automatically — no orchestrator changes needed.
+
+### 2.2 New EdgeKinds (slice 10b)
+
+| EdgeKind | Direction | Source-side construct | Target |
+|---|---|---|---|
+| `SIGNATORY` | `Template → Symbol` | `signatory <expr>` in a template's where-block | Typically a Field of the same Template; can be a free Symbol if the expression names something workspace-scoped |
+| `CONTROLLER` | `Choice → Symbol` | `controller <expr>` in a choice block | Same target shape as Signatory |
+| `OBSERVER` | `Template → Symbol` | `observer <expr>` (optional in templates) | Same target shape |
+| `IMPLEMENTS` | `Template → Interface` | `interface instance I for T where ...` | An `Interface` node anywhere in the workspace |
+| `REQUIRES` | `Interface → Interface` | `interface I requires J where ...` | An `Interface` node anywhere |
+
+### 2.3 New UnresolvedKinds (slice 10b)
+
+Extraction emits `UnresolvedRef { kind: Signatory | Controller | Observer | Implements | Requires, ... }`. Resolution converts them to the corresponding edge types per §4.1.
+
+### 2.4 No data migration
+
+All additions are pure label / property additions; no constraint changes, no FTS index changes, no vector index changes. The `apply_schema` step in `src/db/schema.rs` is unchanged. Old v1-indexed workspaces remain valid (they simply lack v2 nodes/edges until re-indexed).
+
+`schema_version` stays at **1**. The data model is forward-compatible at every layer.
+
+---
+
+## 3. Extraction strategy (the technical core)
+
+### 3.1 The central observation
+
+tree-sitter-haskell parses Daml-specific keywords as `(variable)` nodes inside `(apply ...)` expressions. The Zed Daml LSP extension (the most prominent non-Daml-Studio Daml editor tooling) confirms this approach.
+
+`template Counter with owner : Party where signatory owner` parses (approximately) as:
+
+```
+(top_splice
+  (apply
+    function: (variable "template")
+    argument: (constructor "Counter")
+    ...))
+```
+
+`signatory owner` inside the where-block parses as:
+
+```
+(apply
+  function: (variable "signatory")
+  argument: (variable "owner"))
+```
+
+Same shape applies to every Daml keyword: `choice`, `controller`, `observer`, `interface`, `viewtype`, `implements`, `requires`, `exception`, `signatory`.
+
+We exploit this by writing tree-sitter queries that filter `(apply (variable))` nodes by keyword text, then walk the surrounding tree for the data we want.
+
+### 3.2 Slice 10a — replace regex Pass D with tree-sitter queries
+
+New queries in `src/extraction/languages/daml.scm` (illustrative; the implementer must verify exact node shapes against `tree-sitter-haskell-0.23.1/src/node-types.json` per the same workflow used in slices 5-9):
+
+```scheme
+; Template anchor.
+((apply
+  function: (variable) @kw
+  argument: (constructor) @template.name) @template.def
+  (#eq? @kw "template"))
+
+; Interface anchor.
+((apply
+  function: (variable) @kw
+  argument: (constructor) @interface.name) @interface.def
+  (#eq? @kw "interface"))
+
+; Viewtype.
+((apply
+  function: (variable) @kw
+  argument: (constructor) @viewtype.name) @viewtype.def
+  (#eq? @kw "viewtype"))
+
+; Exception.
+((apply
+  function: (variable) @kw
+  argument: (constructor) @exception.name) @exception.def
+  (#eq? @kw "exception"))
+
+; Choice anchor (shape depends on haskell's parse of `choice C : T ...`).
+((apply
+  function: (variable) @kw
+  argument: (_) @choice.body) @choice.def
+  (#eq? @kw "choice"))
+
+; Field: typed bindings of the form `name : Type` inside with-blocks.
+; Haskell parses these as `signature` nodes (or `top_splice/infix` in some Daml
+; variants — slice 5/6 found Daml's single-colon `:` lands in `top_splice/infix`).
+; The implementer must verify the actual subtree shape.
+(signature name: (variable) @field.name type: (_) @field.type) @field.def
+```
+
+Pass ordering inside `extract_daml` (the implementer assigns concrete names; the slice 9 codebase uses an idiosyncratic mix of `pass_a`/`pass_b`/`pass_c`/`pass_d`):
+
+1. **Module + Imports** (existing, unchanged).
+2. **Top-level haskell-parseable declarations** (existing): Functions, TypeAliases, Structs from `data_type`.
+3. **Daml keyword-anchored constructs** (NEW, replaces the regex pass): Templates, Choices, Interfaces, Viewtypes, Exceptions, Fields. All via tree-sitter queries.
+4. **Call-site UnresolvedRefs** (existing): function applications + `exercise` choices.
+
+Pass 3 must run after pass 2 so Field qualified-name prefixing works (Fields nest under their parent Template/Choice/Interface, whose definitions are emitted in pass 3 itself — within pass 3 the implementer ensures Template comes before its Fields).
+
+The Field extraction in Pass D produces CONTAINS edges from the parent Template / Choice / Interface to each field, matching the existing pattern (File → Module → Function/Type/etc.).
+
+### 3.3 Slice 10b — extract authorization edges
+
+Additional queries:
+
+```scheme
+; Signatory party.
+((apply
+  function: (variable) @kw
+  argument: (_) @signatory.target) @signatory.def
+  (#eq? @kw "signatory"))
+
+; Controller party (inside choice scope).
+((apply
+  function: (variable) @kw
+  argument: (_) @controller.target) @controller.def
+  (#eq? @kw "controller"))
+
+; Observer party.
+((apply
+  function: (variable) @kw
+  argument: (_) @observer.target) @observer.def
+  (#eq? @kw "observer"))
+
+; Template implements Interface.
+((apply
+  function: (variable) @kw
+  argument: (constructor) @implements.interface) @implements.def
+  (#eq? @kw "implements"))
+
+; Interface requires Interface.
+((apply
+  function: (variable) @kw
+  argument: (constructor) @requires.interface) @requires.def
+  (#eq? @kw "requires"))
+```
+
+Each match emits an `UnresolvedRef { kind: <Signatory|Controller|Observer|Implements|Requires>, unresolved_name: <target_text>, source_qid: <Template|Choice|Interface qid>, scope_qid: Some(<enclosing-template-qid>) }`. The `scope_qid` is new — see §4.1.
+
+### 3.4 Why this is strictly better than regex Pass D
+
+| Aspect | Regex (v1) | Tree-sitter (v2) |
+|---|---|---|
+| Span precision | Line-anchored, approximate | Byte-precise from AST |
+| Nested constructs | Hard (would need recursive regex) | Free (queries walk the tree) |
+| Whitespace robustness | Fragile (depends on indentation matching) | Robust |
+| Adding a new keyword | New regex + state machine per kind | Add one `#eq?` filter |
+| Cross-reference resolution | Manually compute byte-offset → enclosing-span | Use existing `enclosing_symbol_qid` helper (lifted in slice 9 task 4) |
+
+---
+
+## 4. Resolution and migration
+
+### 4.1 `scope_qid` on UnresolvedRef
+
+`signatory owner` inside `template Counter with owner: Party where ...` must resolve to the `Counter.owner` Field, **not** to some unrelated `owner` Symbol elsewhere in the workspace. The current resolver (`src/resolution/`) only has `source_qid` (the symbol referencing the name); it has no notion of "look up names in this enclosing scope first."
+
+Slice 10b adds an `Option<String> scope_qid` field to `UnresolvedRef`. For party-edge kinds (Signatory, Controller, Observer), `scope_qid` is the enclosing Template's qid. Resolution adds a new phase that runs *before* Phase B's import-driven match:
+
+**Phase A.5 — Scoped name match (new).**
+For each `UnresolvedRef` with `scope_qid: Some(s)`, look up `<s>.<unresolved_name>` in the Symbol set. If found, emit the appropriate edge directly. If not, fall through to Phase B/C as before.
+
+For `Implements` / `Requires` kinds, `scope_qid` is `None` — they resolve against workspace-wide Interface symbols by qualified_name, the same shape as `IMPORTS` resolution.
+
+### 4.2 Phase assignments
+
+| UnresolvedKind | Resolution phases tried (in order) |
+|---|---|
+| `Signatory`, `Controller`, `Observer` | Phase A.5 (scoped) → Phase C (fallback workspace name-match) |
+| `Implements`, `Requires` | Phase A-shape (qualified_name lookup of an Interface node) |
+
+### 4.3 Backwards compatibility
+
+The slice changes are additive:
+
+- **New Neo4j labels** (`Interface`, `Viewtype`, `Exception`, `Field`) — Neo4j labels are open, no constraint changes.
+- **New relationship types** (`SIGNATORY`, `CONTROLLER`, `OBSERVER`, `IMPLEMENTS`, `REQUIRES`) — relationship types are open, no schema changes.
+- **New `UnresolvedRef.kind` enum values** — `kind` is serialized as a string property, free-form.
+- **New `UnresolvedRef.scope_qid` property** — additive, `Option<String>`. Existing v1 records have `scope_qid` absent; resolver treats absent as `None`.
+
+Old v1-indexed workspaces upgraded to v2 binaries keep their existing graph queryable. Running `codegraph-rs sync` re-indexes touched files and adds new nodes/edges. Running `codegraph-rs index` from scratch produces the full v2 surface.
+
+### 4.4 `schema_version` stays at 1
+
+Per §2.4, all changes are forward-compatible. The first non-additive change in some future slice (file-watcher introducing a new mandatory config field, say) is the right place to bump.
+
+---
+
+## 5. Testing strategy
+
+### 5.1 Fixture extension
+
+`tests/fixtures/tiny-daml/` gains `Splice/Authorization.daml`:
+
+```daml
+module Splice.Authorization where
+
+import Splice.Counter
+
+-- Interface with a viewtype.
+interface Authorizable where
+  viewtype AuthorizableView
+  getOwner : Party
+
+data AuthorizableView = AuthorizableView { owner : Party }
+
+-- Template implementing the interface, with signatory + observer + a choice.
+template AuthorizedCounter
+  with
+    owner : Party
+    delegate : Party
+    count : Int
+  where
+    signatory owner
+    observer delegate
+    interface instance Authorizable for AuthorizedCounter where
+      view = AuthorizableView { owner = owner }
+      getOwner = owner
+
+    choice Bump : ContractId AuthorizedCounter
+      controller delegate
+      do
+        create this with count = count + 1
+
+-- An exception.
+exception InsufficientBalance with
+    actual : Int
+    required : Int
+  where
+    message "Insufficient balance"
+```
+
+Per-slice-10a expectations (asserted by the integration test):
+
+- 1 new Module (`Splice.Authorization`).
+- 1 new Interface (`Authorizable`).
+- 1 new Viewtype (`AuthorizableView`) — note this also generates a `data AuthorizableView` parsed as a Struct.
+- 1 new Template (`AuthorizedCounter`) with 3 Field children (`owner`, `delegate`, `count`).
+- 1 new Choice (`Bump`) — choice arguments depend on grammar exposure; may have 0 or 1 Field children.
+- 1 new Exception (`InsufficientBalance`) with 2 Field children (`actual`, `required`).
+- At least 1 Import (`Splice.Counter` from the existing slice 9 fixture).
+
+### 5.2 Unit tests
+
+Following slices 5-9's pattern, append to `tests/extraction_unit.rs`.
+
+**Slice 10a (~10 tests):**
+
+- `daml_extracts_interface_name_and_qualified_name`
+- `daml_extracts_viewtype_inside_interface_scope`
+- `daml_extracts_exception_with_parse_reliable_false`
+- `daml_template_with_fields_emits_field_children`
+- `daml_choice_with_fields_emits_field_children`
+- `daml_byte_precise_template_span` — Template start/end lines match actual AST extent, not regex line block
+- `daml_pass_d_replaces_regex_no_regression` — comprehensive: indexes Counter.daml fixture from slice 9 and verifies counts match prior slice 9 baseline (regression guard)
+- `daml_field_qualified_name_nests_under_template` — `Foo.Counter.owner`, not `Foo.owner`
+
+**Slice 10b (~8 tests):**
+
+- `daml_signatory_emits_unresolved_ref_with_scope_qid`
+- `daml_controller_inside_choice_uses_choice_scope`
+- `daml_observer_emits_unresolved_ref`
+- `daml_implements_targets_workspace_interface`
+- `daml_requires_emits_interface_to_interface_ref`
+- `daml_signatory_resolves_to_template_field_in_phase_a5`
+- `daml_party_unresolved_ref_falls_through_to_phase_c_when_scoped_miss`
+
+### 5.3 Integration tests
+
+Both slices extend (or add files alongside) `tests/integration_daml_index.rs` — same env gate `CODEGRAPH_RS_TEST_NEO4J=1`.
+
+**Slice 10a integration assertions:**
+
+```cypher
+MATCH (n:Interface) RETURN count(n)              -- expect ≥ 1
+MATCH (n:Viewtype) RETURN count(n)               -- expect ≥ 1
+MATCH (n:Exception) RETURN count(n)              -- expect ≥ 1
+MATCH (n:Field) RETURN count(n)                  -- expect ≥ 5
+MATCH (n:Field {qualified_name: "Splice.Authorization.AuthorizedCounter.owner"}) RETURN count(n) = 1
+```
+
+**Slice 10b integration assertions:**
+
+```cypher
+MATCH (t:Template {name: 'AuthorizedCounter'})-[:SIGNATORY]->(f:Field {name: 'owner'}) RETURN count(*) = 1
+MATCH (c:Choice {name: 'Bump'})-[:CONTROLLER]->(f:Field {name: 'delegate'}) RETURN count(*) = 1
+MATCH (t:Template {name: 'AuthorizedCounter'})-[:IMPLEMENTS]->(i:Interface {qualified_name: 'Splice.Authorization.Authorizable'}) RETURN count(*) = 1
+```
+
+### 5.4 Embedding test inheritance
+
+Slice 7's `tests/integration_vectors.rs` needs no structural changes — `EMBED_KINDS_CYPHER_LIST` already names the new Daml kinds. Slice 10a's integration test adds one assertion under the dual gate (`CODEGRAPH_RS_TEST_NEO4J=1` AND `CODEGRAPH_RS_TEST_EMBEDDINGS=1`):
+
+```rust
+let embedded_interfaces: i64 = scalar(&conn,
+    "MATCH (i:Interface) WHERE i.embedding IS NOT NULL RETURN count(i) AS c").await;
+assert!(embedded_interfaces >= 1, "interfaces should be embedded by slice 7's pipeline");
+```
+
+---
+
+## 6. Risks and mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| **tree-sitter-haskell node shapes differ from expected.** Slices 5-9 already had to verify `signature` (Daml uses `:` not `::`, ends up as `top_splice/infix`) and `apply.function:` field. v2's queries assume `(apply function: (variable) argument: (constructor))` for keyword anchors — that may need adjustment per-keyword. | High | Each task in slice 10a/10b starts with a node-types.json inspection step. The implementer subagent verifies and adjusts before writing queries. |
+| **Daml keywords as user identifiers.** A user could legitimately name a function `signatory` or `observer` (uncommon but possible). Our `#eq?` filter would misfire. | Low | The query also requires the variable be in `function:` position of an `apply` and its argument shape match the expected Daml construct. False positives on `let x = signatory + 1` would need `+ 1` to parse as a constructor — extremely unlikely. Document as a known limitation. |
+| **`interface instance ... for ... where` Daml 2.x syntax.** Spec was written from spec text; the actual Daml 2.x syntax may differ. | Medium | Slice 10a's fixture step verifies against the real Daml compiler (or Splice/daml-finance examples). If the fixture doesn't typecheck under real Daml, fix syntax before extending tests. |
+| **`scope_qid` resolution change touches `src/resolution/`.** That module hasn't been modified since slice 3; adding a new resolution path could regress existing resolution. | Medium | Slice 10b's Phase A.5 runs in addition to existing Phase B/C. Existing tests (`resolution_unit.rs`, `integration_resolve.rs`) must pass unchanged. |
+| **Backwards compat with v1-indexed workspaces.** A user with an existing `.codegraph/` directory should be able to upgrade to v2 binary and (a) re-run `sync` to pick up new node/edge kinds, (b) keep existing graph queryable. | Low | Schema is fully additive (per §4.3). Slice 10a's first task includes a manual smoke test: index a workspace with v1 binary, switch to v2, run `sync`, assert no errors and new nodes appear. |
+| **Resolution performance.** Phase C name-match is currently the slowest step. Adding Phase A.5 (`scope_qid` HashMap lookups) could push latency further. | Low | Workspace sizes are small (<10k symbols typical). If a benchmark shows regression, the optimization is straightforward: cache `<scope_qid>.<name>` lookups in a HashMap built once per resolve. Defer until measured. |
+
+---
+
+## 7. Slice contracts summary
+
+### 7.1 Slice 10a — Daml structure + fields
+
+**Tag:** `slice-10a-daml-structure`
+**Estimated tasks:** ~8
+
+1. NodeKind additions (Interface, Viewtype, Exception, Field) + EMBED_KINDS extensions.
+2. Tree-sitter query for templates (replaces regex template_re).
+3. Tree-sitter query for choices.
+4. Tree-sitter query for interfaces + viewtypes.
+5. Tree-sitter query for exceptions.
+6. Tree-sitter query for fields (with-block bindings).
+7. Fixture extension + integration test additions.
+8. README bump + tag.
+
+**Done criteria:** All 97 v1 tests still pass; new unit tests pass; integration test against extended fixture asserts new node counts; manual verification on a real Daml workspace (Splice or daml-finance) shows Template fields appearing.
+
+### 7.2 Slice 10b — Daml authorization edges
+
+**Tag:** `slice-10b-daml-edges`
+**Estimated tasks:** ~9
+
+1. EdgeKind additions (SIGNATORY, CONTROLLER, OBSERVER, IMPLEMENTS, REQUIRES) + UnresolvedKind additions.
+2. `UnresolvedRef.scope_qid: Option<String>` schema addition + DB write/read path.
+3. Tree-sitter queries for signatory / controller / observer.
+4. Tree-sitter queries for implements / requires.
+5. Resolution Phase A.5 (scoped name match) implementation.
+6. Wire phases into the resolution orchestrator.
+7. Fixture extension verification (Authorization.daml).
+8. Integration test with full Cypher assertions for all 5 new edge types.
+9. README bump + tag.
+
+**Done criteria:** All slice-10a tests still pass; new resolution_unit tests pass; integration test asserts SIGNATORY/CONTROLLER/OBSERVER/IMPLEMENTS/REQUIRES edges land with correct targets; manual smoke check that `_callers`/`_callees`/`_impact` MCP tools still work and return sensible results when called on a Choice (existing graph traversal should be edge-type-agnostic).
+
+---
+
+## 8. Out of scope / future
+
+| Item | Why deferred | Future slice |
+|---|---|---|
+| File watcher / git post-commit hook | Spec §9 lists as v2 territory; user picked depth over breadth | v2.1+ |
+| Framework-specific resolvers (axum, tokio, Daml stdlib) | Resolver pipeline is generic; framework knowledge is a separate concern | v2.1+ |
+| Cross-crate / external dep indexing | Spec §7 "Not in v1" | v2+ |
+| Real `tree-sitter-daml` grammar | Multi-month external project; current haskell-proxy approach is community-validated | If/when grammar appears |
+| LSP server | Different consumer surface | v3 |
+| Web visualizer | Spec §2 says "Neo4j Browser replaces it" for v1 | v3 |
+
+---
+
+## 9. References
+
+- Source spec: [`docs/superpowers/specs/2026-04-22-codegraph-rs-design.md`](2026-04-22-codegraph-rs-design.md) — §4 (node labels including reserved Template/Choice/Field), §7 (resolution pipeline), §8 (embedding eligibility).
+- Slice 9 plan: [`docs/superpowers/plans/2026-05-14-codegraph-rs-slice-9-daml.md`](../plans/2026-05-14-codegraph-rs-slice-9-daml.md) — current Daml extractor implementation (the regex Pass D this spec replaces).
+- DLC-link/zed-daml-lsp — community Daml editor extension confirming the haskell-proxy approach: `https://github.com/DLC-link/zed-daml-lsp` (specifically `languages/daml/highlights.scm` for the Daml keyword set).
+- tree-sitter-haskell 0.23.1 — `~/.cargo/registry/src/index.crates.io-*/tree-sitter-haskell-0.23.1/src/node-types.json` for grammar shapes.

--- a/docs/superpowers/specs/2026-05-15-codegraph-rs-v2-daml-depth-design.md
+++ b/docs/superpowers/specs/2026-05-15-codegraph-rs-v2-daml-depth-design.md
@@ -24,7 +24,7 @@ v1 emits Templates and Choices but they are regex-anchored opaque blobs with lin
 | Slice | Scope | Tag |
 |---|---|---|
 | **10a — Daml structure + fields** | Replace regex `pass_d_templates_and_choices` with tree-sitter queries that filter `(variable)` nodes by Daml keyword. Add NodeKinds: `Interface`, `Viewtype`, `Exception`, `Field`. Fields are CONTAINS-children of their parent Template / Choice / Interface. | `slice-10a-daml-structure` |
-| **10b — Daml authorization edges** | Extract `signatory` / `controller` / `observer` party expressions; resolve to Field Symbols (or free Symbols if literal Party). Extract `implements` / `requires` relationships between Templates and Interfaces. Add 5 new EdgeKinds + 5 new UnresolvedKinds. | `slice-10b-daml-edges` |
+| **10b — Daml authorization edges** | Extract `signatory` / `controller` / `observer` party expressions; resolve identifier-shaped operands to Field Symbols (preferred) or workspace-scoped Symbols (fallback). Decompose multi-party expressions (lists, set-builders) into one ref per identifier — see §3.3. Extract `implements` / `requires` relationships between Templates and Interfaces. Add 5 new EdgeKinds + 5 new UnresolvedKinds. | `slice-10b-daml-edges` |
 
 Each slice is independently shippable, ~7-9 tasks, passing its own integration test gate. v1's pain point ("templates are regex-only opaque blobs") is gone after 10a alone.
 
@@ -45,9 +45,11 @@ Each slice is independently shippable, ~7-9 tasks, passing its own integration t
 | `Interface` | `interface I where ...` | `Module.I` | false (keyword anchor) | yes (add to `EMBED_KINDS_CYPHER_LIST`) |
 | `Viewtype` | `viewtype V` inside an interface body | `Module.I.V` | false (keyword anchor) | yes |
 | `Exception` | `exception E with ... where message ...` | `Module.E` | false (keyword anchor) | yes |
-| `Field` | `with`-block typed bindings inside a Template / Choice / Interface (e.g., `owner : Party`) | `Module.Template.field_name` | true (haskell parses `name : type` as a signature) | no (fields are not embed-eligible per spec §8 — they're leaf state) |
+| `Field` | `with`-block typed bindings inside a Template / Choice / Interface (e.g., `owner : Party`) | Template field: `Module.Template.field_name`. Choice field: `Module.Template.Choice.field_name`. Interface field: `Module.Interface.field_name`. The qualified-name carries the full container chain so a Field is unambiguously addressable across the workspace. | true (haskell parses `name : type` as a signature) | no (fields are not embed-eligible per spec §8 — they're leaf state) |
 
 Templates and Choices remain `parse_reliable: false`. The *keyword anchors* are still detected by text-matching against haskell's `(variable)` nodes; only the surrounding structure (constructor names, with-block field signatures) is grammar-clean. Everything *inside* a template body — signatory expressions, choice signatures, field types — gets `parse_reliable: true`.
+
+**Why `Viewtype` is a NodeKind rather than an edge.** `viewtype V` inside an interface body names an existing `data V = ...` Struct. A cleaner model would be an edge `Interface -[VIEWTYPE]→ Struct(V)`, with the Struct already existing from `data` extraction. We choose the NodeKind model anyway because: (a) it makes Viewtype embed-eligible without bridging through another node, which matters for semantic search queries like *"what's the view of this contract?"*; (b) it keeps slice 10a's surface symmetric — every Daml keyword-anchored construct becomes a NodeKind. The alternative (Viewtype as `EdgeKind::Viewtype` introduced in slice 10b) is a viable v3 refactor if Viewtype-as-Symbol turns out to be redundant in practice.
 
 Slice 7's `EMBED_KINDS_CYPHER_LIST` constants in `src/graph/status.rs` and `src/vectors/query.rs` each gain three entries: `'Interface', 'Viewtype', 'Exception'`. The embedding pipeline picks them up automatically — no orchestrator changes needed.
 
@@ -67,9 +69,9 @@ Extraction emits `UnresolvedRef { kind: Signatory | Controller | Observer | Impl
 
 ### 2.4 No data migration
 
-All additions are pure label / property additions; no constraint changes, no FTS index changes, no vector index changes. The `apply_schema` step in `src/db/schema.rs` is unchanged. Old v1-indexed workspaces remain valid (they simply lack v2 nodes/edges until re-indexed).
+All additions are pure label / property additions at the Neo4j layer; no constraint changes, no FTS index changes, no vector index changes. The `apply_schema` step in `src/db/schema.rs` is unchanged. `schema_version` stays at **1**.
 
-`schema_version` stays at **1**. The data model is forward-compatible at every layer.
+For details of the Rust ↔ Neo4j compatibility story (adding `UnresolvedRef.scope_qid` as a new field, v1 records lacking it), see §4.3.
 
 ---
 
@@ -140,8 +142,20 @@ New queries in `src/extraction/languages/daml.scm` (illustrative; the implemente
 ; Haskell parses these as `signature` nodes (or `top_splice/infix` in some Daml
 ; variants — slice 5/6 found Daml's single-colon `:` lands in `top_splice/infix`).
 ; The implementer must verify the actual subtree shape.
+;
+; CRITICAL: this query shape ALSO matches top-level function signatures
+; (`helperFn : Int -> Int`). The Function extractor in pass 2 already captures
+; those. To distinguish a Field from a top-level signature, the extractor MUST
+; check the ancestor chain at emit time: only emit as Field if the signature
+; node has a Template / Choice / Interface / Exception keyword-anchored
+; `(apply)` somewhere in its ancestor chain (i.e., it sits inside a with-block
+; under a Daml-anchored construct). Top-level signatures keep their existing
+; Function-tied behavior. Pass 3 must NOT emit Fields for signatures that
+; pass 2 already paired with a Function.
 (signature name: (variable) @field.name type: (_) @field.type) @field.def
 ```
+
+**Curried `apply` shape.** Haskell parses multi-argument applications left-associatively: `template Counter with owner: Party where ...` produces a nested chain like `(apply (apply (apply (variable "template") (constructor "Counter")) (where_block ...)) ...)`. The keyword-anchor queries above implicitly rely on tree-sitter's pattern matcher walking the tree until it finds a match — so an `(apply function: (variable "template") argument: (constructor) @template.name)` pattern matches at the **innermost** apply in the chain (the one where `template` is directly applied to its first argument). The implementer must verify by capturing real fixture parses and confirm the match position; if patterns fail to match because they expected the outermost apply, adjust by anchoring at the leftmost-variable apply with a `descendant` traversal in the query.
 
 Pass ordering inside `extract_daml` (the implementer assigns concrete names; the slice 9 codebase uses an idiosyncratic mix of `pass_a`/`pass_b`/`pass_c`/`pass_d`):
 
@@ -192,6 +206,27 @@ Additional queries:
 
 Each match emits an `UnresolvedRef { kind: <Signatory|Controller|Observer|Implements|Requires>, unresolved_name: <target_text>, source_qid: <Template|Choice|Interface qid>, scope_qid: Some(<enclosing-template-qid>) }`. The `scope_qid` is new — see §4.1.
 
+**Multi-party expression decomposition (Signatory / Controller / Observer).** Real Daml uses several expression shapes for parties:
+
+| Daml expression | Decomposition |
+|---|---|
+| `signatory owner` | One ref: `unresolved_name = "owner"` |
+| `signatory [owner, delegate]` | Two refs: `"owner"` and `"delegate"` |
+| `signatory $ Set.fromList [a, b]` | Two refs: `"a"` and `"b"` (the `Set.fromList` and `$` are dropped; identifiers inside the list are extracted) |
+| `signatory $ fromOptional [] mObservers` | One ref: `"mObservers"` (single identifier inside the optional) |
+| `signatory (parties config)` | One ref: `"config"` (or `"parties"`, depending on which the extractor prefers — see below) |
+| `signatory (owner :: signatories)` | Two refs: `"owner"` and `"signatories"` |
+
+Concretely, after matching the keyword-anchored `(apply)`, the extractor runs a sub-walk over the `@target` subtree:
+
+1. Collect every `(variable)` and `(constructor)` leaf inside the subtree.
+2. Filter out known wrapper identifiers: `Set.fromList`, `Set.singleton`, `fromOptional`, `fromSome`, `concat`, `concatMap`, the `$` operator (it's actually parsed as an operator, not a variable), and list/tuple syntactic nodes.
+3. For each remaining identifier, emit one `UnresolvedRef` with `unresolved_name` = that identifier's text. All refs share the same `source_qid` and `scope_qid`; they only differ in line/col.
+
+For `parties config` (a function call), this rule emits **both** "parties" and "config" — the resolver's Phase A.5 + Phase C will resolve each independently. False positives (e.g., resolving `parties` to a workspace-wide helper function) get the edge, but the relevant `config` ref also gets resolved, so the graph still answers "who can exercise this?" correctly. Document this as acceptable v2.0 precision; tighter decomposition is a v2.1 refinement.
+
+`Implements` and `Requires` follow the simpler single-identifier model since their argument is always a single `(constructor)`.
+
 ### 3.4 Why this is strictly better than regex Pass D
 
 | Aspect | Regex (v1) | Tree-sitter (v2) |
@@ -213,16 +248,18 @@ Each match emits an `UnresolvedRef { kind: <Signatory|Controller|Observer|Implem
 Slice 10b adds an `Option<String> scope_qid` field to `UnresolvedRef`. For party-edge kinds (Signatory, Controller, Observer), `scope_qid` is the enclosing Template's qid. Resolution adds a new phase that runs *before* Phase B's import-driven match:
 
 **Phase A.5 — Scoped name match (new).**
-For each `UnresolvedRef` with `scope_qid: Some(s)`, look up `<s>.<unresolved_name>` in the Symbol set. If found, emit the appropriate edge directly. If not, fall through to Phase B/C as before.
+For each `UnresolvedRef` with `scope_qid: Some(s)`, look up `<s>.<unresolved_name>` in the Symbol set. If found, emit the appropriate edge directly. If not, fall through to **Phase C only** (party kinds skip Phase B's import-driven match — party names are always local scope, never workspace-imported).
 
-For `Implements` / `Requires` kinds, `scope_qid` is `None` — they resolve against workspace-wide Interface symbols by qualified_name, the same shape as `IMPORTS` resolution.
+**Algorithm.** Phase A.5 builds a `HashMap<String, String>` once (mapping `qualified_name` → `qid`) by issuing one Cypher `MATCH (s:Symbol) RETURN s.qualified_name AS qname, s.qid AS qid` at phase start. Each subsequent ref lookup is `O(1)` against the map. Total cost: one Cypher per resolve invocation, regardless of ref count. This is cheaper than Phase C's existing per-ref name-match and amortizes well even for small workspaces.
+
+For `Implements` / `Requires` kinds, `scope_qid` is `None` — they resolve against workspace-wide Interface symbols by qualified_name, the same shape as `IMPORTS` resolution (also a Phase A-style lookup).
 
 ### 4.2 Phase assignments
 
 | UnresolvedKind | Resolution phases tried (in order) |
 |---|---|
-| `Signatory`, `Controller`, `Observer` | Phase A.5 (scoped) → Phase C (fallback workspace name-match) |
-| `Implements`, `Requires` | Phase A-shape (qualified_name lookup of an Interface node) |
+| `Signatory`, `Controller`, `Observer` | Phase A.5 (scoped HashMap lookup) → Phase C (fallback workspace name-match). Phase B is intentionally skipped — party names are scope-local, not workspace-imported. |
+| `Implements`, `Requires` | Phase A-shape (qualified_name lookup of an Interface node, same shape as `IMPORTS`). No fallback — if an unknown interface name is referenced, the edge stays unresolved (existing behavior for unknown qualified names). |
 
 ### 4.3 Backwards compatibility
 
@@ -285,6 +322,8 @@ exception InsufficientBalance with
     message "Insufficient balance"
 ```
 
+> **Daml version compatibility.** The `interface instance I for T where ...` syntax inside a template body is the Daml 2.7+ form (pre-2.7 used a separate top-level `instance` declaration). The fixture targets 2.7+ syntax. **Slice 10a Task 1 includes a verification step**: attempt to compile the fixture with the local `daml` compiler (if installed) or paste it into Daml Studio. If the compiler rejects it, switch to the pre-2.7 top-level form and update the fixture inline before proceeding. The extractor changes (tree-sitter queries) are insensitive to which form is used as long as the `interface instance` keyword sequence is in the source — only the IMPLEMENTS-edge source-side computation changes (sourced from Template's nested where-block in 2.7+, sourced from a top-level declaration node in 2.6 and earlier).
+
 Per-slice-10a expectations (asserted by the integration test):
 
 - 1 new Module (`Splice.Authorization`).
@@ -299,7 +338,7 @@ Per-slice-10a expectations (asserted by the integration test):
 
 Following slices 5-9's pattern, append to `tests/extraction_unit.rs`.
 
-**Slice 10a (~10 tests):**
+**Slice 10a (10 tests):**
 
 - `daml_extracts_interface_name_and_qualified_name`
 - `daml_extracts_viewtype_inside_interface_scope`
@@ -309,8 +348,10 @@ Following slices 5-9's pattern, append to `tests/extraction_unit.rs`.
 - `daml_byte_precise_template_span` — Template start/end lines match actual AST extent, not regex line block
 - `daml_pass_d_replaces_regex_no_regression` — comprehensive: indexes Counter.daml fixture from slice 9 and verifies counts match prior slice 9 baseline (regression guard)
 - `daml_field_qualified_name_nests_under_template` — `Foo.Counter.owner`, not `Foo.owner`
+- `daml_field_qualified_name_nests_under_choice` — `Foo.Counter.Bump.delta` (4-segment qname when Choice has its own `with`-block)
+- `daml_top_level_signature_not_emitted_as_field` — disambiguation guard: `helperFn : Int -> Int` at top level remains a Function signature, NOT a stray Field
 
-**Slice 10b (~8 tests):**
+**Slice 10b (10 tests):**
 
 - `daml_signatory_emits_unresolved_ref_with_scope_qid`
 - `daml_controller_inside_choice_uses_choice_scope`
@@ -319,6 +360,9 @@ Following slices 5-9's pattern, append to `tests/extraction_unit.rs`.
 - `daml_requires_emits_interface_to_interface_ref`
 - `daml_signatory_resolves_to_template_field_in_phase_a5`
 - `daml_party_unresolved_ref_falls_through_to_phase_c_when_scoped_miss`
+- `daml_multi_party_list_decomposed` — `signatory [a, b]` emits two refs, not one
+- `daml_multi_party_set_fromlist_decomposed` — `signatory $ Set.fromList [a, b]` emits two refs; `Set.fromList` is filtered out
+- `daml_party_unwrapped_from_optional` — `signatory $ fromOptional [] mObservers` emits one ref for `mObservers`
 
 ### 5.3 Integration tests
 

--- a/docs/superpowers/specs/2026-06-12-codegraph-rs-external-packages-design.md
+++ b/docs/superpowers/specs/2026-06-12-codegraph-rs-external-packages-design.md
@@ -1,0 +1,202 @@
+# codegraph-rs — external-package references design
+
+**Status:** Approved (scope), awaiting implementation plan.
+**Baseline:** `main` @ `fa88834` (after PR #15 — Phase A/B import resolution fixed; `IMPORTS`/Phase-B cross-module calls now work within the indexed workspace).
+**Scope:** A general, package-aware layer so references into *external* dependency packages resolve. External symbols exist purely as resolution targets — excluded from embeddings and search.
+
+This spec extends the v1 design (`2026-04-22-codegraph-rs-design.md`, §7 Resolution) and the v2 Daml-depth design (`2026-05-15-…`). Section refs to "v1 spec §N" point at the former.
+
+---
+
+## 1. Goal and scope
+
+### 1.1 Goal
+
+After #15, intra-workspace resolution works: `import Splice.X` binds to in-workspace Modules, and Phase B resolves cross-module calls precisely (`confidence: import_resolved`). What remains unresolved is **references into packages we don't index**. On the Splice corpus this is a single, well-defined population:
+
+- **6,669** `call` refs with `unresolved_reason = "no_candidate"` — names like `pure`, `map`, `show`, `submit`, `Some`, `Party`, `ContractId`.
+- **20** distinct unresolved `import` module paths, *all* Daml SDK: `DA.*` (stdlib), `Prelude`, `Daml.Script`.
+- **0** unresolved `Splice.*` imports — sibling Splice packages already resolve (they live under the indexed `daml` root).
+
+The goal is a **general** mechanism: today it closes the SDK-stdlib gap; tomorrow it handles any third-party DAR dependency, with no per-dependency special-casing.
+
+### 1.2 Design decisions (locked)
+
+| Axis | Decision |
+|---|---|
+| **Model** | A first-class **`Package`** layer with package-qualified resolution (not workspace-wide name match into externals). |
+| **Generality** | A **general** external-package mechanism driven by compiled artifacts, not a stdlib-only shortcut. |
+| **Population source** | **DAR/DALF metadata** — decode each dependency's compiled Daml-LF to enumerate its exported symbol *names* per module. Source-independent; works for SDK stdlib and third-party DARs uniformly. |
+| **Dependency mapping** | Derived from each local package's `daml.yaml` (`dependencies` / `data-dependencies`) plus DAR `MANIFEST.MF` dependency lists. |
+| **Visibility** | External symbols are **resolution targets only** — marked `external`, excluded from embeddings, `semantic_search`, and keyword `search`. `CALLS`/`TYPE_OF`/`REFERENCES` edges to them still resolve. |
+
+### 1.3 Out of scope
+
+- **External source / bodies.** We ingest exported *names + kinds + module/package*, not definitions or `source` snippets. `graph/node` on an external symbol returns metadata, no snippet.
+- **Semantic search / navigation into external code.** Externals never get embeddings and are filtered out of all search read-paths (§5).
+- **Rust external dependencies (crates).** This layer is Daml-LF-specific. A Rust analogue (resolving into `cargo` deps) is a future slice.
+- **Cross-workspace / multi-repo indexing.** Unchanged from v1.
+- **Re-deriving external symbols from source.** Even where source is available locally (the SDK ships stdlib `.daml`), we standardize on DAR/DALF metadata so the path is uniform and version-faithful to what the code actually compiled against.
+
+---
+
+## 2. Data model additions
+
+### 2.1 `Package` node
+
+| Property | Meaning |
+|---|---|
+| `package_id` | Daml-LF package hash (content-addressed; stable across machines/runs). Primary key. |
+| `name`, `version` | From the DAR manifest / `daml.yaml`. |
+| `external` | `true` for dependency packages; `false` for the workspace's own packages. |
+| `qid` | `pkg:<package_id>` — a new qid namespace, disjoint from local `<root>:<rel_path>:<qname>`. |
+
+Both local and external packages get `Package` nodes so the dependency graph is uniform, **but their identity differs**:
+
+- **External** packages are keyed by the content-addressed LF `package_id` (`qid = pkg:<package_id>`).
+- **Local** packages are *not* decoded from a DAR (we extract them from source and have no compiled `package_id`), so they use a synthetic key derived from their `daml.yaml` `name` (+ `version`): `qid = pkg:local:<name>`, `external = false`. Each `File` maps to its local package by **nearest-ancestor `daml.yaml`** (walk up from the file's directory). A local package's `DEPENDS_ON` set is built from its `daml.yaml` `dependencies` / `data-dependencies` (resolved to the `package_id`s learned during ingestion) plus the implicit SDK packages (§3.1).
+
+### 2.2 External `Module` / symbol nodes
+
+External modules and their exported symbols are ingested as ordinary `:Module` / `:Symbol`-labelled nodes **plus** an `:External` marker label and `external: true` property:
+
+- qid: `pkg:<package_id>:<module_qname>[.<symbol_qname>]`.
+- Symbol kinds map from LF: data types → `Struct`, templates → `Template`, choices → `Choice`, interfaces → `Interface`, values/functions → `Function`. (Names + kinds only; no fields, no bodies, no spans.)
+- They keep the `:Symbol` label **on purpose** — resolution candidate lookups match `(:Symbol {name})` (v1 spec §7), so externals must be findable there. Search/embed exclusion is done at the *read* layer (§5), not by withholding the label.
+
+### 2.3 New edges
+
+| Edge | Direction | Meaning |
+|---|---|---|
+| `IN_PACKAGE` | `Module → Package` | Which package a module belongs to (local and external). |
+| `DEPENDS_ON` | `Package → Package` | Local package → each external package it may import from. Scopes resolution (§4). |
+
+### 2.4 Schema change — additive constraint, **no `schema_version` bump**
+
+`apply_schema` (`src/db/schema.rs`) gains a uniqueness constraint on `Package(qid)` (alongside the existing `symbol_qid_unique` and `unresolved_ref_qid_unique`). Like the others it is idempotent (`CREATE CONSTRAINT … IF NOT EXISTS`), so existing databases simply gain it on the next `index`.
+
+**Do NOT bump `schema_version`.** `SUPPORTED_SCHEMA_VERSION` (`src/config/workspace.rs:80`) is checked with strict equality at config load — `cfg.schema_version != SUPPORTED_SCHEMA_VERSION` ⇒ `bail!` (`workspace.rs:95`). Bumping 1→2 would make *every existing* `.codegraph/config.toml` (all written with `schema_version = 1`, e.g. `~/splice`) fail to load until regenerated. The `schema_version` field guards the **config-file format**, which this change does not alter — adding a Neo4j constraint is orthogonal. If a future change genuinely alters the config format, that bump must ship with a migration (auto-rewrite the field, or relax the gate to `<=`).
+
+The FTS (`symbol_fts`) and vector (`symbol_embedding`) indexes are unchanged — see §5 for why external `:Symbol`s sitting in those indexes is acceptable.
+
+---
+
+## 3. Ingestion — new `extern` stage
+
+A new pipeline stage runs **before resolution** (extract → write → **extern** → resolve → embed) and is idempotent (MERGE by content-addressed `package_id`; identical inputs ⇒ no-ops). It is gated/skippable like embeddings.
+
+### 3.1 Enumerate dependency DARs
+
+For each local `daml.yaml`:
+- `sdk-version` → the SDK package-db at `~/.daml/sdk/<ver>/damlc/resources/pkg-db_dir/<lf>/…` supplies `daml-prim`, `daml-stdlib`, and (for scripts) `daml-script` DALFs. **These SDK packages are *implicit* dependencies of every local package** — they are not listed in `daml.yaml dependencies` but are imported (`Prelude`, `DA.*`, `Daml.Script`). The `extern` stage adds them to every local package's `DEPENDS_ON`.
+- `dependencies` / `data-dependencies` → built DARs (e.g. Splice's `daml/dars/*.dar`).
+
+**Pin one LF version per package.** The SDK `pkg-db_dir` ships `daml-stdlib`/`daml-prim` compiled for *multiple* LF versions (`2.1`, `2.dev`), which are *distinct `package_id`s exposing the same module names* (e.g. `DA.List`). Ingesting more than one would create duplicate module qualified-names and break module lookup (§4.1). Resolve the **single** `<lf>` matching the workspace's target (from `daml.yaml` / `build-options`) and ingest only that. The DAR set to ingest is the transitive closure of the above, deduped by `package_id`.
+
+### 3.2 Decode DAR/DALF — reuse the canton-toolbox decoder
+
+A DAR is a zip: `META-INF/MANIFEST.MF` lists the main DALF + dependency DALFs; each `.dalf` is a Daml-LF protobuf `Archive` (envelope → `ArchivePayload` → LF2 `Package`). Per package we extract: `package_id`, dependency `package_id`s, and per module its exported definitions (name + kind).
+
+**This is already solved in the sibling `canton-toolbox` repo — we reuse it rather than build from scratch.** Its `codegen` crate has a working prost-based LF reader:
+
+- Vendored schema: `codegen/resources/protobuf/com/digitalasset/daml/lf/archive/daml_lf.proto` + `daml_lf2.proto`, compiled by `codegen/build.rs` via `prost-build` into `lf_protobuf.rs` (`com::daml::daml_lf_2`, `…daml_lf_dev`).
+- `archive.rs`: `archive_from_dar`, `extract_dalfs_from_dar` (zip + `Archive::decode`).
+- `package.rs`: `parse_dar(path) -> ParsedDar { main_package_id, packages: HashMap<package_id, Package> }` and `parse_dars(&[..])` (dedupes by hash). **`package_id` is `archive.hash`** — the content-addressed key §2.1 specifies, for free. Targets **DamlLf2** (LF 2.x), which matches Canton 3.x / the local SDK (`pkg-db_dir/2.1`, `2.dev`).
+
+So the ingestion work is: (1) bring this decoder into codegraph-rs, and (2) walk the decoded LF `Package` for exported definition names + kinds (data types → `Struct`, templates → `Template`, choices → `Choice`, interfaces → `Interface`, values → `Function`) and inter-package dependency hashes.
+
+**LF names are interned — not direct strings.** In LF2, module names and definition names are stored as *indices* into the package's interned-string / interned-dotted-name tables, not as inline strings. Extracting a readable `qualified_name` means dereferencing those indices against the package tables — exactly what canton-toolbox's `codegen/src/resolve_type.rs` already does (`*_interned_str` / `*_interned_dname` → `&[String]`). The 11b walk must reuse that dereferencing, not read `.name` fields directly (which yield integers). This is the main correctness subtlety of the AST walk.
+
+**Reuse strategy: vendor (decided).** Copy the minimal decoder into codegraph-rs — the two `.proto`s, the `build.rs` prost-build step, and `archive.rs` / `package.rs` / `lf_protobuf.rs` (plus the interned-name dereferencing helpers from `resolve_type.rs`) — rather than a cross-repo path dependency on canton-toolbox. Keeps codegraph-rs self-contained and local-first; avoids coupling its build to a sibling repo's layout. The 11b spike confirms the exact minimal file set and that LF2 covers every DALF we ingest. (Trade-off accepted: the vendored protos/decoder must be re-synced if upstream LF evolves — low frequency, and pinned to the LF version the workspace's SDK emits.)
+
+### 3.3 Write external nodes + edges
+
+The `extern` stage runs **after `write`** (so local `File`/`Module` nodes already exist) and:
+1. Creates **local** `Package` nodes from each `daml.yaml`, links local `Module`s via `IN_PACKAGE`, and maps each `File` to its local package (nearest-ancestor `daml.yaml`, §2.1).
+2. Ingests external DARs: MERGE external `Package`, external `Module` nodes, and external symbol stubs (`external: true`, `:External`). **Each external `Module` `CONTAINS` its exported symbols** — Phase B's `import_driven_candidates` matches `(m:Module)-[:CONTAINS|EXPORTS]->(:Symbol {name})`, so the containment edge is mandatory for resolution to find them.
+3. Adds `IN_PACKAGE` (module→package) and `DEPENDS_ON` (local→external, incl. implicit SDK packages).
+
+MERGE-by-`package_id` makes it idempotent; repeated `index` runs skip already-ingested external packages. The `extern` stage is **not** part of per-file `sync` — external deps change rarely; re-ingest is triggered by an explicit re-`index` (or a future `daml.yaml`/DAR-change check).
+
+---
+
+## 4. Package-qualified resolution
+
+Resolution gains package scoping. Precedence is **local-import > external-import > local-name-match**; externals bind *only* through an import path, never via fallback.
+
+### 4.1 Phase A (imports)
+
+`import M` in a file resolves to a `Module {qualified_name: M}` reachable from the file's local package — first the workspace (local-first), then the package's `DEPENDS_ON` external packages. This both lights up the 20 stdlib imports and disambiguates same-named modules across packages.
+
+`find_module_by_qualified_name` (`src/db/queries.rs`) currently **hard-`bail!`s on >1 match** — fine when module qnames were workspace-unique, but externals reintroduce duplicates (e.g. a workspace module and a dep both named, or the multi-LF stdlib problem §3.1). The package-scope filter must therefore (a) restrict candidates to the importing file's package + its `DEPENDS_ON` set, and (b) prefer the local match, returning the single in-scope module **instead of bailing**. (§3.1's single-LF pinning removes the most common duplicate at the source.)
+
+### 4.2 Phase B (import-driven)
+
+Already restricts candidates to imported modules (`import_driven_candidates`); externals participate automatically once their `IMPORTS` edges exist. Calls into `DA.*`/`Prelude` resolve here with `confidence: import_resolved`.
+
+### 4.3 Phase C (name-match fallback) — exclude externals
+
+`name_match_candidates` adds `WHERE c.external IS NULL`. Rationale: a bare name like `map` must *not* silently bind to `DA.List.map` workspace-wide — that would manufacture thousands of false edges. Externals are import-scoped only. Local-to-local name match is unchanged.
+
+### 4.4 Phase A.5 (party / implements / requires)
+
+Phase A.5 builds a workspace-wide `qualified_name → qid` map (`build_qname_map` = `MATCH (s:Symbol) …`), which will now also contain external symbols. Implications:
+- **Signatory/Controller/Observer** use *scoped* keys (`<local-scope-qname>.<name>`) — these never collide with `pkg:…`-namespaced externals, so party edges are unaffected.
+- **Implements/Requires** use `find_interface_by_name` (exact, then `.<suffix>` match) — an external `Interface` can now match, and that is **allowed (decided)**: a template implementing an interface defined in a dependency is a real relationship, so `IMPLEMENTS`/`REQUIRES` may point at external interfaces. `build_qname_map` is left unfiltered. (If suffix-matching ever proves too loose against the larger external namespace, tighten `find_interface_by_name` to prefer in-`DEPENDS_ON` packages — a later refinement, not v1.)
+
+### 4.5 Idempotency
+
+`drop_resolution_edges` already clears `CALLS`/`IMPORTS`/`REFERENCES`/`TYPE_OF` by `confidence`. External *nodes/packages* are not resolution-derived (they're ingested facts) and are left intact across re-resolves; only the edges into them are rebuilt.
+
+---
+
+## 5. Visibility — resolution-only
+
+External symbols are excluded from every value-bearing read surface; they exist solely so refs can bind.
+
+| Surface | Change |
+|---|---|
+| **Embeddings** | `EmbedScope` / `fetch_in_scope` (`src/vectors/query.rs`) and the `EMBED_KINDS_CYPHER_LIST` selection add `AND n.external IS NULL`. No external symbol is ever embedded. |
+| **`semantic_search`** | `graph/semantic.rs` query filters `WHERE node.external IS NULL` (externals have no embedding anyway, but the filter is explicit). |
+| **keyword `search`** | `graph/search.rs` FTS query post-filters `WHERE NOT n:External`. |
+| **`status`** | Reports external packages/symbols as a separate line, not folded into workspace symbol counts. |
+
+**FTS-index tradeoff (accepted).** External `:Symbol`s physically sit in the `symbol_fts` index (it's defined on `:Symbol`), but the `search` query excludes them. Rebuilding the FTS index to exclude externals by label is not worth it; the bloat is bounded and search results are correct.
+
+---
+
+## 6. Slices (each independently shippable)
+
+| Slice | Scope | Tag |
+|---|---|---|
+| **11a — model + visibility** | `Package` node, `external` flag/`:External` label, qid namespace, schema v2 constraint, exclude-external filters in embed/search read-paths. No ingestion yet → no behavior change, but the surfaces are ready. | `slice-11a-package-model` |
+| **11b — DAR/DALF ingestion** | Vendor the canton-toolbox LF decoder (§3.2); `extern` pipeline stage; enumerate deps from `daml.yaml` + SDK package-db; walk LF `Package` for exported names/kinds; write external `Package`/`Module`/symbol stubs + `IN_PACKAGE`/`DEPENDS_ON`. | `slice-11b-dar-ingestion` |
+| **11c — package-qualified resolution** | Scope Phase A/B by `DEPENDS_ON`; exclude externals from Phase C; precedence rules. | `slice-11c-package-resolution` |
+| **11d — corpus validation** | Re-index splice; confirm the ~6,669 `no_candidate` stdlib calls bind to external `DA.*`; confirm externals absent from embeddings/search. | (validation, no tag) |
+
+Slice 11a is safe to ship alone (additive). 11b is the heaviest (the LF reader). 11c delivers the user-visible win.
+
+---
+
+## 7. Risks and open items
+
+- **LF decoder (was the primary risk — now de-risked).** Reuses the proven prost-based reader from the sibling `canton-toolbox` `codegen` crate (vendored `daml_lf2.proto` + `prost-build` + `parse_dar`/`Package` walk; `package_id = archive.hash`; LF2). Residual risk is narrowed to the reuse strategy (vendor vs path-dep, §3.2) and walking the LF `Package` AST for exported names — not building a decoder. The 11b spike confirms the minimal vendored file set.
+- **DAR availability.** Resolution quality depends on the dependency DARs being present (Splice's `daml/dars/` + the SDK package-db). If a dep isn't built/available, its refs stay `no_candidate` — degrades gracefully, no errors.
+- **SDK/version coupling + multi-LF duplicates.** External `package_id`s are content hashes, so they're stable and self-identifying. But the SDK ships `daml-stdlib`/`daml-prim` for multiple LF versions under one `pkg-db_dir`, all exposing the same module names — ingesting >1 creates duplicate module qnames that break lookup. Mitigated by pinning to the workspace's single target LF (§3.1) and by the dup-tolerant scoped lookup (§4.1). This is the subtlest correctness trap in the design.
+- **Graph size.** External symbols add nodes but are never embedded (the expensive axis), so the embedding pipeline cost is flat. FTS index gains bounded entries (§5).
+- **Daml-only.** This layer is LF-specific; Rust crate resolution is a separate future slice and shares only the `Package`/`external` model, not the ingestion.
+
+---
+
+## 8. Test plan
+
+- **Unit (11b):** LF/DAR parser against a tiny committed fixture DAR (or DALF) — assert package-id, module list, and a few exported definition names/kinds. **Explicitly assert names resolve to readable strings** (guards the interned-name dereferencing, §3.2) and that re-parsing the same DAR is byte-stable (content-hash dedup).
+- **Unit/integration (3.1):** given a `daml.yaml` + multi-LF SDK package-db, only the pinned-LF `daml-stdlib`/`daml-prim` is ingested (no duplicate `DA.List` modules); `find_module_by_qualified_name` returns the single in-scope module rather than bailing.
+- **Integration (11a/11c, gated on `CODEGRAPH_RS_TEST_NEO4J`):** index `tiny-daml` plus a small external-package fixture; assert (a) local + external `Package` nodes and `IN_PACKAGE`/`DEPENDS_ON` edges (incl. implicit SDK dep); (b) external `Module` `CONTAINS` its symbols and a call into it resolves with `confidence: import_resolved`; (c) external symbols absent from `semantic_search`, keyword `search`, and the embedded set; (d) Phase C does not bind a bare local name to an external symbol; (e) an existing `schema_version = 1` config still loads (no version-bump regression).
+- **Corpus validation (11d):** on `codegraph-splice`, `no_candidate` calls drop sharply (stdlib refs bind); `pure`/`map`/`Some` resolve to external `DA.*`; embedded count unchanged from the local-only baseline.
+
+---
+
+## 9. Relationship to the deferred cleanup
+
+This work intentionally precedes the graph-granularity cleanup discussed separately (pruning inert `UnresolvedRef`/`Import` scaffolding). Resolving external refs converts a large fraction of today's `no_candidate`/`import` refs into edges, so the genuinely-inert remainder — the real cleanup target — is only well-defined *after* this lands. Re-measure then.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2346,7 +2346,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -51,7 +51,7 @@ const WORKER_RECYCLE_INTERVAL = 250;
  * Progress callback for indexing operations
  */
 export interface IndexProgress {
-  phase: 'scanning' | 'parsing' | 'storing' | 'resolving';
+  phase: 'scanning' | 'parsing' | 'storing' | 'resolving' | 'embedding';
   current: number;
   total: number;
   currentFile?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -406,6 +406,21 @@ export class CodeGraph {
               total,
             });
           });
+
+          // Generate embeddings for semantic search
+          try {
+            await this.initializeEmbeddings();
+            await this.generateEmbeddings((progress) => {
+              options.onProgress?.({
+                phase: 'embedding',
+                current: progress.current,
+                total: progress.total,
+              });
+            });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            process.stderr.write(`[CodeGraph] Embedding generation failed: ${msg}\n`);
+          }
         }
 
         return result;
@@ -486,6 +501,21 @@ export class CodeGraph {
                 total,
               });
             });
+          }
+
+          // Generate embeddings for new/changed nodes
+          try {
+            await this.initializeEmbeddings();
+            await this.generateEmbeddings((progress) => {
+              options.onProgress?.({
+                phase: 'embedding',
+                current: progress.current,
+                total: progress.total,
+              });
+            });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            process.stderr.write(`[CodeGraph] Embedding generation failed: ${msg}\n`);
           }
         }
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -116,6 +116,14 @@ export class MCPServer {
     try {
       this.cg = await CodeGraph.open(resolvedRoot);
       this.toolHandler.setDefaultCodeGraph(this.cg);
+
+      // Initialize embeddings for semantic search
+      try {
+        await this.cg.initializeEmbeddings();
+      } catch (embErr) {
+        const msg = embErr instanceof Error ? embErr.message : String(embErr);
+        process.stderr.write(`[CodeGraph MCP] Embedding init failed (semantic search unavailable): ${msg}\n`);
+      }
     } catch (err) {
       // Log the error so transient failures are diagnosable (see issue #47)
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
Design spec for resolving references into **external dependency packages** — the Daml SDK stdlib/prelude/script today (the 6,669 `no_candidate` calls + 20 unresolved `DA.*`/`Prelude`/`Daml.Script` imports left after PR #15), and any third-party DAR later. External symbols are ingested as **resolution-only targets**: marked `external`, excluded from embeddings and search, but valid `CALLS`/`TYPE_OF`/`REFERENCES`/`IMPLEMENTS` targets.

Adds `docs/superpowers/specs/2026-06-12-codegraph-rs-external-packages-design.md`.

## Locked decisions
- First-class **`Package`** layer + **package-qualified** resolution.
- **General** mechanism driven by compiled artifacts (works for SDK stdlib and any DAR).
- Ingestion **vendors** the proven prost-based Daml-LF decoder from the sibling `canton-toolbox` `codegen` crate (no from-scratch LF reader).
- Dependency mapping from `daml.yaml` + DAR manifests; SDK packages are implicit deps.
- External symbols resolution-only (excluded from embed/search); `IMPLEMENTS`/`REQUIRES` may target external interfaces.

## Reviewed against source (codegraph-rs + canton-toolbox)
The spec was plan-verified and corrected before commit:
- **No `schema_version` bump** — it's a strict-equality config gate (`config/workspace.rs:95`); bumping would break every existing workspace. The new `Package(qid)` constraint is additive/idempotent.
- **LF names are interned** — module/def names are indices into the package string/dotted-name tables; the walk must dereference them (reuse `canton-toolbox/.../resolve_type.rs`).
- **Pin one LF version** — the SDK ships stdlib/prim for multiple LF versions with identical module names; ingesting >1 breaks module lookup.
- **Dup-tolerant module lookup** — `find_module_by_qualified_name` currently bails on >1; package-scoped lookup must return the in-scope match instead.
- **Local packages** keyed synthetically (`pkg:local:<name>`) since they have no compiled `package_id`.

## Phasing (slices)
11a model + visibility (additive, no behavior change) → 11b vendor LF decoder + DAR/DALF ingestion → 11c package-qualified resolution → 11d corpus validation.

Implementation has not started. Sign-off requested on the design.