### PR TITLE
docs(readme): point existing users to `codegraph upgrade` under the 1.0 banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ## 🎉 1.0 Released!
 
+Already installed? Run `codegraph upgrade` to update in place.
+
 Follow [@getcodegraph](https://x.com/getcodegraph) on X for updates.
 
 ### Supercharge Claude Code, Cursor, Codex, OpenCode, Hermes Agent, Gemini, Antigravity, and Kiro with Semantic Code Intelligence


### PR DESCRIPTION
Adds a one-line note directly under the **🎉 1.0 Released!** banner so existing users know how to get the new version:

> Already installed? Run `codegraph upgrade` to update in place.

Docs-only; no CHANGELOG entry (cosmetic README header note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
