### PR TITLE
feat(mcp): add CODEGRAPH_MCP_TOOLS presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,17 @@ When running as an MCP server, CodeGraph exposes a **single tool** — `codegrap
 |------|---------|
 | `codegraph_explore` | Answer almost any question in one call — "how does X work", a flow ("how does X reach Y"), or surveying an area — returning the relevant symbols' verbatim source grouped by file, plus the call paths between them and a blast-radius summary. Surfaces dynamic-dispatch hops (callbacks, React re-render, interface→impl) grep can't follow. Name a file or symbol in the query to read its current line-numbered source, the same shape the Read tool gives you. |
 
-The other tools (`codegraph_node`, `codegraph_search`, `codegraph_callers`, `codegraph_callees`, `codegraph_impact`, `codegraph_files`, `codegraph_status`) stay fully functional but **unlisted by default** — everything they return already arrives inline on `codegraph_explore` (its blast-radius section, the relationship map, a symbol's body as its callee list). Re-enable any of them for the MCP surface with the `CODEGRAPH_MCP_TOOLS` environment variable (e.g. `CODEGRAPH_MCP_TOOLS=explore,node,search,callers`), or use their CLI equivalents (`codegraph node` / `query` / `callers` / `callees` / `impact` / `files` / `status`).
+The other tools (`codegraph_node`, `codegraph_search`, `codegraph_callers`, `codegraph_callees`, `codegraph_impact`, `codegraph_files`, `codegraph_status`) stay fully functional but **unlisted by default** — everything they return already arrives inline on `codegraph_explore` (its blast-radius section, the relationship map, a symbol's body as its callee list). Re-enable any of them for the MCP surface with the `CODEGRAPH_MCP_TOOLS` environment variable, or use their CLI equivalents (`codegraph node` / `query` / `callers` / `callees` / `impact` / `files` / `status`).
+
+`CODEGRAPH_MCP_TOOLS` accepts comma-separated short names and presets:
+
+| Value | Exposed tools |
+|---|---|
+| unset or `default` | `explore` |
+| `compact` | `explore,node,search` |
+| `core` | `explore,node,search,callers` |
+| `full` | every defined MCP tool |
+| custom list | e.g. `explore,node,search,callers,impact` |
 
 In a workspace with no `.codegraph/` index, the server announces itself inactive and lists **no** tools — agents work normally with their built-in tools, and indexing stays your decision.
 

--- a/__tests__/mcp-tool-allowlist.test.ts
+++ b/__tests__/mcp-tool-allowlist.test.ts
@@ -4,7 +4,7 @@
  * Filtering happens in ListTools (getTools) and is enforced again on execute().
  */
 import { describe, it, expect, afterEach } from 'vitest';
-import { ToolHandler } from '../src/mcp/tools';
+import { getStaticTools, ToolHandler } from '../src/mcp/tools';
 
 const ENV = 'CODEGRAPH_MCP_TOOLS';
 
@@ -16,6 +16,7 @@ describe('CODEGRAPH_MCP_TOOLS allowlist', () => {
   });
 
   const listed = () => new ToolHandler(null).getTools().map(t => t.name).sort();
+  const staticListed = () => getStaticTools().map(t => t.name).sort();
 
   it('exposes ONLY codegraph_explore by default when unset', () => {
     delete process.env[ENV];
@@ -24,26 +25,90 @@ describe('CODEGRAPH_MCP_TOOLS allowlist', () => {
     // node/search/callers/callees/impact/files/status stay defined and executable
     // but unlisted; CODEGRAPH_MCP_TOOLS re-enables them.
     expect(listed()).toEqual(['codegraph_explore']);
+    expect(staticListed()).toEqual(listed());
   });
 
   it('re-enables an unlisted tool via the allowlist (impact)', () => {
     process.env[ENV] = 'explore,impact';
     expect(listed()).toEqual(['codegraph_explore', 'codegraph_impact']);
+    expect(staticListed()).toEqual(listed());
   });
 
   it('filters ListTools to the allowlisted short names', () => {
     process.env[ENV] = 'explore,search,node';
     expect(listed()).toEqual(['codegraph_explore', 'codegraph_node', 'codegraph_search']);
+    expect(staticListed()).toEqual(listed());
   });
 
-  it('accepts fully-qualified codegraph_ names and ignores whitespace', () => {
-    process.env[ENV] = ' codegraph_explore , search ';
+  it('accepts fully-qualified codegraph_ names and ignores whitespace/case', () => {
+    process.env[ENV] = ' CODEGRAPH_EXPLORE , search ';
     expect(listed()).toEqual(['codegraph_explore', 'codegraph_search']);
+    expect(staticListed()).toEqual(listed());
   });
 
   it('treats an empty/whitespace value as unset (default surface)', () => {
     process.env[ENV] = '   ';
     expect(listed()).toEqual(['codegraph_explore']);
+    expect(staticListed()).toEqual(listed());
+  });
+
+  it('treats separator-only values as unset in both static and live listings', () => {
+    process.env[ENV] = ' , ,, ';
+    expect(listed()).toEqual(['codegraph_explore']);
+    expect(staticListed()).toEqual(listed());
+  });
+
+  it('supports the default preset as an explicit allowlist', async () => {
+    process.env[ENV] = 'default';
+    expect(listed()).toEqual(['codegraph_explore']);
+    expect(staticListed()).toEqual(listed());
+
+    const res = await new ToolHandler(null).execute('codegraph_impact', {});
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/disabled via CODEGRAPH_MCP_TOOLS/);
+  });
+
+  it('supports the compact preset', () => {
+    process.env[ENV] = 'compact';
+    expect(listed()).toEqual(['codegraph_explore', 'codegraph_node', 'codegraph_search']);
+    expect(staticListed()).toEqual(listed());
+  });
+
+  it('supports the core preset', () => {
+    process.env[ENV] = 'core';
+    expect(listed()).toEqual([
+      'codegraph_callers',
+      'codegraph_explore',
+      'codegraph_node',
+      'codegraph_search',
+    ]);
+    expect(staticListed()).toEqual(listed());
+  });
+
+  it('supports the full preset', () => {
+    process.env[ENV] = 'full';
+    expect(listed()).toEqual([
+      'codegraph_callees',
+      'codegraph_callers',
+      'codegraph_explore',
+      'codegraph_files',
+      'codegraph_impact',
+      'codegraph_node',
+      'codegraph_search',
+      'codegraph_status',
+    ]);
+    expect(staticListed()).toEqual(listed());
+  });
+
+  it('combines presets with explicit tool names', () => {
+    process.env[ENV] = 'compact,callers';
+    expect(listed()).toEqual([
+      'codegraph_callers',
+      'codegraph_explore',
+      'codegraph_node',
+      'codegraph_search',
+    ]);
+    expect(staticListed()).toEqual(listed());
   });
 
   it('rejects a disabled tool on execute (defense in depth)', async () => {

--- a/site/src/content/docs/reference/mcp-server.md
+++ b/site/src/content/docs/reference/mcp-server.md
@@ -9,20 +9,23 @@ CodeGraph runs as a [Model Context Protocol](https://modelcontextprotocol.io/) s
 codegraph serve --mcp
 ```
 
-Agents configured by the installer launch this automatically. When a `.codegraph/` index exists, the agent uses the tools below.
+Agents configured by the installer launch this automatically. When a `.codegraph/` index exists, the agent uses the focused default tool below.
 
 ## Tools
 
 | Tool | Purpose |
 |---|---|
-| `codegraph_search` | Find symbols by name across the codebase |
-| `codegraph_callers` | Find what calls a function |
-| `codegraph_callees` | Find what a function calls |
-| `codegraph_impact` | Analyze what code is affected by changing a symbol |
-| `codegraph_node` | Get details about a specific symbol (optionally with source code) |
 | `codegraph_explore` | Return source for several related symbols grouped by file, plus a relationship map, in one call |
-| `codegraph_files` | Get the indexed file structure (faster than filesystem scanning) |
-| `codegraph_status` | Check index health and statistics |
+
+`codegraph_node`, `codegraph_search`, `codegraph_callers`, `codegraph_callees`, `codegraph_impact`, `codegraph_files`, and `codegraph_status` remain implemented but are not listed by default. Set `CODEGRAPH_MCP_TOOLS` to change the exposed MCP surface:
+
+| Value | Exposed tools |
+|---|---|
+| unset or `default` | `explore` |
+| `compact` | `explore,node,search` |
+| `core` | `explore,node,search,callers` |
+| `full` | every defined MCP tool |
+| custom list | e.g. `explore,node,search,callers,impact` |
 
 ## How agents should use it
 

--- a/src/mcp/tool-allowlist.ts
+++ b/src/mcp/tool-allowlist.ts
@@ -1,0 +1,53 @@
+/**
+ * MCP tool allowlist parsing.
+ *
+ * CODEGRAPH_MCP_TOOLS accepts comma-separated short tool names. Presets expand
+ * to short names too, so the rest of the MCP layer handles one simple Set.
+ */
+
+export const DEFAULT_MCP_TOOL_NAMES = Object.freeze([
+  'explore',
+]);
+
+export const COMPACT_MCP_TOOL_NAMES = Object.freeze([
+  'explore',
+  'node',
+  'search',
+]);
+
+export const CORE_MCP_TOOL_NAMES = Object.freeze([
+  'explore',
+  'node',
+  'search',
+  'callers',
+]);
+
+export function normalizeMcpToolName(name: string): string {
+  return name.trim().toLowerCase().replace(/^codegraph_/, '');
+}
+
+export function parseMcpToolAllowlist(
+  raw: string | undefined,
+  allToolNames: Iterable<string>,
+): Set<string> | null {
+  if (!raw || !raw.trim()) return null;
+
+  const all = [...allToolNames].map(normalizeMcpToolName);
+  const out = new Set<string>();
+
+  for (const token of raw.split(',').map(normalizeMcpToolName).filter(Boolean)) {
+    if (token === 'default') {
+      DEFAULT_MCP_TOOL_NAMES.forEach((name) => out.add(name));
+    } else if (token === 'compact') {
+      COMPACT_MCP_TOOL_NAMES.forEach((name) => out.add(name));
+    } else if (token === 'core') {
+      CORE_MCP_TOOL_NAMES.forEach((name) => out.add(name));
+    } else if (token === 'full') {
+      all.forEach((name) => out.add(name));
+    } else {
+      out.add(token);
+    }
+  }
+
+  return out.size > 0 ? out : null;
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -29,6 +29,11 @@ import {
 import { clamp, validatePathWithinRoot, validateProjectPath, isConfigLeafNode, CONFIG_LEAF_LANGUAGES } from '../utils';
 import { isGeneratedFile } from '../extraction/generated-detection';
 import { scanDynamicDispatch } from './dynamic-boundaries';
+import {
+  DEFAULT_MCP_TOOL_NAMES,
+  normalizeMcpToolName,
+  parseMcpToolAllowlist,
+} from './tool-allowlist';
 
 /**
  * An expected, recoverable "codegraph can't serve this" condition — most
@@ -623,12 +628,8 @@ export const tools: ToolDefinition[] = [
  * note in a description only adds once `cg` is loaded; the schemas are static).
  */
 export function getStaticTools(): ToolDefinition[] {
-  const raw = process.env.CODEGRAPH_MCP_TOOLS;
-  if (!raw || !raw.trim()) {
-    return tools.filter(t => DEFAULT_MCP_TOOLS.has(t.name.replace(/^codegraph_/, '')));
-  }
-  const allow = new Set(raw.split(',').map(s => s.trim().replace(/^codegraph_/, '')).filter(Boolean));
-  return allow.size ? tools.filter(t => allow.has(t.name.replace(/^codegraph_/, ''))) : tools;
+  const allow = parseMcpToolAllowlist(process.env.CODEGRAPH_MCP_TOOLS, tools.map(t => t.name));
+  return tools.filter(t => (allow ?? DEFAULT_MCP_TOOLS).has(normalizeMcpToolName(t.name)));
 }
 
 /**
@@ -642,7 +643,7 @@ export function getStaticTools(): ToolDefinition[] {
  * status) remain fully functional — handlers stay, the library API and CLI are
  * untouched, and `CODEGRAPH_MCP_TOOLS=explore,node,...` re-enables any of them.
  */
-const DEFAULT_MCP_TOOLS = new Set(['explore']);
+const DEFAULT_MCP_TOOLS = new Set(DEFAULT_MCP_TOOL_NAMES);
 
 /**
  * Tool handler that executes tools against a CodeGraph instance
@@ -708,24 +709,21 @@ export class ToolHandler {
 
   /**
    * Optional allowlist of exposed tools, parsed from the CODEGRAPH_MCP_TOOLS
-   * env var (comma-separated short names, e.g. "trace,search,node,context").
-   * Unset/empty → every tool is exposed. Lets an operator (or an A/B harness)
-   * trim the tool surface without rebuilding the client config; the ablated
-   * tool is then truly absent from ListTools rather than merely denied on call.
+   * env var (comma-separated short names, e.g. "explore,search,node").
+   * Unset/empty → no execution guard; ListTools falls back to the default
+   * surface. Lets an operator (or an A/B harness) trim the tool surface without
+   * rebuilding the client config; the ablated tool is then truly absent from
+   * ListTools rather than merely denied on call.
    * Matching is on the short form, so "node" and "codegraph_node" both work.
    */
   private toolAllowlist(): Set<string> | null {
-    const raw = process.env.CODEGRAPH_MCP_TOOLS;
-    if (!raw || !raw.trim()) return null;
-    const short = (s: string) => s.trim().replace(/^codegraph_/, '');
-    const set = new Set(raw.split(',').map(short).filter(Boolean));
-    return set.size ? set : null;
+    return parseMcpToolAllowlist(process.env.CODEGRAPH_MCP_TOOLS, tools.map(t => t.name));
   }
 
   /** Whether a tool name passes the CODEGRAPH_MCP_TOOLS allowlist (if any). */
   private isToolAllowed(name: string): boolean {
     const allow = this.toolAllowlist();
-    return !allow || allow.has(name.replace(/^codegraph_/, ''));
+    return !allow || allow.has(normalizeMcpToolName(name));
   }
 
   /**
@@ -736,12 +734,11 @@ export class ToolHandler {
    */
   getTools(): ToolDefinition[] {
     const allow = this.toolAllowlist();
-    // No explicit allowlist → the default 4-tool surface (see
-    // DEFAULT_MCP_TOOLS for the evidence). An allowlist replaces the
-    // default entirely, so any defined tool can be re-enabled.
+    // No explicit allowlist → the single-tool default surface. An allowlist
+    // replaces the default entirely, so any defined tool can be re-enabled.
     let visible = allow
-      ? tools.filter(t => allow.has(t.name.replace(/^codegraph_/, '')))
-      : tools.filter(t => DEFAULT_MCP_TOOLS.has(t.name.replace(/^codegraph_/, '')));
+      ? tools.filter(t => allow.has(normalizeMcpToolName(t.name)))
+      : tools.filter(t => DEFAULT_MCP_TOOLS.has(normalizeMcpToolName(t.name)));
     if (!this.cg) return visible;
 
     try {


### PR DESCRIPTION
## Summary

- Add a shared `CODEGRAPH_MCP_TOOLS` parser so static `tools/list` and live `ToolHandler` use the same allowlist behavior.
- Add presets aligned with the current single-tool MCP default: `default` -> `explore`, `compact` -> `explore,node,search`, `core` -> `explore,node,search,callers`, and `full` -> every defined MCP tool.
- Document the presets in the README and MCP server reference while keeping comma-separated custom tool lists working.

Partially addresses #776.

## Testing

- `npx vitest run __tests__/mcp-tool-allowlist.test.ts`
- `npm exec tsc -- --noEmit`

## Notes

Rebased on current `main` after the default MCP surface moved to `codegraph_explore` only. The patch keeps that default intact; additional tools appear only when `CODEGRAPH_MCP_TOOLS` is set.

Tool descriptions stay untouched, so #775 remains a separate description-only PR.