### PR TITLE
Add shared Docker server and MCP discovery

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.claude
+.cursor
+node_modules
+dist
+coverage
+.codegraph
+.codegraph-*
+.codegraph-server
+site/node_modules
+telemetry-worker/node_modules
+npm-debug.log*
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:22-bookworm-slim AS build
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build && npm prune --omit=dev
+
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+ENV NODE_ENV=production \
+    CODEGRAPH_SERVER_HOST=0.0.0.0 \
+    CODEGRAPH_SERVER_PORT=3000 \
+    CODEGRAPH_SERVER_DATA_DIR=/data \
+    CODEGRAPH_PROJECTS_DIR=/projects
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git openssh-client ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /app/package*.json ./
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+
+RUN mkdir -p /data /projects
+
+EXPOSE 3000
+VOLUME ["/data", "/projects"]
+
+CMD ["node", "dist/bin/codegraph.js", "server", "--host", "0.0.0.0", "--port", "3000"]

--- a/README.md
+++ b/README.md
@@ -109,6 +109,33 @@ codegraph uninstall
 
 ---
 
+## Shared Docker Server
+
+CodeGraph can also run as a shared HTTP service for teams that want to index
+server-side checkouts and expose registry-bound MCP endpoints to developers.
+
+```bash
+docker compose up --build
+```
+
+The container serves a management UI on port `3000`, persists its project
+registry under `/data`, and only accepts project paths or managed Git checkouts
+under `/projects`. Add mounted paths, GitLab/GitHub/generic Git remotes,
+optional branch/credential env-var config, and per-project scheduled syncs from
+the UI. Git credentials are read from environment variables or mounted SSH
+config; token values are not stored by the UI registry.
+Registered projects get MCP endpoints like:
+
+```text
+http://HOST:3000/mcp/PROJECT_ID
+```
+
+Set `CODEGRAPH_ADMIN_TOKEN` and `CODEGRAPH_MCP_TOKEN` before exposing the port
+outside a trusted development network. See `docs/docker-server.md` for the full
+server-mode guide.
+
+---
+
 ## Why CodeGraph?
 
 When Claude Code explores a codebase, it spawns **Explore agents** that scan files with grep, glob, and Read — consuming tokens on every tool call.

--- a/__tests__/mcp-tool-allowlist.test.ts
+++ b/__tests__/mcp-tool-allowlist.test.ts
@@ -17,17 +17,19 @@ describe('CODEGRAPH_MCP_TOOLS allowlist', () => {
 
   const listed = () => new ToolHandler(null).getTools().map(t => t.name).sort();
 
-  it('exposes the default 4-tool surface when unset', () => {
+  it('exposes the default 5-tool surface when unset', () => {
     delete process.env[ENV];
     // The default set (see DEFAULT_MCP_TOOLS): explore + node are the
     // validated workhorses, search the cheap lookup, callers the one
-    // irreplaceable enumerator. callees/impact/files/status stay defined
-    // and executable but unlisted — impact appeared in ZERO recorded runs.
+    // irreplaceable enumerator, and status gives shared servers a cheap
+    // freshness/health check. callees/impact/files stay defined and
+    // executable but unlisted — impact appeared in ZERO recorded runs.
     expect(listed()).toEqual([
       'codegraph_callers',
       'codegraph_explore',
       'codegraph_node',
       'codegraph_search',
+      'codegraph_status',
     ]);
   });
 
@@ -48,7 +50,7 @@ describe('CODEGRAPH_MCP_TOOLS allowlist', () => {
 
   it('treats an empty/whitespace value as unset (default surface)', () => {
     process.env[ENV] = '   ';
-    expect(listed()).toHaveLength(4);
+    expect(listed()).toHaveLength(5);
     expect(listed()).toContain('codegraph_explore');
   });
 

--- a/__tests__/server-mcp-http.test.ts
+++ b/__tests__/server-mcp-http.test.ts
@@ -1,0 +1,104 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { RemoteMcpManager } from '../src/server/mcp-http';
+import { ProjectRegistry } from '../src/server/registry';
+import { ProjectService } from '../src/server/service';
+
+let tmpRoot: string;
+let projectsRoot: string;
+let dataDir: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-server-mcp-'));
+  projectsRoot = path.join(tmpRoot, 'projects');
+  dataDir = path.join(tmpRoot, 'data');
+  fs.mkdirSync(projectsRoot, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('RemoteMcpManager server tools', () => {
+  it('lists project discovery and status tools for an unindexed project endpoint', async () => {
+    const repo = path.join(projectsRoot, 'service-a');
+    fs.mkdirSync(repo);
+    const registry = new ProjectRegistry({ dataDir, projectsRoot });
+    const project = registry.add({ path: repo, name: 'Service A' });
+    const service = new ProjectService(registry);
+    const mcp = new RemoteMcpManager(registry, service, { watch: false });
+
+    const response = await mcp.handle(project.id, rpc(1, 'tools/list'));
+    const names = ((response as any).result.tools as Array<{ name: string }>).map((tool) => tool.name).sort();
+
+    expect(names).toContain('codegraph_projects');
+    expect(names).toContain('codegraph_status');
+    expect(names).not.toContain('codegraph_search');
+  });
+
+  it('lists project discovery at the server endpoint even when no default project exists', async () => {
+    const registry = new ProjectRegistry({ dataDir, projectsRoot });
+    const service = new ProjectService(registry);
+    const mcp = new RemoteMcpManager(registry, service, { watch: false });
+
+    const response = await mcp.handle(null, rpc(1, 'tools/list'));
+    const names = ((response as any).result.tools as Array<{ name: string }>).map((tool) => tool.name);
+
+    expect(names).toEqual(['codegraph_projects']);
+  });
+
+  it('returns sanitized project discovery metadata', async () => {
+    const registry = new ProjectRegistry({ dataDir, projectsRoot });
+    const project = registry.add({
+      sourceType: 'git',
+      name: 'CRM',
+      provider: 'gitlab',
+      remoteUrl: 'https://gitlab.internal/apps/crm.git',
+      branch: 'main',
+      credentialEnv: 'GITLAB_TOKEN',
+      scheduleEnabled: true,
+      scheduleIntervalMinutes: 30,
+    });
+    const service = new ProjectService(registry);
+    const mcp = new RemoteMcpManager(registry, service, { watch: false });
+
+    const response = await mcp.handle(project.id, rpc(1, 'tools/call', {
+      name: 'codegraph_projects',
+      arguments: { query: 'crm' },
+    }));
+    const text = (response as any).result.content[0].text as string;
+    const payload = JSON.parse(text);
+
+    expect(payload.count).toBe(1);
+    expect(payload.projects[0]).toMatchObject({
+      id: project.id,
+      name: 'CRM',
+      projectPathRef: project.id,
+      mcpPath: `/mcp/${encodeURIComponent(project.id)}`,
+      source: {
+        type: 'git',
+        provider: 'gitlab',
+        remoteUrl: 'https://gitlab.internal/apps/crm.git',
+        branch: 'main',
+      },
+      status: {
+        initialized: false,
+        exists: false,
+      },
+      syncSchedule: {
+        enabled: true,
+        intervalMinutes: 30,
+      },
+    });
+    expect(payload.projects[0]).not.toHaveProperty('path');
+    expect(payload.projects[0].source).not.toHaveProperty('credentialEnv');
+  });
+});
+
+function rpc(id: number, method: string, params?: unknown): Record<string, unknown> {
+  return params === undefined
+    ? { jsonrpc: '2.0', id, method }
+    : { jsonrpc: '2.0', id, method, params };
+}

--- a/__tests__/server-registry.test.ts
+++ b/__tests__/server-registry.test.ts
@@ -1,0 +1,160 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ProjectRegistry } from '../src/server/registry';
+
+let tmpRoot: string;
+let projectsRoot: string;
+let dataDir: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-server-registry-'));
+  projectsRoot = path.join(tmpRoot, 'projects');
+  dataDir = path.join(tmpRoot, 'data');
+  fs.mkdirSync(projectsRoot, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('ProjectRegistry', () => {
+  it('adds projects under the configured projects root', () => {
+    const repo = path.join(projectsRoot, 'service-a');
+    fs.mkdirSync(repo);
+    const registry = new ProjectRegistry({ dataDir, projectsRoot });
+
+    const project = registry.add({ path: 'service-a', name: 'Service A' });
+
+    expect(project.name).toBe('Service A');
+    expect(project.path).toBe(fs.realpathSync(repo));
+    expect(project.source).toEqual({ type: 'path' });
+    expect(project.isDefault).toBe(true);
+    expect(registry.list()).toHaveLength(1);
+    expect(registry.getDefault()?.id).toBe(project.id);
+  });
+
+  it('rejects projects outside the configured projects root', () => {
+    const outside = path.join(tmpRoot, 'outside');
+    fs.mkdirSync(outside);
+    const registry = new ProjectRegistry({ dataDir, projectsRoot });
+
+    expect(() => registry.add({ path: outside, name: 'Outside' }))
+      .toThrow(/must be inside/);
+  });
+
+  it('resolves project references by id, name, and registered path', () => {
+    const repo = path.join(projectsRoot, 'service-b');
+    fs.mkdirSync(repo);
+    const registry = new ProjectRegistry({ dataDir, projectsRoot });
+    const project = registry.add({ path: repo, name: 'Service B' });
+
+    expect(registry.resolveProjectRef(project.id)?.id).toBe(project.id);
+    expect(registry.resolveProjectRef('Service B')?.id).toBe(project.id);
+    expect(registry.resolveProjectRef(repo)?.id).toBe(project.id);
+  });
+
+  it('persists projects across registry instances', () => {
+    const repo = path.join(projectsRoot, 'service-c');
+    fs.mkdirSync(repo);
+    const registry = new ProjectRegistry({ dataDir, projectsRoot });
+    const project = registry.add({ path: repo, name: 'Service C' });
+
+    const reloaded = new ProjectRegistry({ dataDir, projectsRoot });
+
+    expect(reloaded.get(project.id)?.path).toBe(project.path);
+  });
+
+  it('adds git projects with a managed checkout path and schedule', () => {
+    const registry = new ProjectRegistry({ dataDir, projectsRoot });
+
+    const project = registry.add({
+      sourceType: 'git',
+      name: 'Internal API',
+      provider: 'gitlab',
+      remoteUrl: 'git@gitlab.internal:platform/api.git',
+      branch: 'main',
+      credentialEnv: 'GITLAB_TOKEN',
+      scheduleEnabled: true,
+      scheduleIntervalMinutes: 30,
+    });
+
+    expect(project.path).toContain(path.join(projectsRoot, '_repos'));
+    expect(project.source).toEqual({
+      type: 'git',
+      provider: 'gitlab',
+      remoteUrl: 'git@gitlab.internal:platform/api.git',
+      branch: 'main',
+      credentialEnv: 'GITLAB_TOKEN',
+      credentialUsername: undefined,
+    });
+    expect(project.syncSchedule?.enabled).toBe(true);
+    expect(project.syncSchedule?.intervalMinutes).toBe(30);
+    expect(project.syncSchedule?.nextRunAt).toBeTruthy();
+  });
+
+  it('rejects unsupported git remote schemes', () => {
+    const registry = new ProjectRegistry({ dataDir, projectsRoot });
+
+    expect(() => registry.add({
+      sourceType: 'git',
+      remoteUrl: 'file:///tmp/repo',
+      name: 'Bad Repo',
+    })).toThrow(/SSH or HTTPS/);
+  });
+
+  it('defaults github and gitlab credentials to environment variable names', () => {
+    const registry = new ProjectRegistry({ dataDir, projectsRoot });
+
+    const github = registry.add({
+      sourceType: 'git',
+      remoteUrl: 'https://github.com/acme/web.git',
+      name: 'Web',
+    });
+    const gitlab = registry.add({
+      sourceType: 'git',
+      remoteUrl: 'https://gitlab.internal/acme/api.git',
+      name: 'API',
+    });
+
+    expect(github.source.type === 'git' && github.source.credentialEnv).toBe('GITHUB_TOKEN');
+    expect(gitlab.source.type === 'git' && gitlab.source.credentialEnv).toBe('GITLAB_TOKEN');
+  });
+
+  it('rejects embedded credentials in https git remotes', () => {
+    const registry = new ProjectRegistry({ dataDir, projectsRoot });
+
+    expect(() => registry.add({
+      sourceType: 'git',
+      remoteUrl: 'https://token@gitlab.internal/acme/api.git',
+      name: 'Leaky Repo',
+    })).toThrow(/must not contain embedded credentials/);
+  });
+
+  it('rejects credential env values that are not env var names', () => {
+    const registry = new ProjectRegistry({ dataDir, projectsRoot });
+
+    expect(() => registry.add({
+      sourceType: 'git',
+      remoteUrl: 'https://gitlab.internal/acme/api.git',
+      credentialEnv: 'glpat-token-with-dashes',
+      name: 'Bad Credential Env',
+    })).toThrow(/valid env var name/);
+  });
+
+  it('updates schedule metadata', () => {
+    const repo = path.join(projectsRoot, 'service-d');
+    fs.mkdirSync(repo);
+    const registry = new ProjectRegistry({ dataDir, projectsRoot });
+    const project = registry.add({ path: repo, name: 'Service D' });
+
+    const updated = registry.updateSchedule(project.id, { enabled: true, intervalMinutes: 15 });
+    const marked = registry.markScheduleRun(project.id, 'failed', 'network unavailable');
+
+    expect(updated?.syncSchedule?.enabled).toBe(true);
+    expect(updated?.syncSchedule?.intervalMinutes).toBe(15);
+    expect(marked?.syncSchedule?.lastStatus).toBe('failed');
+    expect(marked?.syncSchedule?.lastError).toBe('network unavailable');
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  codegraph:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      CODEGRAPH_ADMIN_TOKEN: "change-me"
+      CODEGRAPH_MCP_TOKEN: "change-me"
+      CODEGRAPH_SERVER_CORS_ORIGIN: "*"
+      # Reference this name from the UI's "Token env var" field for HTTPS remotes.
+      GITLAB_TOKEN: ""
+      GITHUB_TOKEN: ""
+    volumes:
+      - codegraph-data:/data
+      - ./projects:/projects
+      # For SSH remotes, mount a read-only deploy key and known_hosts file.
+      # - ~/.ssh:/root/.ssh:ro
+
+volumes:
+  codegraph-data:

--- a/docs/docker-server.md
+++ b/docs/docker-server.md
@@ -1,0 +1,129 @@
+# CodeGraph Docker Server
+
+This mode runs CodeGraph as a shared service instead of a per-developer local
+stdio MCP server. It provides:
+
+- a browser UI at `/` for registering mounted repositories and running
+  `init`, full `index`, and `sync`
+- GitLab/GitHub/generic Git remote registration for server-managed checkouts
+- a persisted project registry in `CODEGRAPH_SERVER_DATA_DIR`
+- one remote MCP HTTP JSON-RPC endpoint per registered project at `/mcp/:id`
+- optional bearer-token protection for the admin API and MCP endpoints
+- per-project scheduled sync intervals
+
+## Run Locally
+
+```bash
+npm ci
+npm run build
+CODEGRAPH_ADMIN_TOKEN=dev-token \
+CODEGRAPH_MCP_TOKEN=dev-token \
+node dist/bin/codegraph.js server \
+  --host 127.0.0.1 \
+  --port 3000 \
+  --projects-root /path/to/projects
+```
+
+Open `http://127.0.0.1:3000`, enter the token, add a project path under the
+configured projects root, then run Index.
+
+## Run With Docker
+
+```bash
+docker compose up --build
+```
+
+Mount repositories under `./projects`, or add Git remotes from the UI. The
+container only accepts checkout/project paths inside `CODEGRAPH_PROJECTS_DIR`
+(`/projects` in the image).
+
+## Adding GitLab or GitHub Repositories
+
+In the UI, choose **Git remote** and configure:
+
+- Provider: GitLab, GitHub, or Generic Git
+- Remote URL: SSH (`git@gitlab.internal:group/repo.git`) or HTTPS
+- Branch: optional; when set, sync fast-forwards that branch
+- Token env var: optional environment variable name such as `GITLAB_TOKEN`
+- Checkout path: optional path under `/projects`; defaults to `_repos/<repo>-<hash>`
+
+Secrets are not stored in the registry. The UI/API accepts only a credential
+environment variable name, never the token value. HTTPS remote URLs with embedded
+credentials are rejected. For HTTPS remotes, put the token in an environment
+variable and enter only the variable name in the UI. GitHub projects default to
+`GITHUB_TOKEN`; GitLab projects default to `GITLAB_TOKEN`. The server reads the
+token from the process environment at clone/sync time and uses `GIT_ASKPASS` for
+`git clone` / `git pull`.
+
+For SSH remotes, mount deploy keys and `known_hosts` into the container, for example:
+
+```yaml
+volumes:
+  - ./projects:/projects
+  - ~/.ssh:/root/.ssh:ro
+```
+
+For GitLab HTTPS tokens, the default username is `oauth2`. For GitHub HTTPS
+tokens, the default username is `x-access-token`. Override it in the UI when
+your internal provider expects a different username.
+
+This server currently stores registry metadata in JSON under
+`CODEGRAPH_SERVER_DATA_DIR`, not in SQL. The design avoids secret-at-rest
+requirements by not persisting credentials at all. If SQL-backed multi-tenant
+storage is added later, stored credentials should still be avoided; if unavoidable,
+they should be envelope-encrypted with a key supplied outside the database.
+
+## Scheduled Sync
+
+Enable scheduled sync when adding a project, or update it from the project
+detail panel. The scheduler wakes once per minute and starts a sync when
+`nextRunAt` is due. For Git projects, sync first updates the checkout from
+`origin` and then updates the CodeGraph index. If a Git checkout is not indexed
+yet, the first scheduled sync builds the initial index.
+
+Only one operation can run per project at a time. If a manual index or sync is
+already running, the scheduler skips that tick and retries on the next due
+evaluation.
+
+## MCP Client Configuration
+
+After a project is registered, copy its endpoint from the UI. The endpoint shape
+is:
+
+```text
+http://HOST:3000/mcp/PROJECT_ID
+```
+
+Use bearer auth when `CODEGRAPH_MCP_TOKEN` is set:
+
+```json
+{
+  "mcpServers": {
+    "codegraph-enterprise": {
+      "type": "http",
+      "url": "http://HOST:3000/mcp/PROJECT_ID",
+      "headers": {
+        "Authorization": "Bearer change-me"
+      }
+    }
+  }
+}
+```
+
+The remote endpoint is intentionally registry-bound. A tool call can omit
+`projectPath` to use the endpoint project, or pass another registered project
+id/name/path. Arbitrary container paths are rejected.
+
+## Environment
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `CODEGRAPH_SERVER_HOST` | `127.0.0.1` locally, `0.0.0.0` in Docker | HTTP bind host |
+| `CODEGRAPH_SERVER_PORT` | `3000` | HTTP port |
+| `CODEGRAPH_SERVER_DATA_DIR` | `~/.codegraph-server` locally, `/data` in Docker | Registry storage |
+| `CODEGRAPH_PROJECTS_DIR` | current directory locally, `/projects` in Docker | Allowed project root |
+| `CODEGRAPH_ADMIN_TOKEN` | unset | Protects UI API |
+| `CODEGRAPH_MCP_TOKEN` | `CODEGRAPH_ADMIN_TOKEN` | Protects MCP endpoints |
+| `CODEGRAPH_SERVER_CORS_ORIGIN` | `*` | CORS origin |
+| `CODEGRAPH_SERVER_NO_WATCH` | unset | Set `1` to disable remote MCP watchers |
+| `GITLAB_TOKEN`, `GITHUB_TOKEN`, etc. | unset | Optional token env vars referenced by project Git source config |

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -20,6 +20,7 @@
  *   codegraph callees <symbol>   Find what a function/method calls
  *   codegraph impact <symbol>    Analyze what code is affected by changing a symbol
  *   codegraph affected [files]   Find test files affected by changes
+ *   codegraph server             Run the HTTP management server
  *   codegraph upgrade [version]  Update CodeGraph to the latest release
  */
 
@@ -1346,6 +1347,72 @@ program
       note: (m) => clack.log.success(m),
       done: (m) => clack.outro(m),
     });
+  });
+
+/**
+ * codegraph server
+ */
+program
+  .command('server')
+  .description('Run the CodeGraph HTTP server with project management UI and remote MCP endpoints')
+  .option('--host <host>', 'Host/interface to bind')
+  .option('--port <port>', 'Port to bind')
+  .option('--data-dir <path>', 'Directory for server registry data')
+  .option('--projects-root <path>', 'Only allow projects under this directory')
+  .option('--admin-token <token>', 'Bearer token for the admin API/UI')
+  .option('--mcp-token <token>', 'Bearer token for MCP clients')
+  .option('--cors-origin <origin>', 'Access-Control-Allow-Origin value')
+  .option('--no-watch', 'Disable MCP file watchers for remote sessions')
+  .action(async (options: {
+    host?: string;
+    port?: string;
+    dataDir?: string;
+    projectsRoot?: string;
+    adminToken?: string;
+    mcpToken?: string;
+    corsOrigin?: string;
+    watch?: boolean;
+  }) => {
+    try {
+      const { startCodeGraphServer, optionsFromEnv } = await import('../server');
+      const port = options.port ? Number(options.port) : undefined;
+      if (port !== undefined && (!Number.isInteger(port) || port <= 0 || port > 65535)) {
+        error(`Invalid port: ${options.port}`);
+        process.exit(1);
+      }
+
+      const resolved = optionsFromEnv({
+        host: options.host,
+        port,
+        dataDir: options.dataDir,
+        projectsRoot: options.projectsRoot,
+        adminToken: options.adminToken,
+        mcpToken: options.mcpToken,
+        corsOrigin: options.corsOrigin,
+        watch: options.watch,
+      });
+      const running = await startCodeGraphServer(resolved);
+      const url = `http://${resolved.host === '0.0.0.0' ? 'localhost' : resolved.host}:${resolved.port}`;
+      success(`CodeGraph server listening at ${url}`);
+      info(`Projects root: ${resolved.projectsRoot}`);
+      info(`Server data:   ${resolved.dataDir}`);
+      if (!resolved.adminToken) {
+        warn('CODEGRAPH_ADMIN_TOKEN is not set; the admin API is open to anyone who can reach this port.');
+      }
+      if (!resolved.mcpToken) {
+        warn('CODEGRAPH_MCP_TOKEN is not set; MCP endpoints are open to anyone who can reach this port.');
+      }
+
+      const shutdown = async () => {
+        await running.close();
+        process.exit(0);
+      };
+      process.once('SIGINT', () => { void shutdown(); });
+      process.once('SIGTERM', () => { void shutdown(); });
+    } catch (err) {
+      error(`Failed to start server: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
   });
 
 /**

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -633,7 +633,7 @@ export function getStaticTools(): ToolDefinition[] {
 
 /**
  * The MCP tools served by DEFAULT (short names). The other defined tools
- * (callees, impact, files, status) remain fully functional — handlers stay,
+ * (callees, impact, files) remain fully functional — handlers stay,
  * the library API and CLI are untouched, and `CODEGRAPH_MCP_TOOLS` re-enables
  * any of them — they just aren't LISTED to agents anymore.
  *
@@ -645,15 +645,16 @@ export function getStaticTools(): ToolDefinition[] {
  *   standalone tool.
  * - `codegraph_callees` is redundant by construction: a symbol's body (which
  *   node returns) IS its callee list, plus the caller/callee trail.
- * - `codegraph_files` / `codegraph_status`: the tiny-repo audit (see
- *   getTools) found they "reduce to one grep"; staleness banners already
- *   inline the pending-sync info on every read tool, and the CLI covers
- *   diagnostics.
+ * - `codegraph_status` is listed because shared/remote servers need a cheap
+ *   way for clients to confirm freshness and index health.
+ * - `codegraph_files`: the tiny-repo audit (see getTools) found it "reduces
+ *   to one grep"; staleness banners already inline the pending-sync info on
+ *   every read tool, and the CLI covers diagnostics.
  * - `codegraph_callers` stays: exhaustive call-site enumeration (every
  *   caller with file:line, callback registrations labeled, one section per
  *   same-named definition) is the one job explore/node don't replicate.
  */
-const DEFAULT_MCP_TOOLS = new Set(['explore', 'node', 'search', 'callers']);
+const DEFAULT_MCP_TOOLS = new Set(['explore', 'node', 'search', 'callers', 'status']);
 
 /**
  * Tool handler that executes tools against a CodeGraph instance
@@ -787,6 +788,7 @@ export class ToolHandler {
         'codegraph_explore',
         'codegraph_search',
         'codegraph_node',
+        'codegraph_status',
       ]);
       if (stats.fileCount < TINY_REPO_FILE_THRESHOLD) {
         visible = visible.filter(t => TINY_REPO_CORE_TOOLS.has(t.name));

--- a/src/server/git.ts
+++ b/src/server/git.ts
@@ -1,0 +1,174 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawn } from 'child_process';
+import type { GitProjectSource, ProjectRecord } from './types';
+
+export type OperationLogger = (message: string) => void;
+
+export async function ensureGitCheckout(project: ProjectRecord, log: OperationLogger): Promise<void> {
+  if (project.source.type !== 'git') return;
+
+  const source = project.source;
+  if (!fs.existsSync(project.path) || isEmptyDirectory(project.path)) {
+    await cloneRepository(project, source, log);
+    return;
+  }
+
+  if (!fs.existsSync(path.join(project.path, '.git'))) {
+    throw new Error(`Checkout path exists but is not a git repository: ${project.path}`);
+  }
+
+  const currentRemote = await runGit(['remote', 'get-url', 'origin'], {
+    cwd: project.path,
+    source,
+    log,
+    quiet: true,
+  });
+  if (currentRemote.trim() !== source.remoteUrl) {
+    throw new Error(
+      `Existing checkout remote does not match registry source. Expected ${redactUrl(source.remoteUrl)}, found ${redactUrl(currentRemote.trim())}`
+    );
+  }
+
+  log(`Fetching ${redactUrl(source.remoteUrl)}`);
+  if (source.branch) {
+    await runGit(['fetch', '--prune', 'origin', source.branch], { cwd: project.path, source, log });
+    const checkoutArgs = await branchExists(project.path, source.branch, source, log)
+      ? ['checkout', source.branch]
+      : ['checkout', '-b', source.branch, '--track', `origin/${source.branch}`];
+    await runGit(checkoutArgs, { cwd: project.path, source, log });
+    await runGit(['pull', '--ff-only', 'origin', source.branch], { cwd: project.path, source, log });
+  } else {
+    await runGit(['pull', '--ff-only'], { cwd: project.path, source, log });
+  }
+}
+
+async function cloneRepository(
+  project: ProjectRecord,
+  source: GitProjectSource,
+  log: OperationLogger,
+): Promise<void> {
+  fs.mkdirSync(path.dirname(project.path), { recursive: true });
+  if (fs.existsSync(project.path) && !isEmptyDirectory(project.path)) {
+    throw new Error(`Checkout path is not empty: ${project.path}`);
+  }
+
+  log(`Cloning ${redactUrl(source.remoteUrl)}`);
+  const args = ['clone', '--depth', '1'];
+  if (source.branch) {
+    args.push('--branch', source.branch, '--single-branch');
+  }
+  args.push(source.remoteUrl, project.path);
+  await runGit(args, { cwd: path.dirname(project.path), source, log });
+}
+
+async function branchExists(
+  cwd: string,
+  branch: string,
+  source: GitProjectSource,
+  log: OperationLogger,
+): Promise<boolean> {
+  try {
+    await runGit(['rev-parse', '--verify', branch], { cwd, source, log, quiet: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface RunGitOptions {
+  cwd: string;
+  source: GitProjectSource;
+  log: OperationLogger;
+  quiet?: boolean;
+}
+
+async function runGit(args: string[], options: RunGitOptions): Promise<string> {
+  return withGitAuth(options.source, async (env) => {
+    return new Promise<string>((resolve, reject) => {
+      const child = spawn('git', args, {
+        cwd: options.cwd,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf-8');
+      });
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf-8');
+      });
+      child.on('error', reject);
+      child.on('close', (code) => {
+        const output = [stdout, stderr].join('\n').trim();
+        if (!options.quiet && output) {
+          for (const line of compactOutput(output)) {
+            options.log(redactUrl(line));
+          }
+        }
+        if (code === 0) {
+          resolve(stdout);
+          return;
+        }
+        reject(new Error(`git ${args[0] ?? 'command'} failed with exit code ${code}: ${redactUrl(output)}`));
+      });
+    });
+  });
+}
+
+async function withGitAuth<T>(
+  source: GitProjectSource,
+  run: (env: NodeJS.ProcessEnv) => Promise<T>,
+): Promise<T> {
+  const token = source.credentialEnv ? process.env[source.credentialEnv] : undefined;
+  if (!source.credentialEnv || !token) {
+    return run({ ...process.env, GIT_TERMINAL_PROMPT: '0' });
+  }
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-git-askpass-'));
+  const askpassPath = path.join(dir, 'askpass.sh');
+  const username = source.credentialUsername || defaultUsername(source.provider);
+  fs.writeFileSync(
+    askpassPath,
+    '#!/usr/bin/env sh\n' +
+    'case "$1" in\n' +
+    '*Username*) printf "%s\\n" "$CODEGRAPH_GIT_USERNAME" ;;\n' +
+    '*) printf "%s\\n" "$CODEGRAPH_GIT_TOKEN" ;;\n' +
+    'esac\n',
+    { mode: 0o700 },
+  );
+
+  try {
+    return await run({
+      ...process.env,
+      GIT_TERMINAL_PROMPT: '0',
+      GIT_ASKPASS: askpassPath,
+      CODEGRAPH_GIT_USERNAME: username,
+      CODEGRAPH_GIT_TOKEN: token,
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function defaultUsername(provider: GitProjectSource['provider']): string {
+  if (provider === 'github') return 'x-access-token';
+  if (provider === 'gitlab') return 'oauth2';
+  return 'git';
+}
+
+function isEmptyDirectory(targetPath: string): boolean {
+  if (!fs.existsSync(targetPath)) return true;
+  return fs.statSync(targetPath).isDirectory() && fs.readdirSync(targetPath).length === 0;
+}
+
+function compactOutput(output: string): string[] {
+  const lines = output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  return lines.slice(Math.max(0, lines.length - 20));
+}
+
+function redactUrl(value: string): string {
+  return value.replace(/(https?:\/\/)([^/@\s]+)@/g, '$1[redacted]@');
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,444 @@
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { URL } from 'url';
+import type { IncomingMessage, ServerResponse } from 'http';
+import { RemoteMcpManager } from './mcp-http';
+import { ProjectRegistry } from './registry';
+import { ProjectService } from './service';
+import { APP_CSS, APP_JS, renderIndexHtml } from './ui';
+
+const DEFAULT_PORT = 3000;
+const MAX_BODY_BYTES = 1024 * 1024;
+
+export interface CodeGraphServerOptions {
+  host: string;
+  port: number;
+  dataDir: string;
+  projectsRoot: string;
+  adminToken?: string;
+  mcpToken?: string;
+  corsOrigin: string;
+  watch: boolean;
+}
+
+export interface RunningCodeGraphServer {
+  server: http.Server;
+  registry: ProjectRegistry;
+  service: ProjectService;
+  close: () => Promise<void>;
+}
+
+export function optionsFromEnv(overrides: Partial<CodeGraphServerOptions> = {}): CodeGraphServerOptions {
+  const dataDir = process.env.CODEGRAPH_SERVER_DATA_DIR
+    || path.join(os.homedir(), '.codegraph-server');
+  const projectsRoot = process.env.CODEGRAPH_PROJECTS_DIR || process.cwd();
+  const adminToken = overrides.adminToken ?? process.env.CODEGRAPH_ADMIN_TOKEN ?? undefined;
+  return {
+    host: overrides.host ?? process.env.CODEGRAPH_SERVER_HOST ?? '127.0.0.1',
+    port: overrides.port ?? parsePort(process.env.CODEGRAPH_SERVER_PORT),
+    dataDir: overrides.dataDir ?? dataDir,
+    projectsRoot: overrides.projectsRoot ?? projectsRoot,
+    adminToken,
+    mcpToken: overrides.mcpToken ?? process.env.CODEGRAPH_MCP_TOKEN ?? adminToken,
+    corsOrigin: overrides.corsOrigin ?? process.env.CODEGRAPH_SERVER_CORS_ORIGIN ?? '*',
+    watch: overrides.watch ?? process.env.CODEGRAPH_SERVER_NO_WATCH !== '1',
+  };
+}
+
+export async function startCodeGraphServer(
+  input: Partial<CodeGraphServerOptions> = {},
+): Promise<RunningCodeGraphServer> {
+  const options = optionsFromEnv(input);
+  const registry = new ProjectRegistry({
+    dataDir: options.dataDir,
+    projectsRoot: options.projectsRoot,
+  });
+  const service = new ProjectService(registry);
+  const mcp = new RemoteMcpManager(registry, service, { watch: options.watch });
+  service.startScheduler();
+
+  const server = http.createServer((req, res) => {
+    void handleRequest(req, res, options, service, mcp);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(options.port, options.host, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  return {
+    server,
+    registry,
+    service,
+    close: async () => {
+      service.stopScheduler();
+      mcp.stop();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => err ? reject(err) : resolve());
+      });
+    },
+  };
+}
+
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: CodeGraphServerOptions,
+  service: ProjectService,
+  mcp: RemoteMcpManager,
+): Promise<void> {
+  applyCors(res, options);
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  try {
+    const requestUrl = new URL(req.url || '/', 'http://localhost');
+    const pathname = requestUrl.pathname;
+
+    if (req.method === 'GET' && pathname === '/') {
+      sendText(res, 200, renderIndexHtml(), 'text/html; charset=utf-8', options);
+      return;
+    }
+    if (req.method === 'GET' && pathname === '/assets/app.css') {
+      sendText(res, 200, APP_CSS, 'text/css; charset=utf-8', options);
+      return;
+    }
+    if (req.method === 'GET' && pathname === '/assets/app.js') {
+      sendText(res, 200, APP_JS, 'application/javascript; charset=utf-8', options);
+      return;
+    }
+    if (pathname === '/api/health') {
+      sendJson(res, 200, { ok: true }, options);
+      return;
+    }
+    if (pathname === '/api/config') {
+      sendJson(res, 200, {
+        projectsRoot: options.projectsRoot,
+        adminAuthRequired: !!options.adminToken,
+        mcpAuthRequired: !!options.mcpToken,
+      }, options);
+      return;
+    }
+    if (pathname.startsWith('/api/')) {
+      if (!authorize(req, options.adminToken)) {
+        sendUnauthorized(res, options);
+        return;
+      }
+      await handleApi(req, res, pathname, service, options);
+      return;
+    }
+    if (pathname === '/mcp' || pathname.startsWith('/mcp/')) {
+      if (!authorize(req, options.mcpToken)) {
+        sendUnauthorized(res, options);
+        return;
+      }
+      await handleMcp(req, res, pathname, mcp, options);
+      return;
+    }
+
+    sendJson(res, 404, { error: 'Not found' }, options);
+  } catch (err) {
+    sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) }, options);
+  }
+}
+
+async function handleApi(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pathname: string,
+  service: ProjectService,
+  options: CodeGraphServerOptions,
+): Promise<void> {
+  const parts = pathname.split('/').filter(Boolean).map(decodeURIComponent);
+  if (parts[1] !== 'projects') {
+    sendJson(res, 404, { error: 'Unknown API route' }, options);
+    return;
+  }
+
+  if (parts.length === 2) {
+    if (req.method === 'GET') {
+      sendJson(res, 200, { projects: service.listProjects() }, options);
+      return;
+    }
+    if (req.method === 'POST') {
+      const body = await readJsonBody(req);
+      const input = body && typeof body === 'object'
+        ? body as Record<string, unknown>
+        : {};
+      const secretField = findSecretField(input);
+      if (secretField) {
+        sendJson(res, 400, { error: `Do not send secret values in the UI/API payload (${secretField}); configure an environment variable and reference its name instead` }, options);
+        return;
+      }
+      const sourceType = input.sourceType === 'git' ? 'git' : 'path';
+      if (sourceType === 'path' && typeof input.path !== 'string') {
+        sendJson(res, 400, { error: 'path is required for local path projects' }, options);
+        return;
+      }
+      if (sourceType === 'git' && typeof input.remoteUrl !== 'string') {
+        sendJson(res, 400, { error: 'remoteUrl is required for git projects' }, options);
+        return;
+      }
+      try {
+        const project = service.addProject({
+          sourceType,
+          path: typeof input.path === 'string' ? input.path : undefined,
+          name: typeof input.name === 'string' ? input.name : undefined,
+          provider: input.provider === 'github' || input.provider === 'gitlab' || input.provider === 'generic'
+            ? input.provider
+            : undefined,
+          remoteUrl: typeof input.remoteUrl === 'string' ? input.remoteUrl : undefined,
+          branch: typeof input.branch === 'string' ? input.branch : undefined,
+          credentialEnv: typeof input.credentialEnv === 'string' ? input.credentialEnv : undefined,
+          credentialUsername: typeof input.credentialUsername === 'string' ? input.credentialUsername : undefined,
+          makeDefault: input.makeDefault === true,
+          scheduleEnabled: input.scheduleEnabled === true,
+          scheduleIntervalMinutes: typeof input.scheduleIntervalMinutes === 'number'
+            ? input.scheduleIntervalMinutes
+            : undefined,
+        });
+        sendJson(res, 201, { project }, options);
+      } catch (err) {
+        sendJson(res, 400, { error: errorMessage(err) }, options);
+      }
+      return;
+    }
+  }
+
+  const projectId = parts[2];
+  if (!projectId) {
+    sendJson(res, 404, { error: 'Project id is required' }, options);
+    return;
+  }
+
+  if (parts.length === 3) {
+    if (req.method === 'GET') {
+      const project = service.getProject(projectId);
+      sendJson(res, project ? 200 : 404, project ? { project } : { error: 'Project not found' }, options);
+      return;
+    }
+    if (req.method === 'DELETE') {
+      const removed = service.removeProject(projectId);
+      sendJson(res, removed ? 200 : 404, removed ? { project: removed } : { error: 'Project not found' }, options);
+      return;
+    }
+  }
+
+  const action = parts[3];
+  if (!action) {
+    sendJson(res, 404, { error: 'Project action is required' }, options);
+    return;
+  }
+
+  if (req.method === 'POST' && (action === 'init' || action === 'index' || action === 'sync')) {
+    try {
+      const operation = service.startOperation(projectId, action);
+      sendJson(res, 202, { operation }, options);
+    } catch (err) {
+      sendJson(res, messageLooksLikeConflict(err) ? 409 : 400, { error: errorMessage(err) }, options);
+    }
+    return;
+  }
+
+  if (req.method === 'POST' && action === 'default') {
+    const project = service.setDefault(projectId);
+    sendJson(res, project ? 200 : 404, project ? { project } : { error: 'Project not found' }, options);
+    return;
+  }
+
+  if (req.method === 'POST' && action === 'schedule') {
+    const body = await readJsonBody(req);
+    const input = body && typeof body === 'object'
+      ? body as { enabled?: unknown; intervalMinutes?: unknown }
+      : {};
+    if (typeof input.enabled !== 'boolean') {
+      sendJson(res, 400, { error: 'enabled must be a boolean' }, options);
+      return;
+    }
+    const project = service.updateSchedule(projectId, {
+      enabled: input.enabled,
+      intervalMinutes: typeof input.intervalMinutes === 'number'
+        ? input.intervalMinutes
+        : undefined,
+    });
+    sendJson(res, project ? 200 : 404, project ? { project } : { error: 'Project not found' }, options);
+    return;
+  }
+
+  if (req.method === 'GET' && action === 'operation') {
+    const operation = service.getOperation(projectId);
+    sendJson(res, 200, { operation }, options);
+    return;
+  }
+
+  sendJson(res, 404, { error: 'Unknown project action' }, options);
+}
+
+async function handleMcp(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pathname: string,
+  mcp: RemoteMcpManager,
+  options: CodeGraphServerOptions,
+): Promise<void> {
+  if (req.method === 'GET') {
+    const projectId = mcpProjectIdFromPath(pathname);
+    sendJson(res, 200, {
+      endpoint: pathname,
+      projectId,
+      transport: 'http-json-rpc',
+      method: 'POST',
+    }, options);
+    return;
+  }
+  if (req.method !== 'POST') {
+    sendJson(res, 405, { error: 'MCP endpoint expects POST' }, options);
+    return;
+  }
+
+  let body: unknown;
+  try {
+    body = await readJsonBody(req);
+  } catch (err) {
+    sendJson(res, 400, {
+      jsonrpc: '2.0',
+      id: null,
+      error: { code: -32700, message: errorMessage(err) },
+    }, options);
+    return;
+  }
+
+  if (Array.isArray(body)) {
+    sendJson(res, 400, {
+      jsonrpc: '2.0',
+      id: null,
+      error: { code: -32600, message: 'Batch JSON-RPC is not supported' },
+    }, options);
+    return;
+  }
+
+  const response = await mcp.handle(mcpProjectIdFromPath(pathname), body);
+  if (!response) {
+    res.writeHead(202);
+    res.end();
+    return;
+  }
+  sendJson(res, 'error' in response ? 400 : 200, response, options);
+}
+
+function mcpProjectIdFromPath(pathname: string): string | null {
+  const parts = pathname.split('/').filter(Boolean).map(decodeURIComponent);
+  return parts[1] || null;
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > MAX_BODY_BYTES) {
+      throw new Error('Request body is too large');
+    }
+    chunks.push(buffer);
+  }
+  if (chunks.length === 0) return {};
+  return JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+}
+
+function sendJson(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  options: CodeGraphServerOptions,
+): void {
+  applyCors(res, options);
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+  });
+  res.end(JSON.stringify(body));
+}
+
+function sendText(
+  res: ServerResponse,
+  status: number,
+  body: string,
+  contentType: string,
+  options: CodeGraphServerOptions,
+): void {
+  applyCors(res, options);
+  res.writeHead(status, {
+    'Content-Type': contentType,
+    'Cache-Control': 'no-store',
+  });
+  res.end(body);
+}
+
+function applyCors(res: ServerResponse, options: CodeGraphServerOptions): void {
+  res.setHeader('Access-Control-Allow-Origin', options.corsOrigin);
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,DELETE,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'authorization,content-type,mcp-session-id,mcp-protocol-version');
+}
+
+function authorize(req: IncomingMessage, token: string | undefined): boolean {
+  if (!token) return true;
+  const auth = req.headers.authorization;
+  if (auth === `Bearer ${token}`) return true;
+  const alt = req.headers['x-codegraph-token'];
+  return alt === token;
+}
+
+function sendUnauthorized(res: ServerResponse, options: CodeGraphServerOptions): void {
+  applyCors(res, options);
+  res.writeHead(401, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'WWW-Authenticate': 'Bearer',
+  });
+  res.end(JSON.stringify({ error: 'Unauthorized' }));
+}
+
+function parsePort(raw: string | undefined): number {
+  const port = raw ? Number(raw) : DEFAULT_PORT;
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    return DEFAULT_PORT;
+  }
+  return port;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function messageLooksLikeConflict(err: unknown): boolean {
+  return errorMessage(err).includes('already running');
+}
+
+function findSecretField(input: Record<string, unknown>): string | null {
+  const allowed = new Set([
+    'credentialEnv',
+    'credentialUsername',
+    'sourceType',
+    'path',
+    'name',
+    'provider',
+    'remoteUrl',
+    'branch',
+    'makeDefault',
+    'scheduleEnabled',
+    'scheduleIntervalMinutes',
+  ]);
+  const secretPattern = /(token|password|secret|private.?key|deploy.?key|credential.?value|credential.?token|access.?key)/i;
+  for (const key of Object.keys(input)) {
+    if (allowed.has(key)) continue;
+    if (secretPattern.test(key)) return key;
+  }
+  return null;
+}

--- a/src/server/mcp-http.ts
+++ b/src/server/mcp-http.ts
@@ -1,0 +1,429 @@
+import { isInitialized } from '../directory';
+import { MCPEngine } from '../mcp/engine';
+import { SERVER_INFO, PROTOCOL_VERSION } from '../mcp/session';
+import { SERVER_INSTRUCTIONS, SERVER_INSTRUCTIONS_UNINDEXED } from '../mcp/server-instructions';
+import { ErrorCodes, type JsonRpcResponse } from '../mcp/transport';
+import { tools as codegraphTools, type ToolDefinition, type ToolResult } from '../mcp/tools';
+import { getTelemetry } from '../telemetry';
+import type { ProjectRegistry } from './registry';
+import type { ProjectService } from './service';
+import type { OperationState, ProjectRecord, ProjectStatus } from './types';
+
+interface JsonRpcIncoming {
+  jsonrpc?: unknown;
+  id?: unknown;
+  method?: unknown;
+  params?: unknown;
+}
+
+type ProjectListing = ProjectRecord & {
+  mcpPath: string;
+  status?: ProjectStatus;
+  operation?: OperationState;
+};
+
+export interface RemoteMcpManagerOptions {
+  watch?: boolean;
+}
+
+export class RemoteMcpManager {
+  private engines = new Map<string, MCPEngine>();
+  private watch: boolean;
+  private service: ProjectService | null;
+
+  constructor(
+    private registry: ProjectRegistry,
+    serviceOrOptions: ProjectService | RemoteMcpManagerOptions | null = null,
+    options: RemoteMcpManagerOptions = {},
+  ) {
+    if (isProjectService(serviceOrOptions)) {
+      this.service = serviceOrOptions;
+    } else {
+      this.service = null;
+      options = serviceOrOptions ?? {};
+    }
+    this.watch = options.watch ?? true;
+  }
+
+  stop(): void {
+    for (const engine of this.engines.values()) {
+      engine.stop();
+    }
+    this.engines.clear();
+  }
+
+  async handle(projectId: string | null, payload: unknown): Promise<JsonRpcResponse | null> {
+    if (!isJsonRpcIncoming(payload)) {
+      return this.error(null, ErrorCodes.InvalidRequest, 'Invalid JSON-RPC request');
+    }
+
+    const id = typeof payload.id === 'string' || typeof payload.id === 'number'
+      ? payload.id
+      : null;
+    const isNotification = !('id' in payload);
+    const method = payload.method;
+
+    if (typeof method !== 'string') {
+      return this.error(id, ErrorCodes.InvalidRequest, 'Missing JSON-RPC method');
+    }
+
+    const project = this.resolveTargetProject(projectId);
+    if (!project && projectId) {
+      return this.error(id, ErrorCodes.InvalidParams, 'No registered CodeGraph project matches this MCP endpoint');
+    }
+
+    switch (method) {
+      case 'initialize':
+        return isNotification ? null : this.result(id, this.initializeResult(project));
+      case 'initialized':
+      case 'notifications/initialized':
+        return null;
+      case 'ping':
+        return isNotification ? null : this.result(id, {});
+      case 'tools/list':
+        return isNotification ? null : this.result(id, await this.listTools(project));
+      case 'tools/call':
+        return isNotification ? null : this.result(id, await this.callTool(project, payload.params));
+      case 'resources/list':
+        return isNotification ? null : this.result(id, { resources: [] });
+      case 'resources/templates/list':
+        return isNotification ? null : this.result(id, { resourceTemplates: [] });
+      case 'prompts/list':
+        return isNotification ? null : this.result(id, { prompts: [] });
+      default:
+        return isNotification ? null : this.error(id, ErrorCodes.MethodNotFound, `Method not found: ${method}`);
+    }
+  }
+
+  private initializeResult(project: ProjectRecord | null): unknown {
+    const indexed = project ? isInitialized(project.path) : false;
+    if (project && indexed) {
+      void this.getEngine(project).ensureInitialized(project.path);
+    }
+    return {
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: { tools: {} },
+      serverInfo: SERVER_INFO,
+      instructions: project && indexed
+        ? SERVER_INSTRUCTIONS
+        : `${SERVER_INSTRUCTIONS_UNINDEXED}\n\nUse codegraph_projects to list projects registered on this shared CodeGraph server.`,
+    };
+  }
+
+  private async listTools(project: ProjectRecord | null): Promise<{ tools: ToolDefinition[] }> {
+    const serverTools = this.getServerTools();
+    if (!project) {
+      return { tools: serverTools };
+    }
+
+    const engine = this.getEngine(project);
+    await engine.ensureInitialized(project.path);
+    const statusTool = this.getCodeGraphTool('codegraph_status');
+    if (!engine.hasDefaultCodeGraph()) {
+      return {
+        tools: this.uniqueTools([
+          ...serverTools,
+          ...(statusTool ? this.decorateTools([statusTool]) : []),
+        ]),
+      };
+    }
+    return {
+      tools: this.uniqueTools([
+        ...serverTools,
+        ...this.decorateTools(engine.getToolHandler().getTools()),
+      ]),
+    };
+  }
+
+  private async callTool(project: ProjectRecord | null, params: unknown): Promise<ToolResult> {
+    if (!params || typeof params !== 'object') {
+      return this.toolError('Missing tool call params');
+    }
+    const raw = params as { name?: unknown; arguments?: unknown };
+    if (typeof raw.name !== 'string' || !raw.name) {
+      return this.toolError('Missing tool name');
+    }
+    if (raw.name === 'codegraph_projects') {
+      return this.callProjectsTool(raw.arguments);
+    }
+    if (!project) {
+      return this.toolError('No default project is registered on this CodeGraph server. Use codegraph_projects to list available projects.');
+    }
+
+    const engine = this.getEngine(project);
+    await engine.ensureInitialized(project.path);
+    const args = this.normalizeToolArguments(raw.arguments);
+    if (isToolResult(args)) {
+      return args;
+    }
+
+    const result = await engine.getToolHandler().execute(raw.name, args);
+    try {
+      getTelemetry().recordUsage('mcp_tool', raw.name, !result.isError, { name: 'codegraph-server-http' });
+    } catch {
+      /* telemetry must not affect MCP responses */
+    }
+    return result;
+  }
+
+  private normalizeToolArguments(value: unknown): Record<string, unknown> | ToolResult {
+    const args = value && typeof value === 'object'
+      ? { ...(value as Record<string, unknown>) }
+      : {};
+    const projectPath = args.projectPath;
+    if (projectPath === undefined || projectPath === null) {
+      return args;
+    }
+    if (typeof projectPath !== 'string') {
+      return this.toolError('projectPath must be a registered project id, name, or path');
+    }
+    const project = this.registry.resolveProjectRef(projectPath);
+    if (!project) {
+      return this.toolError(`Project is not registered on this CodeGraph server: ${projectPath}`);
+    }
+    args.projectPath = project.path;
+    return args;
+  }
+
+  private decorateTools(tools: ToolDefinition[]): ToolDefinition[] {
+    return tools.map((tool) => {
+      const projectPath = tool.inputSchema.properties.projectPath;
+      if (!projectPath) return tool;
+      return {
+        ...tool,
+        inputSchema: {
+          ...tool.inputSchema,
+          properties: {
+            ...tool.inputSchema.properties,
+            projectPath: {
+              ...projectPath,
+              description: 'Optional registered project id, name, or path on this CodeGraph server. Omit it to use this endpoint project.',
+            },
+          },
+        },
+      };
+    });
+  }
+
+  private getServerTools(): ToolDefinition[] {
+    return this.isToolAllowedByEnv('codegraph_projects') ? [CODEGRAPH_PROJECTS_TOOL] : [];
+  }
+
+  private getCodeGraphTool(name: string): ToolDefinition | null {
+    if (!this.isToolAllowedByEnv(name)) return null;
+    return codegraphTools.find((tool) => tool.name === name) ?? null;
+  }
+
+  private isToolAllowedByEnv(name: string): boolean {
+    const raw = process.env.CODEGRAPH_MCP_TOOLS;
+    if (!raw || !raw.trim()) return true;
+    const allow = new Set(raw.split(',').map((value) => shortToolName(value)).filter(Boolean));
+    return allow.has(shortToolName(name));
+  }
+
+  private uniqueTools(tools: ToolDefinition[]): ToolDefinition[] {
+    const seen = new Set<string>();
+    return tools.filter((tool) => {
+      if (seen.has(tool.name)) return false;
+      seen.add(tool.name);
+      return true;
+    });
+  }
+
+  private callProjectsTool(value: unknown): ToolResult {
+    if (!this.isToolAllowedByEnv('codegraph_projects')) {
+      return this.toolError('Tool codegraph_projects is disabled via CODEGRAPH_MCP_TOOLS');
+    }
+
+    const args = value && typeof value === 'object' && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : {};
+    const query = typeof args.query === 'string' ? args.query.trim().toLowerCase() : '';
+    if (query.length > 10_000) {
+      return this.toolError('query must be 10000 characters or fewer');
+    }
+    const onlyIndexed = args.onlyIndexed === true;
+    const includeStatus = args.includeStatus !== false || onlyIndexed;
+    const projects = includeStatus && this.service
+      ? this.service.listProjects()
+      : this.registry.list().map(projectToListingWithoutStatus);
+
+    const filtered = projects
+      .filter((project) => !onlyIndexed || project.status?.initialized === true)
+      .filter((project) => !query || projectMatchesQuery(project, query))
+      .map((project) => serializeProjectForMcp(project, includeStatus));
+
+    const result = {
+      count: filtered.length,
+      projects: filtered,
+      usage: {
+        projectPath: 'Use a project id or name from this list as projectPath on codegraph_search, codegraph_node, codegraph_explore, or codegraph_status.',
+        endpoint: 'Use mcpPath to connect directly to a single project endpoint.',
+      },
+    };
+
+    try {
+      getTelemetry().recordUsage('mcp_tool', 'codegraph_projects', true, { name: 'codegraph-server-http' });
+    } catch {
+      /* telemetry must not affect MCP responses */
+    }
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  }
+
+  private getEngine(project: ProjectRecord): MCPEngine {
+    let engine = this.engines.get(project.id);
+    if (!engine) {
+      engine = new MCPEngine({ watch: this.watch });
+      engine.setProjectPathHint(project.path);
+      this.engines.set(project.id, engine);
+    }
+    return engine;
+  }
+
+  private resolveTargetProject(projectId: string | null): ProjectRecord | null {
+    if (!projectId) return this.registry.getDefault();
+    return this.registry.get(projectId);
+  }
+
+  private result(id: string | number | null, result: unknown): JsonRpcResponse {
+    return { jsonrpc: '2.0', id, result };
+  }
+
+  private error(
+    id: string | number | null,
+    code: number,
+    message: string,
+    data?: unknown,
+  ): JsonRpcResponse {
+    return { jsonrpc: '2.0', id, error: { code, message, data } };
+  }
+
+  private toolError(message: string): ToolResult {
+    return {
+      content: [{ type: 'text', text: message }],
+      isError: true,
+    };
+  }
+}
+
+const CODEGRAPH_PROJECTS_TOOL: ToolDefinition = {
+  name: 'codegraph_projects',
+  description: 'List projects registered on this shared CodeGraph server. Use a returned id or name as projectPath on other CodeGraph tools, or connect directly to the returned mcpPath.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Optional case-insensitive filter over project id, name, provider, remote URL, or branch.',
+      },
+      includeStatus: {
+        type: 'boolean',
+        description: 'Include index health and freshness metadata for each project (default: true).',
+        default: true,
+      },
+      onlyIndexed: {
+        type: 'boolean',
+        description: 'Return only projects with an initialized CodeGraph index (default: false).',
+        default: false,
+      },
+    },
+  },
+};
+
+function isProjectService(value: ProjectService | RemoteMcpManagerOptions | null): value is ProjectService {
+  return !!value && typeof value === 'object' && 'listProjects' in value && 'getProject' in value;
+}
+
+function shortToolName(name: string): string {
+  return name.trim().replace(/^codegraph_/, '');
+}
+
+function projectToListingWithoutStatus(project: ProjectRecord): ProjectListing {
+  return {
+    ...project,
+    mcpPath: `/mcp/${encodeURIComponent(project.id)}`,
+  };
+}
+
+function projectMatchesQuery(project: ProjectListing, query: string): boolean {
+  const source = project.source.type === 'git'
+    ? [project.source.provider, project.source.remoteUrl, project.source.branch ?? '']
+    : [project.source.type];
+  return [
+    project.id,
+    project.name,
+    ...source,
+  ].some((value) => value.toLowerCase().includes(query));
+}
+
+function serializeProjectForMcp(project: ProjectListing, includeStatus: boolean): Record<string, unknown> {
+  const output: Record<string, unknown> = {
+    id: project.id,
+    name: project.name,
+    projectPathRef: project.id,
+    mcpPath: project.mcpPath,
+    isDefault: project.isDefault === true,
+    source: project.source.type === 'git'
+      ? {
+        type: 'git',
+        provider: project.source.provider,
+        remoteUrl: project.source.remoteUrl,
+        branch: project.source.branch,
+      }
+      : { type: 'path' },
+    syncSchedule: project.syncSchedule
+      ? {
+        enabled: project.syncSchedule.enabled,
+        intervalMinutes: project.syncSchedule.intervalMinutes,
+        nextRunAt: project.syncSchedule.nextRunAt,
+        lastRunAt: project.syncSchedule.lastRunAt,
+        lastStatus: project.syncSchedule.lastStatus,
+        lastError: project.syncSchedule.lastError,
+      }
+      : undefined,
+    operation: project.operation ? serializeOperation(project.operation) : undefined,
+  };
+
+  if (includeStatus && project.status) {
+    output.status = {
+      initialized: project.status.initialized,
+      exists: project.status.exists,
+      lastIndexed: project.status.lastIndexed,
+      fileCount: project.status.fileCount,
+      nodeCount: project.status.nodeCount,
+      edgeCount: project.status.edgeCount,
+      dbSizeBytes: project.status.dbSizeBytes,
+      backend: project.status.backend,
+      journalMode: project.status.journalMode,
+      languages: project.status.languages,
+      nodesByKind: project.status.nodesByKind,
+      pendingChanges: project.status.pendingChanges,
+      reindexRecommended: project.status.reindexRecommended,
+      error: project.status.error,
+    };
+  }
+
+  return Object.fromEntries(Object.entries(output).filter(([, value]) => value !== undefined));
+}
+
+function serializeOperation(operation: OperationState): Record<string, unknown> {
+  return Object.fromEntries(Object.entries({
+    kind: operation.kind,
+    status: operation.status,
+    trigger: operation.trigger,
+    startedAt: operation.startedAt,
+    finishedAt: operation.finishedAt,
+    error: operation.error,
+  }).filter(([, value]) => value !== undefined));
+}
+
+function isJsonRpcIncoming(value: unknown): value is JsonRpcIncoming {
+  return !!value && typeof value === 'object' && (value as JsonRpcIncoming).jsonrpc === '2.0';
+}
+
+function isToolResult(value: unknown): value is ToolResult {
+  return !!value && typeof value === 'object' && Array.isArray((value as ToolResult).content);
+}

--- a/src/server/registry.ts
+++ b/src/server/registry.ts
@@ -1,0 +1,438 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { getCodeGraphDir, unsafeIndexRootReason } from '../directory';
+import type {
+  AddProjectInput,
+  GitProjectSource,
+  ProjectRecord,
+  ProjectSyncSchedule,
+  RegistryData,
+  UpdateProjectScheduleInput,
+} from './types';
+
+const REGISTRY_FILE = 'projects.json';
+
+export interface ProjectRegistryOptions {
+  dataDir: string;
+  projectsRoot: string;
+}
+
+export class ProjectRegistry {
+  private data: RegistryData;
+  readonly dataDir: string;
+  readonly projectsRoot: string;
+  readonly registryPath: string;
+
+  constructor(options: ProjectRegistryOptions) {
+    this.dataDir = path.resolve(options.dataDir);
+    this.projectsRoot = path.resolve(options.projectsRoot);
+    this.registryPath = path.join(this.dataDir, REGISTRY_FILE);
+
+    fs.mkdirSync(this.dataDir, { recursive: true });
+    fs.mkdirSync(this.projectsRoot, { recursive: true });
+    this.data = this.load();
+  }
+
+  list(): ProjectRecord[] {
+    return this.data.projects.map((project) => ({ ...project }));
+  }
+
+  get(id: string): ProjectRecord | null {
+    const project = this.data.projects.find((p) => p.id === id);
+    return project ? { ...project } : null;
+  }
+
+  getDefault(): ProjectRecord | null {
+    const project = this.data.projects.find((p) => p.isDefault) ?? this.data.projects[0];
+    return project ? { ...project } : null;
+  }
+
+  add(input: AddProjectInput): ProjectRecord {
+    const sourceType = input.sourceType ?? (input.remoteUrl ? 'git' : 'path');
+    const source = sourceType === 'git'
+      ? this.buildGitSource(input)
+      : { type: 'path' as const };
+    const projectPath = source.type === 'git'
+      ? this.resolveAllowedGitCheckoutPath(input.path, source.remoteUrl, input.name)
+      : this.resolveAllowedProjectPath(input.path ?? '');
+
+    const existing = this.data.projects.find((project) =>
+      project.path === projectPath ||
+      (source.type === 'git' && project.source.type === 'git' && project.source.remoteUrl === source.remoteUrl)
+    );
+    if (existing) {
+      const updated = {
+        ...existing,
+        name: input.name?.trim() || existing.name,
+        source,
+        syncSchedule: this.buildSchedule(input, existing.syncSchedule),
+        updatedAt: new Date().toISOString(),
+      };
+      this.replace(updated);
+      return { ...updated };
+    }
+
+    const now = new Date().toISOString();
+    const name = input.name?.trim() || path.basename(projectPath) || 'project';
+    const project: ProjectRecord = {
+      id: this.uniqueId(name, projectPath),
+      name,
+      path: projectPath,
+      source,
+      syncSchedule: this.buildSchedule(input),
+      createdAt: now,
+      updatedAt: now,
+      isDefault: input.makeDefault === true || this.data.projects.length === 0,
+    };
+
+    if (project.isDefault) {
+      this.data.projects = this.data.projects.map((p) => ({ ...p, isDefault: false }));
+    }
+    this.data.projects.push(project);
+    this.save();
+    return { ...project };
+  }
+
+  remove(id: string): ProjectRecord | null {
+    const project = this.data.projects.find((p) => p.id === id);
+    if (!project) return null;
+    this.data.projects = this.data.projects.filter((p) => p.id !== id);
+    if (project.isDefault && this.data.projects[0]) {
+      this.data.projects[0] = { ...this.data.projects[0], isDefault: true, updatedAt: new Date().toISOString() };
+    }
+    this.save();
+    return { ...project };
+  }
+
+  setDefault(id: string): ProjectRecord | null {
+    const found = this.data.projects.find((project) => project.id === id);
+    if (!found) return null;
+    const now = new Date().toISOString();
+    const selected: ProjectRecord = { ...found, isDefault: true, updatedAt: now };
+    this.data.projects = this.data.projects.map((project) => {
+      return project.id === id
+        ? selected
+        : { ...project, isDefault: false };
+    });
+    this.save();
+    return { ...selected };
+  }
+
+  updateSchedule(id: string, input: UpdateProjectScheduleInput): ProjectRecord | null {
+    const project = this.data.projects.find((p) => p.id === id);
+    if (!project) return null;
+    const interval = normalizeInterval(input.intervalMinutes, project.syncSchedule?.intervalMinutes);
+    const updated: ProjectRecord = {
+      ...project,
+      syncSchedule: {
+        ...project.syncSchedule,
+        enabled: input.enabled,
+        intervalMinutes: interval,
+        nextRunAt: input.enabled
+          ? nextRunAt(interval, new Date())
+          : project.syncSchedule?.nextRunAt,
+      },
+      updatedAt: new Date().toISOString(),
+    };
+    this.replace(updated);
+    return { ...updated };
+  }
+
+  markScheduleRun(id: string, status: 'succeeded' | 'failed', error?: string): ProjectRecord | null {
+    const project = this.data.projects.find((p) => p.id === id);
+    if (!project?.syncSchedule) return null;
+    const now = new Date();
+    const updated: ProjectRecord = {
+      ...project,
+      syncSchedule: {
+        ...project.syncSchedule,
+        lastRunAt: now.toISOString(),
+        lastStatus: status,
+        lastError: status === 'failed' ? error : undefined,
+        nextRunAt: project.syncSchedule.enabled
+          ? nextRunAt(project.syncSchedule.intervalMinutes, now)
+          : project.syncSchedule.nextRunAt,
+      },
+      updatedAt: now.toISOString(),
+    };
+    this.replace(updated);
+    return { ...updated };
+  }
+
+  resolveProjectRef(ref: string): ProjectRecord | null {
+    const trimmed = ref.trim();
+    if (!trimmed) return null;
+    const direct = this.data.projects.find((p) => p.id === trimmed || p.name === trimmed);
+    if (direct) return { ...direct };
+
+    let resolved: string | null = null;
+    try {
+      resolved = this.resolveAllowedProjectPath(trimmed);
+    } catch {
+      resolved = null;
+    }
+    if (!resolved) return null;
+
+    const byPath = this.data.projects.find((p) => p.path === resolved);
+    return byPath ? { ...byPath } : null;
+  }
+
+  resolveAllowedProjectPath(inputPath: string): string {
+    const raw = inputPath.trim();
+    if (!raw) {
+      throw new Error('Project path is required');
+    }
+    const candidate = path.isAbsolute(raw)
+      ? path.resolve(raw)
+      : path.resolve(this.projectsRoot, raw);
+
+    if (!fs.existsSync(candidate)) {
+      throw new Error(`Project path does not exist: ${candidate}`);
+    }
+    const stat = fs.statSync(candidate);
+    if (!stat.isDirectory()) {
+      throw new Error(`Project path must be a directory: ${candidate}`);
+    }
+
+    const root = realpath(this.projectsRoot);
+    const projectPath = realpath(candidate);
+    if (!isPathWithin(root, projectPath)) {
+      throw new Error(`Project path must be inside ${root}`);
+    }
+
+    const unsafe = unsafeIndexRootReason(projectPath);
+    if (unsafe) {
+      throw new Error(`Refusing to index ${projectPath} because it looks like ${unsafe}`);
+    }
+    return projectPath;
+  }
+
+  resolveAllowedGitCheckoutPath(inputPath: string | undefined, remoteUrl: string, name?: string): string {
+    const baseName = name?.trim() || repoNameFromRemote(remoteUrl);
+    const defaultPath = path.join('_repos', `${slugify(baseName)}-${shortHash(remoteUrl)}`);
+    const raw = inputPath?.trim() || defaultPath;
+    const candidate = path.isAbsolute(raw)
+      ? path.resolve(raw)
+      : path.resolve(this.projectsRoot, raw);
+    const root = realpath(this.projectsRoot);
+    const target = fs.existsSync(candidate) ? realpath(candidate) : realpathPotential(candidate);
+
+    if (!isPathWithin(root, target)) {
+      throw new Error(`Checkout path must be inside ${root}`);
+    }
+    if (target === root) {
+      throw new Error('Checkout path cannot be the projects root');
+    }
+
+    const unsafe = unsafeIndexRootReason(target);
+    if (unsafe) {
+      throw new Error(`Refusing to use ${target} because it looks like ${unsafe}`);
+    }
+    return target;
+  }
+
+  getIndexPath(project: ProjectRecord): string {
+    return getCodeGraphDir(project.path);
+  }
+
+  private load(): RegistryData {
+    if (!fs.existsSync(this.registryPath)) {
+      return { version: 1, projects: [] };
+    }
+    const parsed = JSON.parse(fs.readFileSync(this.registryPath, 'utf-8')) as Partial<RegistryData>;
+    if (parsed.version !== 1 || !Array.isArray(parsed.projects)) {
+      throw new Error(`Invalid CodeGraph server registry at ${this.registryPath}`);
+    }
+    return {
+      version: 1,
+      projects: parsed.projects.map((project) => this.normalizeLoadedProject(project)),
+    };
+  }
+
+  private normalizeLoadedProject(project: ProjectRecord): ProjectRecord {
+    return {
+      ...project,
+      source: project.source ?? { type: 'path' },
+      syncSchedule: project.syncSchedule
+        ? {
+          enabled: !!project.syncSchedule.enabled,
+          intervalMinutes: normalizeInterval(project.syncSchedule.intervalMinutes),
+          nextRunAt: project.syncSchedule.nextRunAt,
+          lastRunAt: project.syncSchedule.lastRunAt,
+          lastStatus: project.syncSchedule.lastStatus,
+          lastError: project.syncSchedule.lastError,
+        }
+        : undefined,
+    };
+  }
+
+  private buildGitSource(input: AddProjectInput): GitProjectSource {
+    const remoteUrl = input.remoteUrl?.trim();
+    if (!remoteUrl) {
+      throw new Error('Git remote URL is required');
+    }
+    if (!isAllowedGitRemote(remoteUrl)) {
+      throw new Error('Git remote must be an SSH or HTTPS URL');
+    }
+    if (remoteUrlContainsCredentials(remoteUrl)) {
+      throw new Error('Git remote URL must not contain embedded credentials; use a token environment variable instead');
+    }
+    const provider = input.provider ?? inferProvider(remoteUrl);
+    const credentialEnv = input.credentialEnv?.trim() || defaultCredentialEnv(provider);
+    validateCredentialEnv(credentialEnv);
+    const credentialUsername = input.credentialUsername?.trim();
+    return {
+      type: 'git',
+      provider,
+      remoteUrl,
+      branch: normalizeBranch(input.branch),
+      credentialEnv: credentialEnv || undefined,
+      credentialUsername: credentialUsername || undefined,
+    };
+  }
+
+  private buildSchedule(input: AddProjectInput, existing?: ProjectSyncSchedule): ProjectSyncSchedule | undefined {
+    const enabled = input.scheduleEnabled ?? existing?.enabled ?? false;
+    const rawInterval = input.scheduleIntervalMinutes ?? existing?.intervalMinutes;
+    const intervalMinutes = normalizeInterval(rawInterval);
+    if (!enabled && !existing) return undefined;
+    return {
+      enabled,
+      intervalMinutes,
+      nextRunAt: enabled
+        ? existing?.nextRunAt ?? nextRunAt(intervalMinutes, new Date())
+        : existing?.nextRunAt,
+      lastRunAt: existing?.lastRunAt,
+      lastStatus: existing?.lastStatus,
+      lastError: existing?.lastError,
+    };
+  }
+
+  private replace(project: ProjectRecord): void {
+    this.data.projects = this.data.projects.map((existing) =>
+      existing.id === project.id ? project : existing
+    );
+    if (project.isDefault) {
+      this.data.projects = this.data.projects.map((existing) =>
+        existing.id === project.id ? existing : { ...existing, isDefault: false }
+      );
+    }
+    this.save();
+  }
+
+  private save(): void {
+    const tmp = `${this.registryPath}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(this.data, null, 2) + '\n');
+    fs.renameSync(tmp, this.registryPath);
+  }
+
+  private uniqueId(name: string, projectPath: string): string {
+    const base = slugify(name || path.basename(projectPath) || 'project');
+    const hash = crypto.createHash('sha1').update(projectPath).digest('hex').slice(0, 8);
+    let id = `${base}-${hash}`;
+    let suffix = 2;
+    while (this.data.projects.some((project) => project.id === id)) {
+      id = `${base}-${hash}-${suffix++}`;
+    }
+    return id;
+  }
+}
+
+function slugify(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'project';
+}
+
+function repoNameFromRemote(remoteUrl: string): string {
+  const withoutTrailing = remoteUrl.replace(/\/+$/, '').replace(/\.git$/, '');
+  const lastSlash = Math.max(withoutTrailing.lastIndexOf('/'), withoutTrailing.lastIndexOf(':'));
+  const name = lastSlash >= 0 ? withoutTrailing.slice(lastSlash + 1) : withoutTrailing;
+  return name || 'repo';
+}
+
+function shortHash(value: string): string {
+  return crypto.createHash('sha1').update(value).digest('hex').slice(0, 8);
+}
+
+function normalizeBranch(branch: string | undefined): string | undefined {
+  const trimmed = branch?.trim();
+  return trimmed || undefined;
+}
+
+function normalizeInterval(value: number | undefined, fallback = 60): number {
+  const parsed = Number(value ?? fallback);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(1, Math.min(10080, Math.floor(parsed)));
+}
+
+function nextRunAt(intervalMinutes: number, from: Date): string {
+  return new Date(from.getTime() + intervalMinutes * 60_000).toISOString();
+}
+
+function isAllowedGitRemote(remoteUrl: string): boolean {
+  if (/^git@[^:]+:[^ ]+$/i.test(remoteUrl)) return true;
+  if (/^ssh:\/\/[^ ]+$/i.test(remoteUrl)) return true;
+  if (/^https:\/\/[^ ]+$/i.test(remoteUrl)) return true;
+  return false;
+}
+
+function remoteUrlContainsCredentials(remoteUrl: string): boolean {
+  if (!/^https:\/\//i.test(remoteUrl)) return false;
+  try {
+    const parsed = new URL(remoteUrl);
+    return !!parsed.username || !!parsed.password;
+  } catch {
+    return false;
+  }
+}
+
+function validateCredentialEnv(value: string | undefined): void {
+  if (!value) return;
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
+    throw new Error('Credential environment variable must be a valid env var name, not a token value');
+  }
+}
+
+function defaultCredentialEnv(provider: 'github' | 'gitlab' | 'generic'): string | undefined {
+  if (provider === 'github') return 'GITHUB_TOKEN';
+  if (provider === 'gitlab') return 'GITLAB_TOKEN';
+  return process.env.CODEGRAPH_GIT_TOKEN ? 'CODEGRAPH_GIT_TOKEN' : undefined;
+}
+
+function inferProvider(remoteUrl: string): 'github' | 'gitlab' | 'generic' {
+  const lower = remoteUrl.toLowerCase();
+  if (lower.includes('github')) return 'github';
+  if (lower.includes('gitlab')) return 'gitlab';
+  return 'generic';
+}
+
+function realpath(targetPath: string): string {
+  try {
+    return fs.realpathSync(targetPath);
+  } catch {
+    return path.resolve(targetPath);
+  }
+}
+
+function realpathPotential(targetPath: string): string {
+  const resolved = path.resolve(targetPath);
+  let current = resolved;
+  const missing: string[] = [];
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    missing.unshift(path.basename(current));
+    current = parent;
+  }
+  const base = realpath(current);
+  return path.join(base, ...missing);
+}
+
+function isPathWithin(root: string, target: string): boolean {
+  const relative = path.relative(root, target);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}

--- a/src/server/service.ts
+++ b/src/server/service.ts
@@ -1,0 +1,344 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import CodeGraph from '../index';
+import { getCodeGraphDir, isInitialized } from '../directory';
+import type { IndexResult } from '../extraction';
+import { ensureGitCheckout } from './git';
+import type { ProjectRegistry } from './registry';
+import type {
+  AddProjectInput,
+  OperationKind,
+  OperationState,
+  OperationTrigger,
+  ProjectRecord,
+  ProjectStatus,
+  ProjectSummary,
+  UpdateProjectScheduleInput,
+} from './types';
+
+export class ProjectService {
+  private operations = new Map<string, OperationState>();
+  private scheduler: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private registry: ProjectRegistry) {}
+
+  listProjects(): ProjectSummary[] {
+    return this.registry.list().map((project) => this.summarize(project));
+  }
+
+  getProject(id: string): ProjectSummary | null {
+    const project = this.registry.get(id);
+    return project ? this.summarize(project) : null;
+  }
+
+  addProject(input: AddProjectInput): ProjectSummary {
+    const project = this.registry.add(input);
+    return this.summarize(project);
+  }
+
+  removeProject(id: string): ProjectRecord | null {
+    if (this.isRunning(id)) {
+      throw new Error('Cannot remove a project while an operation is running');
+    }
+    this.operations.delete(id);
+    return this.registry.remove(id);
+  }
+
+  setDefault(id: string): ProjectSummary | null {
+    const project = this.registry.setDefault(id);
+    return project ? this.summarize(project) : null;
+  }
+
+  updateSchedule(id: string, input: UpdateProjectScheduleInput): ProjectSummary | null {
+    const project = this.registry.updateSchedule(id, input);
+    return project ? this.summarize(project) : null;
+  }
+
+  startScheduler(): void {
+    if (this.scheduler) return;
+    this.scheduler = setInterval(() => {
+      this.runDueSchedules();
+    }, 60_000);
+    this.scheduler.unref?.();
+    this.runDueSchedules();
+  }
+
+  stopScheduler(): void {
+    if (!this.scheduler) return;
+    clearInterval(this.scheduler);
+    this.scheduler = null;
+  }
+
+  getOperation(projectId: string): OperationState | null {
+    const operation = this.operations.get(projectId);
+    return operation ? cloneOperation(operation) : null;
+  }
+
+  startOperation(projectId: string, kind: OperationKind, trigger: OperationTrigger = 'manual'): OperationState {
+    const project = this.registry.get(projectId);
+    if (!project) {
+      throw new Error(`Unknown project: ${projectId}`);
+    }
+    const existing = this.operations.get(projectId);
+    if (existing?.status === 'running') {
+      throw new Error(`${existing.kind} is already running for ${project.name}`);
+    }
+
+    const operation: OperationState = {
+      id: `${kind}-${Date.now().toString(36)}`,
+      projectId,
+      kind,
+      status: 'running',
+      trigger,
+      startedAt: new Date().toISOString(),
+      logs: [],
+    };
+    this.operations.set(projectId, operation);
+    this.runOperation(project, operation).catch((err) => {
+      this.fail(operation, err instanceof Error ? err.message : String(err));
+    });
+    return cloneOperation(operation);
+  }
+
+  describeStatus(project: ProjectRecord): ProjectStatus {
+    const exists = fs.existsSync(project.path);
+    const base: ProjectStatus = {
+      initialized: false,
+      exists,
+      projectPath: project.path,
+      indexPath: getCodeGraphDir(project.path),
+      lastIndexed: null,
+      fileCount: 0,
+      nodeCount: 0,
+      edgeCount: 0,
+      dbSizeBytes: 0,
+      backend: null,
+      journalMode: null,
+      languages: [],
+      nodesByKind: {},
+      pendingChanges: { added: 0, modified: 0, removed: 0 },
+      reindexRecommended: false,
+    };
+
+    if (!exists && project.source.type !== 'git') {
+      return { ...base, error: 'Project path no longer exists' };
+    }
+    if (!exists) {
+      return base;
+    }
+    if (!isInitialized(project.path)) {
+      return base;
+    }
+
+    let cg: CodeGraph | null = null;
+    try {
+      cg = CodeGraph.openSync(project.path);
+      const stats = cg.getStats();
+      const changed = cg.getChangedFiles();
+      const lastIndexedMs = cg.getLastIndexedAt();
+      return {
+        ...base,
+        initialized: true,
+        lastIndexed: lastIndexedMs != null ? new Date(lastIndexedMs).toISOString() : null,
+        fileCount: stats.fileCount,
+        nodeCount: stats.nodeCount,
+        edgeCount: stats.edgeCount,
+        dbSizeBytes: stats.dbSizeBytes,
+        backend: cg.getBackend(),
+        journalMode: cg.getJournalMode(),
+        languages: Object.entries(stats.filesByLanguage)
+          .filter(([, count]) => count > 0)
+          .map(([language]) => language),
+        nodesByKind: stats.nodesByKind,
+        pendingChanges: {
+          added: changed.added.length,
+          modified: changed.modified.length,
+          removed: changed.removed.length,
+        },
+        reindexRecommended: cg.isIndexStale(),
+      };
+    } catch (err) {
+      return {
+        ...base,
+        initialized: true,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    } finally {
+      if (cg) {
+        try { cg.close(); } catch { /* ignore close failures in status */ }
+      }
+    }
+  }
+
+  private summarize(project: ProjectRecord): ProjectSummary {
+    const operation = this.operations.get(project.id);
+    return {
+      ...project,
+      status: this.describeStatus(project),
+      operation: operation ? cloneOperation(operation) : undefined,
+      mcpPath: `/mcp/${encodeURIComponent(project.id)}`,
+    };
+  }
+
+  private async runOperation(project: ProjectRecord, operation: OperationState): Promise<void> {
+    this.log(operation, `Starting ${operation.kind} for ${project.name}`);
+    await this.prepareSource(project, operation);
+    switch (operation.kind) {
+      case 'init':
+        await this.initProject(project, operation);
+        break;
+      case 'index':
+        await this.indexProject(project, operation);
+        break;
+      case 'sync':
+        if (isInitialized(project.path)) {
+          await this.syncProject(project, operation);
+        } else {
+          this.log(operation, 'Project is not initialized; building the initial index');
+          await this.indexProject(project, operation);
+        }
+        break;
+    }
+    operation.status = 'succeeded';
+    operation.finishedAt = new Date().toISOString();
+    this.log(operation, `${operation.kind} completed`);
+    if (operation.trigger === 'schedule') {
+      this.registry.markScheduleRun(project.id, 'succeeded');
+    }
+  }
+
+  private async prepareSource(project: ProjectRecord, operation: OperationState): Promise<void> {
+    if (project.source.type !== 'git') return;
+    await ensureGitCheckout(project, (message) => this.log(operation, message));
+  }
+
+  private async initProject(project: ProjectRecord, operation: OperationState): Promise<void> {
+    if (isInitialized(project.path)) {
+      this.log(operation, 'Project is already initialized');
+      operation.result = this.describeStatus(project);
+      return;
+    }
+    let cg: CodeGraph | null = null;
+    try {
+      cg = await CodeGraph.init(project.path, { index: false });
+      this.log(operation, `Created ${path.relative(project.path, getCodeGraphDir(project.path)) || '.codegraph'}`);
+      const result = await cg.indexAll({ onProgress: (progress) => this.logProgress(operation, progress) });
+      operation.result = compactIndexResult(result);
+      if (!result.success) {
+        throw new Error('Initial indexing failed');
+      }
+    } finally {
+      if (cg) cg.close();
+    }
+  }
+
+  private async indexProject(project: ProjectRecord, operation: OperationState): Promise<void> {
+    let cg: CodeGraph | null = null;
+    try {
+      if (!isInitialized(project.path)) {
+        cg = await CodeGraph.init(project.path, { index: false });
+        this.log(operation, 'Initialized project before indexing');
+      } else {
+        cg = await CodeGraph.open(project.path);
+        cg.clear();
+        this.log(operation, 'Cleared existing graph for a full rebuild');
+      }
+      const result = await cg.indexAll({ onProgress: (progress) => this.logProgress(operation, progress) });
+      operation.result = compactIndexResult(result);
+      if (!result.success) {
+        throw new Error('Indexing failed');
+      }
+    } finally {
+      if (cg) cg.close();
+    }
+  }
+
+  private async syncProject(project: ProjectRecord, operation: OperationState): Promise<void> {
+    if (!isInitialized(project.path)) {
+      throw new Error('Project is not initialized');
+    }
+    let cg: CodeGraph | null = null;
+    try {
+      cg = await CodeGraph.open(project.path);
+      const result = await cg.sync({ onProgress: (progress) => this.logProgress(operation, progress) });
+      operation.result = result;
+      const changed = result.filesAdded + result.filesModified + result.filesRemoved;
+      this.log(operation, `Synced ${changed} changed file(s)`);
+    } finally {
+      if (cg) cg.close();
+    }
+  }
+
+  private logProgress(
+    operation: OperationState,
+    progress: { phase: string; current: number; total: number; currentFile?: string },
+  ): void {
+    if (progress.total > 0) {
+      const pct = Math.floor((progress.current / progress.total) * 100);
+      if (pct % 10 === 0 || progress.current === progress.total) {
+        this.log(operation, `${progress.phase}: ${progress.current}/${progress.total} (${pct}%)`);
+      }
+    } else if (progress.current > 0 && progress.current % 500 === 0) {
+      this.log(operation, `${progress.phase}: ${progress.current} file(s)`);
+    }
+  }
+
+  private fail(operation: OperationState, message: string): void {
+    operation.status = 'failed';
+    operation.error = message;
+    operation.finishedAt = new Date().toISOString();
+    this.log(operation, `Failed: ${message}`);
+    if (operation.trigger === 'schedule') {
+      this.registry.markScheduleRun(operation.projectId, 'failed', message);
+    }
+  }
+
+  private log(operation: OperationState, message: string): void {
+    const timestamp = new Date().toISOString();
+    operation.logs.push(`${timestamp} ${message}`);
+    if (operation.logs.length > 400) {
+      operation.logs.splice(0, operation.logs.length - 400);
+    }
+  }
+
+  private isRunning(projectId: string): boolean {
+    return this.operations.get(projectId)?.status === 'running';
+  }
+
+  private runDueSchedules(): void {
+    const now = Date.now();
+    for (const project of this.registry.list()) {
+      const schedule = project.syncSchedule;
+      if (!schedule?.enabled) continue;
+      const nextRun = schedule.nextRunAt ? Date.parse(schedule.nextRunAt) : 0;
+      if (Number.isFinite(nextRun) && nextRun > now) continue;
+      if (this.isRunning(project.id)) continue;
+      try {
+        this.startOperation(project.id, 'sync', 'schedule');
+      } catch {
+        // The project may have been removed or started manually between list()
+        // and scheduling. The next scheduler tick will re-evaluate.
+      }
+    }
+  }
+}
+
+function compactIndexResult(result: IndexResult): unknown {
+  return {
+    success: result.success,
+    filesIndexed: result.filesIndexed,
+    filesSkipped: result.filesSkipped,
+    filesErrored: result.filesErrored,
+    nodesCreated: result.nodesCreated,
+    edgesCreated: result.edgesCreated,
+    durationMs: result.durationMs,
+    errors: result.errors.slice(0, 20),
+  };
+}
+
+function cloneOperation(operation: OperationState): OperationState {
+  return {
+    ...operation,
+    logs: [...operation.logs],
+  };
+}

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,0 +1,106 @@
+export interface ProjectRecord {
+  id: string;
+  name: string;
+  path: string;
+  source: ProjectSource;
+  syncSchedule?: ProjectSyncSchedule;
+  createdAt: string;
+  updatedAt: string;
+  isDefault?: boolean;
+}
+
+export type ProjectSource = PathProjectSource | GitProjectSource;
+
+export interface PathProjectSource {
+  type: 'path';
+}
+
+export type GitProvider = 'github' | 'gitlab' | 'generic';
+
+export interface GitProjectSource {
+  type: 'git';
+  provider: GitProvider;
+  remoteUrl: string;
+  branch?: string;
+  credentialEnv?: string;
+  credentialUsername?: string;
+}
+
+export interface ProjectSyncSchedule {
+  enabled: boolean;
+  intervalMinutes: number;
+  nextRunAt?: string;
+  lastRunAt?: string;
+  lastStatus?: 'succeeded' | 'failed';
+  lastError?: string;
+}
+
+export interface AddProjectInput {
+  sourceType?: 'path' | 'git';
+  name?: string;
+  path?: string;
+  provider?: GitProvider;
+  remoteUrl?: string;
+  branch?: string;
+  credentialEnv?: string;
+  credentialUsername?: string;
+  makeDefault?: boolean;
+  scheduleEnabled?: boolean;
+  scheduleIntervalMinutes?: number;
+}
+
+export interface UpdateProjectScheduleInput {
+  enabled: boolean;
+  intervalMinutes?: number;
+}
+
+export interface RegistryData {
+  version: 1;
+  projects: ProjectRecord[];
+}
+
+export interface ProjectStatus {
+  initialized: boolean;
+  exists: boolean;
+  projectPath: string;
+  indexPath: string;
+  lastIndexed: string | null;
+  fileCount: number;
+  nodeCount: number;
+  edgeCount: number;
+  dbSizeBytes: number;
+  backend: string | null;
+  journalMode: string | null;
+  languages: string[];
+  nodesByKind: Record<string, number>;
+  pendingChanges: {
+    added: number;
+    modified: number;
+    removed: number;
+  };
+  reindexRecommended: boolean;
+  error?: string;
+}
+
+export interface ProjectSummary extends ProjectRecord {
+  status: ProjectStatus;
+  operation?: OperationState;
+  mcpPath: string;
+}
+
+export type OperationKind = 'init' | 'index' | 'sync';
+export type OperationStatus = 'running' | 'succeeded' | 'failed';
+export type OperationTrigger = 'manual' | 'schedule';
+
+export interface OperationState {
+  id: string;
+  projectId: string;
+  kind: OperationKind;
+  status: OperationStatus;
+  trigger: OperationTrigger;
+  startedAt: string;
+  finishedAt?: string;
+  logs: string[];
+  result?: unknown;
+  error?: string;
+}

--- a/src/server/ui.ts
+++ b/src/server/ui.ts
@@ -1,0 +1,893 @@
+export function renderIndexHtml(): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CodeGraph Server</title>
+  <link rel="stylesheet" href="/assets/app.css">
+  <script src="/assets/app.js" defer></script>
+</head>
+<body>
+  <div class="shell">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">CodeGraph</p>
+        <h1>Project Index Server</h1>
+      </div>
+      <div class="top-actions">
+        <div id="health" class="status-pill">Checking</div>
+        <button id="refreshBtn" class="icon-button" type="button" aria-label="Refresh projects" title="Refresh"></button>
+      </div>
+    </header>
+
+    <section id="tokenPanel" class="auth-panel hidden" aria-live="polite">
+      <label for="tokenInput">Access token</label>
+      <input id="tokenInput" type="password" autocomplete="current-password" placeholder="Bearer token">
+      <button id="saveTokenBtn" type="button">Apply</button>
+    </section>
+
+    <main class="layout">
+      <aside class="sidebar" aria-label="Projects">
+        <form id="addProjectForm" class="project-form">
+          <div class="field">
+            <label for="sourceType">Source</label>
+            <select id="sourceType" name="sourceType">
+              <option value="path">Mounted path</option>
+              <option value="git">Git remote</option>
+            </select>
+          </div>
+          <div class="field git-field hidden">
+            <label for="provider">Provider</label>
+            <select id="provider" name="provider">
+              <option value="gitlab">GitLab</option>
+              <option value="github">GitHub</option>
+              <option value="generic">Generic Git</option>
+            </select>
+          </div>
+          <div class="field git-field hidden">
+            <label for="remoteUrl">Remote URL</label>
+            <input id="remoteUrl" name="remoteUrl" placeholder="git@gitlab.internal:team/service.git">
+          </div>
+          <div class="field">
+            <label id="projectPathLabel" for="projectPath">Project path</label>
+            <input id="projectPath" name="path" placeholder="/projects/service-a">
+          </div>
+          <div class="field">
+            <label for="projectName">Display name</label>
+            <input id="projectName" name="name" placeholder="service-a">
+          </div>
+          <div class="field git-field hidden">
+            <label for="branch">Branch</label>
+            <input id="branch" name="branch" placeholder="main">
+          </div>
+          <div class="field git-field hidden">
+            <label for="credentialEnv">Token env var</label>
+            <input id="credentialEnv" name="credentialEnv" placeholder="GITLAB_TOKEN">
+          </div>
+          <div class="field git-field hidden">
+            <label for="credentialUsername">Token username</label>
+            <input id="credentialUsername" name="credentialUsername" placeholder="oauth2">
+          </div>
+          <div class="schedule-row">
+            <label><input id="addScheduleEnabled" type="checkbox"> Scheduled sync</label>
+            <input id="addScheduleInterval" type="number" min="1" value="60" aria-label="Sync interval minutes">
+          </div>
+          <button type="submit" class="primary-action" id="addProjectBtn"></button>
+        </form>
+        <div class="sidebar-heading">
+          <span>Registered Projects</span>
+          <span id="projectCount">0</span>
+        </div>
+        <div id="projectList" class="project-list"></div>
+      </aside>
+
+      <section class="workspace" aria-live="polite">
+        <div id="emptyState" class="empty-state">
+          <h2>No project selected</h2>
+          <p>Add a mounted repository path, then index it.</p>
+        </div>
+
+        <div id="projectDetail" class="detail hidden">
+          <div class="detail-header">
+            <div>
+              <p id="selectedPath" class="path-label"></p>
+              <h2 id="selectedName"></h2>
+            </div>
+            <div class="action-row">
+              <button id="initBtn" type="button"></button>
+              <button id="indexBtn" type="button"></button>
+              <button id="syncBtn" type="button"></button>
+              <button id="defaultBtn" type="button"></button>
+              <button id="removeBtn" class="danger" type="button"></button>
+            </div>
+          </div>
+
+          <div id="statusBanner" class="status-banner"></div>
+
+          <div class="metric-grid">
+            <div class="metric"><span>Files</span><strong id="metricFiles">0</strong></div>
+            <div class="metric"><span>Nodes</span><strong id="metricNodes">0</strong></div>
+            <div class="metric"><span>Edges</span><strong id="metricEdges">0</strong></div>
+            <div class="metric"><span>Database</span><strong id="metricDb">0 MB</strong></div>
+          </div>
+
+          <div class="split">
+            <section class="panel">
+              <div class="panel-title">MCP Endpoint</div>
+              <div class="copy-row">
+                <input id="mcpEndpoint" readonly>
+                <button id="copyMcpBtn" class="icon-button" type="button" aria-label="Copy MCP endpoint" title="Copy endpoint"></button>
+              </div>
+              <dl class="facts">
+                <div><dt>Last indexed</dt><dd id="lastIndexed">Never</dd></div>
+                <div><dt>Journal</dt><dd id="journalMode">Unknown</dd></div>
+                <div><dt>Pending</dt><dd id="pendingChanges">0</dd></div>
+              </dl>
+            </section>
+
+            <section class="panel">
+              <div class="panel-title">Languages</div>
+              <div id="languageList" class="tag-list"></div>
+            </section>
+
+            <section class="panel">
+              <div class="panel-title">Source & Schedule</div>
+              <dl class="facts compact-facts">
+                <div><dt>Source</dt><dd id="sourceKind">Path</dd></div>
+                <div><dt>Remote</dt><dd id="remoteDetail">-</dd></div>
+                <div><dt>Branch</dt><dd id="branchDetail">-</dd></div>
+                <div><dt>Credential</dt><dd id="credentialDetail">-</dd></div>
+                <div><dt>Next sync</dt><dd id="nextRunAt">Manual</dd></div>
+              </dl>
+              <div class="schedule-editor">
+                <label><input id="scheduleEnabled" type="checkbox"> Scheduled sync</label>
+                <input id="scheduleInterval" type="number" min="1" aria-label="Sync interval minutes">
+                <button id="scheduleSaveBtn" class="icon-button" type="button" aria-label="Save schedule" title="Save schedule"></button>
+              </div>
+            </section>
+          </div>
+
+          <section class="panel log-panel">
+            <div class="panel-title">Operation Log</div>
+            <pre id="operationLog"></pre>
+          </section>
+        </div>
+      </section>
+    </main>
+  </div>
+</body>
+</html>`;
+}
+
+export const APP_CSS = `
+:root {
+  color-scheme: light;
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --surface-strong: #f0f4f8;
+  --line: #d6dee8;
+  --line-strong: #b9c5d3;
+  --text: #111827;
+  --muted: #5b6675;
+  --primary: #1769aa;
+  --primary-strong: #0f4f86;
+  --green: #1f8a4c;
+  --amber: #a26312;
+  --red: #b42318;
+  --shadow: 0 10px 28px rgba(15, 23, 42, .08);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-width: 320px;
+}
+
+button, input, select { font: inherit; }
+button {
+  min-height: 44px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 0 14px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: border-color 180ms ease, background 180ms ease, color 180ms ease;
+}
+button:hover { border-color: var(--primary); }
+button:focus-visible, input:focus-visible {
+  outline: 3px solid rgba(23, 105, 170, .24);
+  outline-offset: 2px;
+}
+button:disabled {
+  opacity: .55;
+  cursor: not-allowed;
+}
+button svg { width: 18px; height: 18px; flex: 0 0 18px; }
+
+.shell { min-height: 100vh; }
+.topbar {
+  min-height: 76px;
+  padding: 16px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, .92);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(10px);
+}
+.eyebrow {
+  margin: 0 0 2px;
+  color: var(--primary);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+h1, h2, p { margin-top: 0; }
+h1 { margin-bottom: 0; font-size: 24px; line-height: 1.2; }
+h2 { margin-bottom: 0; font-size: 22px; line-height: 1.25; }
+.top-actions, .action-row, .copy-row { display: flex; align-items: center; gap: 10px; }
+.status-pill {
+  min-height: 36px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: var(--surface-strong);
+  border: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 14px;
+}
+.status-pill.ok { color: var(--green); border-color: rgba(31, 138, 76, .35); background: #eef8f1; }
+.status-pill.bad { color: var(--red); border-color: rgba(180, 35, 24, .35); background: #fff2f0; }
+.icon-button { width: 44px; padding: 0; }
+
+.auth-panel {
+  margin: 16px 24px 0;
+  padding: 14px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  display: grid;
+  grid-template-columns: auto minmax(160px, 360px) 120px;
+  align-items: center;
+  gap: 12px;
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 360px minmax(0, 1fr);
+  gap: 20px;
+  padding: 20px 24px 28px;
+}
+.sidebar, .workspace {
+  min-width: 0;
+}
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.project-form, .panel, .empty-state {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+.project-form { padding: 16px; display: grid; gap: 12px; }
+.field { display: grid; gap: 6px; }
+label, .panel-title, .sidebar-heading {
+  font-size: 13px;
+  font-weight: 700;
+  color: #344054;
+}
+input {
+  min-height: 44px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 12px;
+  color: var(--text);
+  background: #fff;
+  width: 100%;
+}
+select {
+  min-height: 44px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 36px 0 12px;
+  color: var(--text);
+  background: #fff;
+  width: 100%;
+  cursor: pointer;
+}
+input[type="checkbox"] {
+  width: 18px;
+  min-height: 18px;
+  height: 18px;
+  accent-color: var(--primary);
+}
+.primary-action {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+.primary-action:hover { background: var(--primary-strong); border-color: var(--primary-strong); }
+.danger { color: var(--red); border-color: rgba(180, 35, 24, .35); }
+.sidebar-heading {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 2px;
+}
+.project-list {
+  display: grid;
+  gap: 8px;
+}
+.project-item {
+  min-height: 72px;
+  width: 100%;
+  text-align: left;
+  justify-content: flex-start;
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr);
+  gap: 12px;
+  padding: 12px;
+}
+.project-item.active {
+  border-color: var(--primary);
+  background: #edf6ff;
+}
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-top: 6px;
+  background: var(--line-strong);
+}
+.dot.ready { background: var(--green); }
+.dot.running { background: var(--amber); }
+.dot.error { background: var(--red); }
+.project-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.project-title strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.default-mark {
+  font-size: 12px;
+  color: var(--primary);
+  border: 1px solid rgba(23,105,170,.25);
+  border-radius: 999px;
+  padding: 2px 6px;
+}
+.project-path {
+  color: var(--muted);
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 2px;
+}
+
+.workspace { display: block; }
+.empty-state { min-height: 280px; display: grid; place-content: center; text-align: center; padding: 24px; }
+.empty-state p { color: var(--muted); margin: 8px 0 0; }
+.detail { display: grid; gap: 16px; }
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+.path-label {
+  color: var(--muted);
+  margin-bottom: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  word-break: break-all;
+}
+.action-row { flex-wrap: wrap; justify-content: flex-end; }
+.status-banner {
+  min-height: 46px;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--muted);
+}
+.status-banner.ready { color: var(--green); background: #eef8f1; border-color: rgba(31,138,76,.28); }
+.status-banner.running { color: var(--amber); background: #fff7eb; border-color: rgba(162,99,18,.32); }
+.status-banner.error { color: var(--red); background: #fff2f0; border-color: rgba(180,35,24,.28); }
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(120px, 1fr));
+  gap: 12px;
+}
+.metric {
+  min-height: 92px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  display: grid;
+  align-content: space-between;
+}
+.metric span { color: var(--muted); font-size: 13px; }
+.metric strong { font-size: 26px; line-height: 1.1; }
+.split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+.panel { padding: 16px; min-width: 0; }
+.panel-title { margin-bottom: 12px; }
+.copy-row input {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+}
+.facts {
+  margin: 14px 0 0;
+  display: grid;
+  gap: 10px;
+}
+.facts div {
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr);
+  gap: 12px;
+}
+.compact-facts div { grid-template-columns: 92px minmax(0, 1fr); }
+dt { color: var(--muted); }
+dd { margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.schedule-row, .schedule-editor {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 86px;
+  gap: 10px;
+  align-items: center;
+}
+.schedule-row label, .schedule-editor label {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+}
+.schedule-editor {
+  grid-template-columns: minmax(0, 1fr) 86px 44px;
+  margin-top: 14px;
+}
+.schedule-row input[type="number"], .schedule-editor input[type="number"] {
+  text-align: right;
+}
+.tag-list { display: flex; gap: 8px; flex-wrap: wrap; min-height: 32px; }
+.tag {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--line);
+  background: var(--surface-strong);
+  border-radius: 999px;
+  padding: 4px 9px;
+  font-size: 13px;
+}
+.log-panel pre {
+  margin: 0;
+  min-height: 180px;
+  max-height: 320px;
+  overflow: auto;
+  padding: 12px;
+  background: #101828;
+  color: #e6edf3;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+.hidden { display: none !important; }
+
+@media (max-width: 980px) {
+  .layout { grid-template-columns: 1fr; }
+  .sidebar { order: 2; }
+  .workspace { order: 1; }
+  .metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .split { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 640px) {
+  .topbar { padding: 14px 16px; align-items: flex-start; }
+  .layout { padding: 16px; }
+  .top-actions { flex-wrap: wrap; justify-content: flex-end; }
+  h1 { font-size: 21px; }
+  .auth-panel { margin: 12px 16px 0; grid-template-columns: 1fr; }
+  .detail-header { display: grid; }
+  .action-row { justify-content: stretch; }
+  .action-row button { flex: 1 1 136px; }
+  .metric-grid { grid-template-columns: 1fr; }
+  .schedule-row, .schedule-editor { grid-template-columns: 1fr; }
+  .facts div { grid-template-columns: 1fr; gap: 2px; }
+}
+`;
+
+export const APP_JS = `
+(function () {
+  var state = { config: null, projects: [], selectedId: null, token: localStorage.getItem('codegraphToken') || '' };
+
+  var els = {};
+  document.addEventListener('DOMContentLoaded', function () {
+    [
+      'health','refreshBtn','tokenPanel','tokenInput','saveTokenBtn','addProjectForm','sourceType','provider',
+      'remoteUrl','projectPath','projectPathLabel','projectName','branch','credentialEnv','credentialUsername',
+      'addScheduleEnabled','addScheduleInterval',
+      'addProjectBtn','projectCount','projectList','emptyState','projectDetail','selectedPath','selectedName',
+      'initBtn','indexBtn','syncBtn','defaultBtn','removeBtn','statusBanner','metricFiles','metricNodes',
+      'metricEdges','metricDb','mcpEndpoint','copyMcpBtn','lastIndexed','journalMode','pendingChanges',
+      'languageList','sourceKind','remoteDetail','branchDetail','credentialDetail','nextRunAt',
+      'scheduleEnabled','scheduleInterval','scheduleSaveBtn','operationLog'
+    ].forEach(function (id) { els[id] = document.getElementById(id); });
+
+    setButton(els.refreshBtn, 'refresh', '');
+    setButton(els.addProjectBtn, 'plus', 'Add Project');
+    setButton(els.initBtn, 'circle', 'Init');
+    setButton(els.indexBtn, 'play', 'Index');
+    setButton(els.syncBtn, 'refresh', 'Sync');
+    setButton(els.defaultBtn, 'pin', 'Default');
+    setButton(els.removeBtn, 'trash', 'Remove');
+    setButton(els.copyMcpBtn, 'copy', '');
+    setButton(els.scheduleSaveBtn, 'save', '');
+
+    els.tokenInput.value = state.token;
+    els.sourceType.addEventListener('change', updateSourceFields);
+    els.provider.addEventListener('change', updateCredentialPlaceholder);
+    els.refreshBtn.addEventListener('click', loadProjects);
+    els.saveTokenBtn.addEventListener('click', saveToken);
+    els.addProjectForm.addEventListener('submit', addProject);
+    els.initBtn.addEventListener('click', function () { runOperation('init'); });
+    els.indexBtn.addEventListener('click', function () { runOperation('index'); });
+    els.syncBtn.addEventListener('click', function () { runOperation('sync'); });
+    els.defaultBtn.addEventListener('click', setDefaultProject);
+    els.removeBtn.addEventListener('click', removeProject);
+    els.copyMcpBtn.addEventListener('click', copyMcpEndpoint);
+    els.scheduleSaveBtn.addEventListener('click', saveSchedule);
+
+    updateSourceFields();
+    updateCredentialPlaceholder();
+    boot();
+    window.setInterval(function () {
+      if (state.projects.some(function (p) { return p.operation && p.operation.status === 'running'; })) {
+        loadProjects(true);
+      }
+    }, 3500);
+  });
+
+  function icon(name) {
+    var paths = {
+      refresh: '<path d="M21 12a9 9 0 0 1-15.5 6.2"/><path d="M3 12A9 9 0 0 1 18.5 5.8"/><path d="M18 3v4h4"/><path d="M6 21v-4H2"/>',
+      plus: '<path d="M12 5v14"/><path d="M5 12h14"/>',
+      play: '<path d="M8 5v14l11-7z"/>',
+      circle: '<circle cx="12" cy="12" r="8"/><path d="M12 8v8"/><path d="M8 12h8"/>',
+      pin: '<path d="M12 17v5"/><path d="M5 17h14"/><path d="m7 17 2-9h6l2 9"/><path d="M9 4h6"/>',
+      trash: '<path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/>',
+      copy: '<rect x="9" y="9" width="11" height="11" rx="2"/><rect x="4" y="4" width="11" height="11" rx="2"/>',
+      save: '<path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><path d="M17 21v-8H7v8"/><path d="M7 3v5h8"/>'
+    };
+    return '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' + (paths[name] || '') + '</svg>';
+  }
+
+  function setButton(button, iconName, text) {
+    button.innerHTML = icon(iconName) + (text ? '<span>' + text + '</span>' : '');
+  }
+
+  async function boot() {
+    try {
+      state.config = await request('/api/config', { skipAuth: true });
+      if (state.config.adminAuthRequired) {
+        els.tokenPanel.classList.remove('hidden');
+      }
+      if (state.config.projectsRoot) {
+        els.projectPath.placeholder = state.config.projectsRoot + '/service-a';
+      }
+      await loadProjects();
+      setHealth(true);
+    } catch (err) {
+      setHealth(false, err.message);
+    }
+  }
+
+  function updateSourceFields() {
+    var isGit = els.sourceType.value === 'git';
+    document.querySelectorAll('.git-field').forEach(function (node) {
+      node.classList.toggle('hidden', !isGit);
+    });
+    els.projectPathLabel.textContent = isGit ? 'Checkout path' : 'Project path';
+    els.projectPath.required = !isGit;
+    els.remoteUrl.required = isGit;
+    if (isGit) {
+      els.projectPath.placeholder = '_repos/service-a';
+    } else if (state.config && state.config.projectsRoot) {
+      els.projectPath.placeholder = state.config.projectsRoot + '/service-a';
+    }
+  }
+
+  function updateCredentialPlaceholder() {
+    if (els.provider.value === 'github') {
+      els.credentialEnv.placeholder = 'GITHUB_TOKEN';
+      els.credentialUsername.placeholder = 'x-access-token';
+    } else if (els.provider.value === 'gitlab') {
+      els.credentialEnv.placeholder = 'GITLAB_TOKEN';
+      els.credentialUsername.placeholder = 'oauth2';
+    } else {
+      els.credentialEnv.placeholder = 'CODEGRAPH_GIT_TOKEN';
+      els.credentialUsername.placeholder = 'git';
+    }
+  }
+
+  function saveToken() {
+    state.token = els.tokenInput.value.trim();
+    localStorage.setItem('codegraphToken', state.token);
+    loadProjects();
+  }
+
+  async function loadProjects(quiet) {
+    try {
+      var data = await request('/api/projects');
+      state.projects = data.projects || [];
+      if (!state.selectedId && state.projects[0]) state.selectedId = state.projects[0].id;
+      if (state.selectedId && !state.projects.some(function (p) { return p.id === state.selectedId; })) {
+        state.selectedId = state.projects[0] ? state.projects[0].id : null;
+      }
+      render();
+      setHealth(true);
+    } catch (err) {
+      if (!quiet) setHealth(false, err.message);
+      render();
+    }
+  }
+
+  async function addProject(event) {
+    event.preventDefault();
+    var sourceType = els.sourceType.value === 'git' ? 'git' : 'path';
+    var body = {
+      sourceType: sourceType,
+      path: els.projectPath.value.trim(),
+      name: els.projectName.value.trim(),
+      scheduleEnabled: els.addScheduleEnabled.checked,
+      scheduleIntervalMinutes: Number(els.addScheduleInterval.value || 60)
+    };
+    if (sourceType === 'git') {
+      body.provider = els.provider.value;
+      body.remoteUrl = els.remoteUrl.value.trim();
+      body.branch = els.branch.value.trim();
+      body.credentialEnv = els.credentialEnv.value.trim();
+      body.credentialUsername = els.credentialUsername.value.trim();
+      if (!body.remoteUrl) return;
+      if (!body.path) delete body.path;
+    } else if (!body.path) {
+      return;
+    }
+    await request('/api/projects', { method: 'POST', body: body });
+    els.projectPath.value = '';
+    els.projectName.value = '';
+    els.remoteUrl.value = '';
+    els.branch.value = '';
+    els.credentialEnv.value = '';
+    els.credentialUsername.value = '';
+    await loadProjects();
+  }
+
+  async function runOperation(kind) {
+    var selected = getSelected();
+    if (!selected) return;
+    await request('/api/projects/' + encodeURIComponent(selected.id) + '/' + kind, { method: 'POST' });
+    await loadProjects();
+  }
+
+  async function setDefaultProject() {
+    var selected = getSelected();
+    if (!selected) return;
+    await request('/api/projects/' + encodeURIComponent(selected.id) + '/default', { method: 'POST' });
+    await loadProjects();
+  }
+
+  async function removeProject() {
+    var selected = getSelected();
+    if (!selected) return;
+    if (!window.confirm('Remove ' + selected.name + ' from this server registry?')) return;
+    await request('/api/projects/' + encodeURIComponent(selected.id), { method: 'DELETE' });
+    state.selectedId = null;
+    await loadProjects();
+  }
+
+  async function copyMcpEndpoint() {
+    var value = els.mcpEndpoint.value;
+    if (!value) return;
+    await navigator.clipboard.writeText(value);
+  }
+
+  async function saveSchedule() {
+    var selected = getSelected();
+    if (!selected) return;
+    await request('/api/projects/' + encodeURIComponent(selected.id) + '/schedule', {
+      method: 'POST',
+      body: {
+        enabled: els.scheduleEnabled.checked,
+        intervalMinutes: Number(els.scheduleInterval.value || 60)
+      }
+    });
+    await loadProjects();
+  }
+
+  function render() {
+    els.projectCount.textContent = String(state.projects.length);
+    els.projectList.innerHTML = '';
+    state.projects.forEach(function (project) {
+      var button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'project-item' + (project.id === state.selectedId ? ' active' : '');
+      button.innerHTML =
+        '<span class="dot ' + projectClass(project) + '"></span>' +
+        '<span>' +
+          '<span class="project-title"><strong>' + escapeHtml(project.name) + '</strong>' +
+          (project.isDefault ? '<span class="default-mark">default</span>' : '') + '</span>' +
+          '<span class="project-path">' + escapeHtml(projectListSubtitle(project)) + '</span>' +
+        '</span>';
+      button.addEventListener('click', function () {
+        state.selectedId = project.id;
+        render();
+      });
+      els.projectList.appendChild(button);
+    });
+    renderSelected();
+  }
+
+  function renderSelected() {
+    var project = getSelected();
+    els.emptyState.classList.toggle('hidden', !!project);
+    els.projectDetail.classList.toggle('hidden', !project);
+    if (!project) return;
+
+    var status = project.status || {};
+    var source = project.source || { type: 'path' };
+    var op = project.operation;
+    var running = op && op.status === 'running';
+    els.selectedName.textContent = project.name;
+    els.selectedPath.textContent = project.path;
+    els.metricFiles.textContent = formatNumber(status.fileCount || 0);
+    els.metricNodes.textContent = formatNumber(status.nodeCount || 0);
+    els.metricEdges.textContent = formatNumber(status.edgeCount || 0);
+    els.metricDb.textContent = formatBytes(status.dbSizeBytes || 0);
+    els.mcpEndpoint.value = window.location.origin + project.mcpPath;
+    els.lastIndexed.textContent = status.lastIndexed ? new Date(status.lastIndexed).toLocaleString() : 'Never';
+    els.journalMode.textContent = status.journalMode || 'Unknown';
+    els.pendingChanges.textContent = String((status.pendingChanges ? status.pendingChanges.added + status.pendingChanges.modified + status.pendingChanges.removed : 0));
+    renderSourceDetails(project);
+    els.languageList.innerHTML = '';
+    (status.languages || []).forEach(function (language) {
+      var tag = document.createElement('span');
+      tag.className = 'tag';
+      tag.textContent = language;
+      els.languageList.appendChild(tag);
+    });
+    if (!status.languages || status.languages.length === 0) {
+      els.languageList.innerHTML = '<span class="tag">No indexed files</span>';
+    }
+
+    els.initBtn.disabled = running || status.initialized;
+    els.indexBtn.disabled = running || (!status.exists && source.type !== 'git');
+    els.syncBtn.disabled = running || (!status.initialized && source.type !== 'git');
+    els.defaultBtn.disabled = running || project.isDefault;
+    els.removeBtn.disabled = running;
+    els.scheduleSaveBtn.disabled = running;
+
+    var bannerClass = '';
+    var bannerText = '';
+    if (running) {
+      bannerClass = 'running';
+      bannerText = op.kind + ' is running';
+    } else if (status.error) {
+      bannerClass = 'error';
+      bannerText = status.error;
+    } else if (status.initialized) {
+      bannerClass = 'ready';
+      bannerText = status.reindexRecommended ? 'Indexed; full rebuild recommended for this engine version' : 'Indexed and ready';
+    } else {
+      bannerText = 'Registered but not indexed';
+    }
+    els.statusBanner.className = 'status-banner ' + bannerClass;
+    els.statusBanner.textContent = bannerText;
+    els.operationLog.textContent = op && op.logs && op.logs.length ? op.logs.join('\\n') : 'No operation has run for this project.';
+  }
+
+  function renderSourceDetails(project) {
+    var source = project.source || { type: 'path' };
+    var schedule = project.syncSchedule || { enabled: false, intervalMinutes: 60 };
+    if (source.type === 'git') {
+      els.sourceKind.textContent = source.provider || 'git';
+      els.remoteDetail.textContent = source.remoteUrl || '-';
+      els.branchDetail.textContent = source.branch || 'default';
+      els.credentialDetail.textContent = source.credentialEnv || 'server git config';
+    } else {
+      els.sourceKind.textContent = 'path';
+      els.remoteDetail.textContent = project.path;
+      els.branchDetail.textContent = '-';
+      els.credentialDetail.textContent = '-';
+    }
+    els.scheduleEnabled.checked = !!schedule.enabled;
+    els.scheduleInterval.value = String(schedule.intervalMinutes || 60);
+    els.nextRunAt.textContent = schedule.enabled && schedule.nextRunAt
+      ? new Date(schedule.nextRunAt).toLocaleString()
+      : 'Manual';
+  }
+
+  function getSelected() {
+    return state.projects.find(function (project) { return project.id === state.selectedId; }) || null;
+  }
+
+  async function request(path, options) {
+    options = options || {};
+    var headers = { 'Accept': 'application/json' };
+    if (options.body !== undefined) headers['Content-Type'] = 'application/json';
+    if (!options.skipAuth && state.token) headers['Authorization'] = 'Bearer ' + state.token;
+    var response = await fetch(path, {
+      method: options.method || 'GET',
+      headers: headers,
+      body: options.body !== undefined ? JSON.stringify(options.body) : undefined
+    });
+    var text = await response.text();
+    var data = text ? JSON.parse(text) : {};
+    if (!response.ok) {
+      throw new Error(data.error || response.statusText);
+    }
+    return data;
+  }
+
+  function setHealth(ok, message) {
+    els.health.className = 'status-pill ' + (ok ? 'ok' : 'bad');
+    els.health.textContent = ok ? 'Online' : (message || 'Offline');
+  }
+
+  function projectClass(project) {
+    if (project.operation && project.operation.status === 'running') return 'running';
+    if (project.status && project.status.error) return 'error';
+    if (project.status && project.status.initialized) return 'ready';
+    return '';
+  }
+
+  function projectListSubtitle(project) {
+    var source = project.source || { type: 'path' };
+    if (source.type === 'git') {
+      return (source.branch ? source.branch + ' · ' : '') + source.remoteUrl;
+    }
+    return project.path;
+  }
+
+  function formatNumber(value) {
+    return Number(value || 0).toLocaleString();
+  }
+
+  function formatBytes(bytes) {
+    if (!bytes) return '0 MB';
+    return (bytes / 1024 / 1024).toFixed(2) + ' MB';
+  }
+
+  function escapeHtml(value) {
+    return String(value).replace(/[&<>"']/g, function (ch) {
+      return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[ch];
+    });
+  }
+})();
+`;


### PR DESCRIPTION
Adds a shared Docker/server mode for CodeGraph so teams can run a central CodeGraph service, manage indexed projects through a small UI, and expose registered project graphs over HTTP MCP endpoints.
What Changed
Added codegraph server CLI command for running the HTTP management server.
Added Docker support with Dockerfile, docker-compose.yml, /data persistence, and /projects project isolation.
Added a browser UI for adding, indexing, syncing, deleting, and scheduling projects.
Added support for mounted local projects and Git remotes from GitHub, GitLab, or generic Git servers.
Added Git checkout/sync flow with branch support and scheduled syncs.
Added secure credential handling by referencing environment variable names instead of storing token values.
Added authenticated admin API and MCP endpoints via CODEGRAPH_ADMIN_TOKEN and CODEGRAPH_MCP_TOKEN.
Added remote HTTP MCP endpoints at /mcp and /mcp/:projectId.
Added MCP project-path protection so clients can only query registered projects.
Exposed codegraph_status in tools/list.
Added codegraph_projects MCP discovery tool for listing registered projects and index status.
Added docs for Docker/server usage and MCP client connection.
Added tests for registry validation, schedules, Git credential env handling, MCP discovery, and default tool listing.
Validation
tsc --noEmit
vitest run __tests__/mcp-tool-allowlist.test.ts __tests__/server-mcp-http.test.ts