### PR TITLE
chore(release): bump version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colbymchenry/codegraph",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Supercharge Claude Code with semantic code intelligence. 94% fewer tool calls • 77% faster exploration • 100% local.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps `package.json` to **1.0.1** to cut the next release.

This is the only edit the Release workflow needs — it will promote `[Unreleased]` → `[1.0.1]` in `CHANGELOG.md`, sync `package-lock.json`, build the per-platform bundles, create the GitHub Release, and publish the npm packages.

Release notes (from `[Unreleased]`): worktree-duplication fix (#848), `serve --mcp` no longer hangs for humans (#867), cross-file static-method resolution + `affected` path normalization (#825), plus the already-staged `codegraph daemon`/`version` commands and the MCP self-heal watchdog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
