### PR TITLE
ci: standardize actions/checkout to v6 in deploy-site workflow

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build with Astro
         uses: withastro/action@v3
         with:


### PR DESCRIPTION
## What

Bump `actions/checkout@v4` → `@v6` in `.github/workflows/deploy-site.yml`.

## Why

The repo runs two different major versions of the same action across its two workflows:

- `.github/workflows/release.yml` → `actions/checkout@v6` (and `actions/setup-node@v6`)
- `.github/workflows/deploy-site.yml` → `actions/checkout@v4`

Aligning both on `checkout@v6` keeps the CI consistent and on the current major.

```diff
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
```

**Scope:** only `actions/checkout` is bumped. `actions/deploy-pages@v4` and `withastro/action@v3` are independent action version lines and are intentionally left untouched.