### PR TITLE
chore(release): 1.0.0 — README banner + X account

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # CodeGraph
 
+## 🎉 1.0 Released!
+
+Follow [@getcodegraph](https://x.com/getcodegraph) on X for updates.
+
 ### Supercharge Claude Code, Cursor, Codex, OpenCode, Hermes Agent, Gemini, Antigravity, and Kiro with Semantic Code Intelligence
 
 **~16% cheaper · ~58% fewer tool calls · 100% local**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colbymchenry/codegraph",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "description": "Supercharge Claude Code with semantic code intelligence. 94% fewer tool calls • 77% faster exploration • 100% local.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump to 1.0.0 (lock-file sync is handled by the Release workflow), "1.0 Released!" banner and [@getcodegraph](https://x.com/getcodegraph) link at the top of the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)