### PR TITLE
docs: clarify the installer already inits the current project (#826)

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,10 @@ Restart your agent (Claude Code / Cursor / Codex CLI / opencode / Hermes Agent /
 
 ### 3. Initialize Projects
 
+The interactive installer in step 1 already initializes **the project you ran it in** (it runs `codegraph init` for you on a local install — see "Initialize your current project" above). For that project you can skip straight to step 2.
+
+To index **other** projects, run `codegraph init` in each one:
+
 ```bash
 cd your-project
 codegraph init


### PR DESCRIPTION
Fixes #826.

## What

The **Quick Start** lists `codegraph init` as step 3 as if it were always required after install. This clarifies that the interactive installer already initializes the project it is run in, so step 3 only applies to *other* projects.

## Why

Step 1 of the same Quick Start already documents that the installer will:

> - Initialize your current project (local installs only)

This is real — `src/installer/index.ts` runs `initializeLocalProject()` on a local install, which calls `CodeGraph.init()` + `indexAll()`:

```
// Step 6: for local install, initialize the project.
await initializeLocalProject(clack, useDefaults);
```

So a user who follows the steps literally runs `codegraph init` (step 3) in the **same** project the installer just initialized, and gets:

```
Already initialized in /path/to/project
Use "codegraph index" to re-index or "codegraph sync" to update
```

That is exactly what the reporter hit in #826. This is a docs-only clarification:

```diff
 ### 3. Initialize Projects
+
+The interactive installer in step 1 already initializes **the project you ran it in**
+(it runs `codegraph init` for you on a local install ...). For that project you can
+skip straight to step 2.
+
+To index **other** projects, run `codegraph init` in each one:

 cd your-project
 codegraph init
```

No code change.