### PR TITLE
docs: correct Node engines floor to >=20.0.0 in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ npx vitest run __tests__/extraction.test.ts -t "TypeScript"
 
 `copy-assets` (called from `build`) copies `src/db/schema.sql` and all `src/extraction/wasm/*.wasm` files into `dist/`. **Any new SQL or grammar wasm must be copied or it won't ship.**
 
-Node engines: `>=18.0.0 <25.0.0`. There is a hard exit on Node 25.x (see `src/bin/node-version-check.ts`).
+Node engines: `>=20.0.0 <25.0.0`. There is a hard exit on Node 25.x (see `src/bin/node-version-check.ts`).
 
 ## Architecture
 


### PR DESCRIPTION
## What

CLAUDE.md '## Build, Test, Run' section says:

> Node engines: `>=18.0.0 <25.0.0`.

The actual supported floor is **Node 20**, not 18. This one-line doc fix aligns it with the code.

## Why

Three sources of truth all say 20, only this doc line says 18:

- **package.json** — `"engines": { "node": ">=20.0.0 <25.0.0" }`
- **src/bin/node-version-check.ts** — `export const MIN_NODE_MAJOR = 20;`, hard-enforced at CLI bootstrap (not just an npm warning). Its own JSDoc: *"Lowest supported Node.js major version. Matches the `engines` floor in package.json."*
- **buildNodeTooOldBanner** — the banner shown below the floor reads *"CodeGraph requires Node.js 20 or newer."*

So the CLI hard-exits on Node 18, but the LLM-readable architecture doc tells agents 18 is fine. Diff:

```diff
-Node engines: `>=18.0.0 <25.0.0`. There is a hard exit on Node 25.x (see `src/bin/node-version-check.ts`).
+Node engines: `>=20.0.0 <25.0.0`. There is a hard exit on Node 25.x (see `src/bin/node-version-check.ts`).
```

Docs-only, no code change.