### PR TITLE
docs(readme): auto-sync becomes quick-start step 4 heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,15 @@ codegraph init
 
 <sub>`codegraph init` creates the local `.codegraph/` directory and builds the full graph in the same step — one command, done.</sub>
 
-**From that moment the index keeps itself up to date — it is never stale.** CodeGraph watches the project and auto-syncs on every file change: while your agent edits code, or you add, modify, or delete files, the graph updates automatically. There is nothing to re-run.
-
-
 <div align="center">
 
 ![1_C_VYnhpys0UHrOuOgpgoyw](https://github.com/user-attachments/assets/f168182f-4d9a-44e0-94d7-08d018cc8a3a)
 
 </div>
+
+### 4. No more syncing!
+
+Auto-sync is enabled by default. CodeGraph watches the project and updates the graph on every file change — while your agent edits code, or you add, modify, or delete files. **The index is never stale, and there is nothing to re-run.**
 
 ### Uninstall
 


### PR DESCRIPTION
The auto-sync guarantee was buried as a bold paragraph under step 3 — promote it to its own numbered step ("4. No more syncing!") so it reads at the same weight as the other quick-start steps. Step 3's demo image moves with step 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)