### PR TITLE
fix(resolution): reject wildcard alias when prefix and suffix overlap

### DIFF
--- a/__tests__/resolution.test.ts
+++ b/__tests__/resolution.test.ts
@@ -1359,6 +1359,50 @@ func main() {
       expect(legacyCallers.some((c) => c.node.filePath === 'src/main.ts')).toBe(false);
     });
 
+    it('does not match a wildcard alias when the import has no segment for `*` (prefix/suffix overlap)', async () => {
+      // Pattern `@x/*/index` -> prefix `@x/`, suffix `/index`. An import of
+      // `@x/index` has nothing in the `*` slot, so it must NOT resolve via
+      // this alias. Previously startsWith(prefix) && endsWith(suffix) both
+      // passed for the single shared `/`, producing a bogus mapped target.
+      fs.mkdirSync(path.join(tempDir, 'src/widgets/button'), { recursive: true });
+      // The file the BOGUS rewrite would point at (`widgets/index`). If the
+      // alias wrongly matches `@x/index`, the call would attach here.
+      fs.writeFileSync(
+        path.join(tempDir, 'src/widgets/index.ts'),
+        `export function trap(): number { return 0; }\n`
+      );
+      // A real relative-resolvable target for the bare import.
+      fs.writeFileSync(
+        path.join(tempDir, 'src/index.ts'),
+        `export function trap(): number { return 1; }\n`
+      );
+      fs.writeFileSync(
+        path.join(tempDir, 'src/main.ts'),
+        `import { trap } from '@x/index';\nexport function go(): number { return trap(); }\n`
+      );
+      fs.writeFileSync(
+        path.join(tempDir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: './src',
+            paths: { '@x/*/index': ['widgets/*/index'] },
+          },
+        })
+      );
+
+      cg = await CodeGraph.init(tempDir, { index: true });
+      cg.resolveReferences();
+
+      // The widgets/index.ts `trap` must NOT receive a caller from main.ts
+      // via the overlapping-alias false match.
+      const widgetsTrap = cg
+        .getNodesByKind('function')
+        .find((n) => n.name === 'trap' && n.filePath === 'src/widgets/index.ts');
+      expect(widgetsTrap).toBeDefined();
+      const bogusCallers = cg.getCallers(widgetsTrap!.id);
+      expect(bogusCallers.some((c) => c.node.filePath === 'src/main.ts')).toBe(false);
+    });
+
     it('falls back gracefully when tsconfig is absent', async () => {
       fs.mkdirSync(path.join(tempDir, 'src'), { recursive: true });
       fs.writeFileSync(

--- a/src/resolution/path-aliases.ts
+++ b/src/resolution/path-aliases.ts
@@ -219,6 +219,14 @@ export function applyAliases(
 
     let captured = '';
     if (pat.hasWildcard) {
+      // The prefix and suffix must occupy DISJOINT regions of the import
+      // path. When they overlap (the import is shorter than prefix+suffix),
+      // `startsWith` and `endsWith` can both be satisfied by the same
+      // characters — e.g. pattern `src/*/index` (prefix `src/`, suffix
+      // `/index`) would otherwise falsely match `src/index`, whose single
+      // `/` is counted as both the prefix's and the suffix's slash. Such an
+      // import has no wildcard segment, so it must not match.
+      if (importPath.length < pat.prefix.length + pat.suffix.length) continue;
       captured = importPath.slice(pat.prefix.length, importPath.length - pat.suffix.length);
     } else if (importPath !== pat.prefix) {
       // Literal pattern must match exactly.


### PR DESCRIPTION
## What

`applyAliases` in `src/resolution/path-aliases.ts` matched a tsconfig `paths` wildcard pattern against imports where the pattern's prefix and suffix overlap.

For a pattern like `@x/*/index` (prefix `@x/`, suffix `/index`), an import of `@x/index` — which has **nothing** in the `*` slot — was wrongly accepted, because `startsWith(prefix)` and `endsWith(suffix)` can both be satisfied by the same shared `/`. The captured wildcard came out empty and the import resolved to a bogus mapped file, so call/reference edges were attached to the wrong symbol.

## Why

```
prefix = '@x/'    (len 3)
suffix = '/index' (len 6)
import = '@x/index' (len 8)   // 8 < 3 + 6  → no room for the wildcard
```

`@x/index`.startsWith('@x/') ✓ and `@x/index`.endsWith('/index') ✓, but the two regions overlap on the single `/`. TypeScript requires the `*` to match at least one character, so this import must **not** resolve through the alias.

Before the fix, `applyAliases('@x/index', …)` returned `['widgets/index']` (with `captured === ''`), silently mis-resolving the import.

## Fix

Guard the wildcard branch so prefix and suffix must occupy disjoint regions before a match is accepted:

```ts
if (importPath.length < pat.prefix.length + pat.suffix.length) continue;
```

Literal (non-wildcard) patterns are unaffected — they already require an exact match.

## Test

Adds a regression test in the existing `tsconfig path aliases` describe block (`__tests__/resolution.test.ts`). It indexes a project with `paths: { '@x/*/index': ['widgets/*/index'] }` and a bare `import { trap } from '@x/index'`, then asserts the `widgets/index.ts` symbol does **not** receive a caller via the false match. Verified the test fails on `main` and passes with this fix; `npm run build` is clean.