### PR TITLE
feat(mcp/cli): add codegraph_check for circular import detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### New Features
+
+- New `codegraph check` command detects circular file-import cycles in an indexed project and prints each cycle's file paths, exiting non-zero when any are found — so it drops straight into a git pre-commit hook and catches import cycles before they break a build instead of after. The same detection is also available to an AI agent as `codegraph_check`, or enable it in an agent's tool list with `CODEGRAPH_MCP_TOOLS=check`.
+
 
 ## [1.0.1] - 2026-06-13
 

--- a/__tests__/cli-check.test.ts
+++ b/__tests__/cli-check.test.ts
@@ -1,0 +1,87 @@
+/**
+ * `codegraph check` — CLI subcommand that prints file-level circular import
+ * cycles and exits non-zero when any are found (so it works as a git
+ * pre-commit hook: `codegraph check || exit 1`).
+ *
+ * Indexing is done via the library (CodeGraph.initSync + indexAll), matching
+ * the proven cli-affected-paths.test.ts pattern — avoids interactive prompts
+ * and daemon spawning. The command under test is invoked end-to-end against
+ * the built binary in dist/.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CodeGraph } from '../src';
+
+const BIN = path.resolve(__dirname, '../dist/bin/codegraph.js');
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(cwd: string): RunResult {
+  try {
+    const stdout = execFileSync(process.execPath, [BIN, 'check', cwd], {
+      encoding: 'utf8',
+      env: { ...process.env, CODEGRAPH_NO_DAEMON: '1', CODEGRAPH_WASM_RELAUNCHED: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; status?: number };
+    return { code: err.status ?? 1, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+  }
+}
+
+/** Index a temp project from a map of rel-path -> file content, then close. */
+async function indexProject(dir: string, files: Record<string, string>): Promise<void> {
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+  const cg = CodeGraph.initSync(dir);
+  await cg.indexAll();
+  cg.close();
+}
+
+describe('codegraph check (CLI)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-cli-check-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('exits 0 and reports no cycles on an acyclic project', async () => {
+    await indexProject(dir, {
+      'src/c.ts': "import { d } from './d';\nexport function c() { return d(); }\n",
+      'src/d.ts': "export function d() { return 42; }\n",
+    });
+
+    const res = run(dir);
+    expect(res.code).toBe(0);
+    expect(res.stdout.toLowerCase()).toContain('no circular');
+  });
+
+  it('exits non-zero and names both files when a cycle exists', async () => {
+    await indexProject(dir, {
+      'src/a.ts': "import { b } from './b';\nexport function a() { return b(); }\n",
+      'src/b.ts': "import { a } from './a';\nexport function b() { return a(); }\n",
+    });
+
+    const res = run(dir);
+    // Cycle present → non-zero exit (git-hook ready).
+    expect(res.code).not.toBe(0);
+    // Output names both members of the cycle (asserted on stdout content so
+    // this fails for the right reason pre-implementation, not just exit code).
+    expect(res.stdout).toContain('src/a.ts');
+    expect(res.stdout).toContain('src/b.ts');
+  });
+});

--- a/__tests__/mcp-check-circular-imports.test.ts
+++ b/__tests__/mcp-check-circular-imports.test.ts
@@ -1,0 +1,61 @@
+/**
+ * codegraph_check — surfaces file-level circular import cycles via the MCP
+ * tool surface. Backed by the existing (previously dead-code)
+ * CodeGraph.findCircularDependencies() DFS detector.
+ *
+ * Scope of this suite: the MCP wiring (tool def + dispatch + handler +
+ * formatting). The underlying algorithm is already covered elsewhere; we
+ * treat it as a black box and assert on the formatted tool output.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import CodeGraph from '../src/index';
+import { ToolHandler } from '../src/mcp/tools';
+
+describe('codegraph_check (circular import detection)', () => {
+  let dir: string;
+  let cg: CodeGraph;
+  let h: ToolHandler;
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-check-'));
+    cg = null as unknown as CodeGraph;
+    h = null as unknown as ToolHandler;
+  });
+
+  afterEach(() => {
+    if (cg) try { cg.close(); } catch { /* already closed */ }
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** Build a two-file import cycle a.ts <-> b.ts, index, and arm the handler. */
+  async function withCycle(): Promise<void> {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(
+      path.join(dir, 'src', 'a.ts'),
+      "import { b } from './b';\nexport function a() { return b(); }\n",
+    );
+    fs.writeFileSync(
+      path.join(dir, 'src', 'b.ts'),
+      "import { a } from './a';\nexport function b() { return a(); }\n",
+    );
+    cg = CodeGraph.initSync(dir, { config: { include: ['**/*.ts'], exclude: [] } });
+    await cg.indexAll();
+    h = new ToolHandler(cg);
+  }
+
+  const text = async (args: Record<string, unknown>): Promise<string> =>
+    (await h.execute('codegraph_check', args)).content.map((c) => (c as { text: string }).text).join('\n');
+
+  it('detects a two-file import cycle and names both files in the output', async () => {
+    await withCycle();
+    const out = await text({});
+
+    expect(out).toMatch(/circular/i);                    // header mentions "circular"
+    expect(out).toContain('src/a.ts');                   // both cycle members named
+    expect(out).toContain('src/b.ts');
+    expect(out).toMatch(/(1 cycle|cycles?:\s*1)/i);      // cycle count present
+  });
+});

--- a/__tests__/mcp-check-circular-imports.test.ts
+++ b/__tests__/mcp-check-circular-imports.test.ts
@@ -58,4 +58,54 @@ describe('codegraph_check (circular import detection)', () => {
     expect(out).toContain('src/b.ts');
     expect(out).toMatch(/(1 cycle|cycles?:\s*1)/i);      // cycle count present
   });
+
+  /** Build an acyclic two-file graph: c.ts imports d.ts, d.ts imports nothing. */
+  async function withoutCycle(): Promise<void> {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(
+      path.join(dir, 'src', 'c.ts'),
+      "import { d } from './d';\nexport function c() { return d(); }\n",
+    );
+    fs.writeFileSync(
+      path.join(dir, 'src', 'd.ts'),
+      "export function d() { return 42; }\n",
+    );
+    cg = CodeGraph.initSync(dir, { config: { include: ['**/*.ts'], exclude: [] } });
+    await cg.indexAll();
+    h = new ToolHandler(cg);
+  }
+
+  it('reports a clean success message (not an error) when there are no cycles', async () => {
+    await withoutCycle();
+    const result = await h.execute('codegraph_check', {});
+    expect(result.isError).toBeFalsy();                 // happy path, never isError
+    const out = result.content.map((c) => (c as { text: string }).text).join('\n');
+    expect(out.toLowerCase()).toContain('no circular');
+  });
+
+  it('reports each cycle separately when more than one exists', async () => {
+    // Two independent cycles: x<->y in src/, and p<->q in other/.
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.mkdirSync(path.join(dir, 'other'));
+    fs.writeFileSync(path.join(dir, 'src', 'x.ts'),
+      "import { y } from './y';\nexport function x() { return y(); }\n");
+    fs.writeFileSync(path.join(dir, 'src', 'y.ts'),
+      "import { x } from './x';\nexport function y() { return x(); }\n");
+    fs.writeFileSync(path.join(dir, 'other', 'p.ts'),
+      "import { q } from './q';\nexport function p() { return q(); }\n");
+    fs.writeFileSync(path.join(dir, 'other', 'q.ts'),
+      "import { p } from './p';\nexport function q() { return p(); }\n");
+    cg = CodeGraph.initSync(dir, { config: { include: ['**/*.ts'], exclude: [] } });
+    await cg.indexAll();
+    h = new ToolHandler(cg);
+
+    const out = await text({});
+    expect(out).toMatch(/2 cycles/i);
+    expect(out).toMatch(/Cycle 1/);
+    expect(out).toMatch(/Cycle 2/);
+    // All four files appear somewhere in the output.
+    for (const f of ['src/x.ts', 'src/y.ts', 'other/p.ts', 'other/q.ts']) {
+      expect(out).toContain(f);
+    }
+  });
 });

--- a/__tests__/mcp-check-circular-imports.test.ts
+++ b/__tests__/mcp-check-circular-imports.test.ts
@@ -108,4 +108,16 @@ describe('codegraph_check (circular import detection)', () => {
       expect(out).toContain(f);
     }
   });
+
+  it('is callable directly but NOT listed in the default tool surface', async () => {
+    await withoutCycle();
+    const result = await h.execute('codegraph_check', {});
+    expect(result.isError).toBeFalsy();                       // callable
+
+    // Default surface (no cg armed): the 4-tool trim. codegraph_check is
+    // intentionally absent here — agents won't see it in tools/list unless
+    // CODEGRAPH_MCP_TOOLS re-enables it.
+    const unlisted = new ToolHandler(null).getTools().map((t) => t.name);
+    expect(unlisted).not.toContain('codegraph_check');
+  });
 });

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -1858,6 +1858,74 @@ program
   });
 
 /**
+ * codegraph check [path]
+ *
+ * Detect circular file-import cycles in an indexed project. Prints each cycle
+ * as an ordered list of file paths. Exits non-zero if any cycle is found, so
+ * the command drops into a git pre-commit hook directly:
+ *
+ *   # .git/hooks/pre-commit
+ *   codegraph check || exit 1
+ *
+ * Backed by CodeGraph.findCircularDependencies() (the same DFS detector the
+ * codegraph_check MCP tool surfaces).
+ */
+program
+  .command('check [path]')
+  .description('Detect circular file-import cycles (exits non-zero if any found)')
+  .option('-j, --json', 'Output as JSON')
+  .action(async (pathArg: string | undefined, options: { json?: boolean }) => {
+    const projectPath = resolveProjectPath(pathArg);
+
+    try {
+      if (!isInitialized(projectPath)) {
+        warn('Not initialized');
+        info('Run "codegraph init" first');
+        process.exitCode = 1;
+        return;
+      }
+
+      const { default: CodeGraph } = await loadCodeGraph();
+      const cg = await CodeGraph.open(projectPath);
+      try {
+        // Deterministic ordering (sort by first path) — same contract as the
+        // MCP handler, so CLI and MCP output stay consistent.
+        const cycles = [...cg.findCircularDependencies()].sort((x, y) => {
+          const a = x[0] ?? '';
+          const b = y[0] ?? '';
+          return a < b ? -1 : a > b ? 1 : 0;
+        });
+
+        if (options.json) {
+          console.log(JSON.stringify({
+            projectPath,
+            cycleCount: cycles.length,
+            cycles,
+          }));
+        } else if (cycles.length === 0) {
+          console.log(chalk.green('No circular imports found.'));
+        } else {
+          console.log(chalk.bold(`\nCircular Imports — ${cycles.length} cycle${cycles.length === 1 ? '' : 's'} found\n`));
+          cycles.forEach((cycle, i) => {
+            console.log(chalk.cyan(`Cycle ${i + 1} (${cycle.length} files):`));
+            for (const p of cycle) console.log(`  ${p}`);
+            if (cycle.length > 1) console.log(`  ↳ ${cycle[0]} (back to start)`);
+            console.log();
+          });
+        }
+
+        // Non-zero exit on cycles so this works as a git pre-commit gate.
+        if (cycles.length > 0) process.exitCode = 1;
+      } finally {
+        cg.destroy();
+      }
+    } catch (err) {
+      error(`Check failed: ${err instanceof Error ? err.message : String(err)}`);
+      process.exitCode = 1;
+    }
+  });
+
+/**
  * codegraph install
  */
 program

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -597,6 +597,17 @@ export const tools: ToolDefinition[] = [
       },
     },
   },
+  {
+    name: 'codegraph_check',
+    description:
+      'Detect circular file-import cycles in the indexed project. Returns the cycle count and each cycle as an ordered list of file paths. Use before a refactor or commit to catch import cycles that break builds; a clean result is a success, not an error.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: projectPathProperty,
+      },
+    },
+  },
 ];
 
 /**
@@ -1120,6 +1131,8 @@ export class ToolHandler {
           return await this.handleStatus(args);
         case 'codegraph_files':
           result = await this.handleFiles(args); break;
+        case 'codegraph_check':
+          result = await this.handleCheck(args); break;
         default:
           return this.errorResult(`Unknown tool: ${toolName}`);
       }
@@ -3251,6 +3264,52 @@ export class ToolHandler {
       lines.push(`**Called by ←** ${callers.slice(0, TRAIL_CAP).map(fmt).join(', ')}${callers.length > TRAIL_CAP ? `, +${callers.length - TRAIL_CAP} more` : ''}`);
     }
     return lines.join('\n');
+  }
+
+  /**
+   * Handle codegraph_check — surface file-level circular import cycles.
+   *
+   * Backed by CodeGraph.findCircularDependencies() (src/graph/queries.ts),
+   * which runs a DFS over file-level `imports` edges with white/gray/black
+   * coloring. The algorithm is unchanged here; this method only formats its
+   * string[][] result for the MCP surface.
+   *
+   * Output contract:
+   *  - No cycles  → SUCCESS textResult ("No circular imports found"), never
+   *    an error (per "Errors teach abandonment" — a clean graph is happy path).
+   *  - N > 0      → header with cycle count, then one numbered section per
+   *    cycle listing its file paths in DFS order. Cycles are sorted by first
+   *    path for deterministic output; the underlying result set is unchanged.
+   */
+  private async handleCheck(args: Record<string, unknown>): Promise<ToolResult> {
+    const cg = this.getCodeGraph(args.projectPath as string | undefined);
+    const rawCycles = cg.findCircularDependencies();
+
+    if (rawCycles.length === 0) {
+      return this.textResult('No circular imports found.');
+    }
+
+    // Deterministic ordering for stable tests + readable output. Sort by the
+    // first path in each cycle; the DFS result set itself is unchanged.
+    const cycles = [...rawCycles].sort((x, y) => {
+      const a = x[0] ?? '';
+      const b = y[0] ?? '';
+      return a < b ? -1 : a > b ? 1 : 0;
+    });
+
+    const lines: string[] = [
+      `## Circular Imports — ${cycles.length} cycle${cycles.length === 1 ? '' : 's'} found`,
+      '',
+    ];
+    cycles.forEach((cycle, i) => {
+      lines.push(`### Cycle ${i + 1} (${cycle.length} files)`);
+      for (const p of cycle) lines.push(`- ${p}`);
+      // Close the loop visually: last file imports the first.
+      if (cycle.length > 1) lines.push(`- ↳ ${cycle[0]} (back to start)`);
+      lines.push('');
+    });
+
+    return this.textResult(this.truncateOutput(lines.join('\n').trim()));
   }
 
   /**


### PR DESCRIPTION
## Summary

Surfaces the existing `findCircularDependencies()` DFS detector (`src/graph/queries.ts:225`) on two channels:

- **MCP tool** (`codegraph_check`) — callable by AI agents, ships functional but NOT in `DEFAULT_MCP_TOOLS` (deliberate surface-trim per CLAUDE.md eval evidence)
- **CLI subcommand** (`codegraph check [path]`) — deterministic, git-hook ready (exits non-zero on cycles)

Closes #888

## What Changed

**5 files, 341 insertions, 0 deletions:**

- `src/mcp/tools.ts` — tool def (~line 600) + dispatch case (~line 1123) + `handleCheck` handler (~line 3256)
- `src/bin/codegraph.ts` — `codegraph check [path]` subcommand (~line 1859), `process.exitCode = 1` on cycles
- `__tests__/mcp-check-circular-imports.test.ts` (new) — 4 MCP tests
- `__tests__/cli-check.test.ts` (new) — 2 CLI tests
- `CHANGELOG.md` — `[Unreleased]` entry

## Why

The DFS detector at `src/graph/queries.ts:225` was fully implemented with zero callers — dead code. Circular imports cause build failures, slow bundlers, and create maintenance traps. This PR completes the feature by wiring the existing algorithm to both agent and developer workflows.

The CLI channel is the primary path (deterministic, user-invoked). The MCP channel is correctly low-salience — `DEFAULT_MCP_TOOLS` remains unchanged per CLAUDE.md's evidence that agents under-pick new tools.

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| `codegraph_check` NOT in `DEFAULT_MCP_TOOLS` | CLAUDE.md eval evidence: agents under-pick new tools; adding unproven tools dilutes selection |
| CLI exits non-zero on cycles | Git-hook ready (`codegraph check \|\| exit 1`); `--json` flag available for scripts |
| Both channels sort deterministically | Byte-stable output across runs; identical comparator in MCP handler + CLI action |
| CLI indexes via library API | Avoids interactive prompts from `codegraph init --index`; sets `CODEGRAPH_NO_DAEMON=1` |

## Verification

```
✓ tsc --noEmit → exit 0
✓ npm run build → dist verified (tools.js has codegraph_check, bin has check cmd)
✓ 6/6 new tests pass (4 MCP + 2 CLI)
✓ 46/46 MCP-dispatch tests pass (no regression)
✓ Full suite: 15 pre-existing Windows failures only (all in untouched modules, CLAUDE.md-documented)
```

## Test Coverage

| Test | Asserts |
|------|---------|
| MCP: cycle detection | Detects a two-file import cycle and names both files in output |
| MCP: no cycles | Reports clean success message (not an error) when there are no cycles |
| MCP: multi-cycle | Reports each cycle separately when more than one exists |
| MCP: surface trim | Is callable directly but NOT listed in the default tool surface |
| CLI: acyclic | Exits 0 and reports no cycles on an acyclic project |
| CLI: cyclic | Exits non-zero and names both files when a cycle exists |

## Migration

None. `codegraph_check` is a new MCP tool (additive). `codegraph check` is a new CLI subcommand (additive). No schema changes. No breaking changes.

To enable `codegraph_check` for agents, add `check` to `CODEGRAPH_MCP_TOOLS` env var. To run as a git hook: `codegraph check || exit 1` in `.git/hooks/pre-commit`.
