### PR TITLE
feat(resolution): resolve this.<field>.method() on the field's declared type (TS/JS)

### DIFF
--- a/__tests__/ts-di-method-resolution.test.ts
+++ b/__tests__/ts-di-method-resolution.test.ts
@@ -1,0 +1,133 @@
+/**
+ * TS/JS `this.<field>.method()` resolution via the field's declared type.
+ *
+ * A method call on an injected/declared field, like `this.userService.findAll()`,
+ * used to degrade to the bare name `findAll`, which (a) misbound to a
+ * same-named method on an unrelated class when several existed, and (b) left
+ * the real target with zero callers. The receiver `this.<field>` is now
+ * re-encoded as `<field>.method` and resolved on the field's declared type,
+ * recovered from the constructor parameter property or a class-body field.
+ *
+ * This is the static-analysis case that dominates NestJS (controllers calling
+ * injected services, services calling injected repositories) and any typed TS
+ * OOP code. resolveMethodOnType validates the method exists on the inferred
+ * type, so the typed path only ever REPLACES a wrong/ambiguous bare-name
+ * binding with the correct one. It never forces an unvalidated edge.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { CodeGraph } from '../src';
+import { initGrammars, loadAllGrammars } from '../src/extraction/grammars';
+
+let tmpDir: string;
+let cg: CodeGraph;
+
+/** `Class::method` qualified names every `calls` edge out of the method `fromQn` points at. */
+const callTargetsFrom = (fromQn: string): string[] => {
+  const from = cg.getNodesByName(fromQn.split('::').pop()!).find((n) => n.qualifiedName === fromQn);
+  if (!from) return [];
+  return cg
+    .getOutgoingEdges(from.id)
+    .filter((e) => e.kind === 'calls')
+    .map((e) => cg.getNode(e.target)?.qualifiedName)
+    .filter((qn): qn is string => Boolean(qn));
+};
+
+const callerCount = (methodQn: string): number => {
+  const node = cg
+    .getNodesByName(methodQn.split('::').pop()!)
+    .find((n) => n.qualifiedName === methodQn);
+  if (!node) return -1;
+  return cg.getIncomingEdges(node.id).filter((e) => e.kind === 'calls').length;
+};
+
+beforeAll(async () => {
+  await initGrammars();
+  await loadAllGrammars();
+
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-tsdi-'));
+  const mk = (rel: string, content: string): void => {
+    const p = path.join(tmpDir, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, content);
+  };
+
+  // Two services share findAll() and create(); the bare name alone can't tell
+  // them apart. wipe() exists only on ProductService.
+  mk(
+    'src/user.service.ts',
+    ['export class UserService {', '  findAll() { return ["u"]; }', '  create() { return "u"; }', '}'].join('\n')
+  );
+  mk(
+    'src/product.service.ts',
+    [
+      'export class ProductService {',
+      '  findAll() { return ["p"]; }',
+      '  create() { return "p"; }',
+      '  wipe() { return "gone"; }',
+      '}',
+    ].join('\n')
+  );
+  // Constructor parameter property injection (the NestJS norm).
+  mk(
+    'src/user.controller.ts',
+    [
+      "import { UserService } from './user.service';",
+      'export class UserController {',
+      '  constructor(private readonly userService: UserService) {}',
+      '  list() { return this.userService.findAll(); }',
+      '  add() { return this.userService.create(); }',
+      '}',
+    ].join('\n')
+  );
+  // Class-body field injection with an explicit type annotation.
+  mk(
+    'src/product.controller.ts',
+    [
+      "import { ProductService } from './product.service';",
+      'export class ProductController {',
+      '  private readonly productService: ProductService;',
+      '  constructor(productService: ProductService) { this.productService = productService; }',
+      '  list() { return this.productService.findAll(); }',
+      '  purge() { return this.productService.wipe(); }',
+      '}',
+    ].join('\n')
+  );
+
+  cg = CodeGraph.initSync(tmpDir);
+  await cg.indexAll();
+}, 120_000);
+
+afterAll(() => {
+  cg?.destroy();
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('TS this.<field>.method() resolves on the field type', () => {
+  it('constructor-injected service: shared method names bind to the injected type', () => {
+    expect(callTargetsFrom('UserController::list')).toContain('UserService::findAll');
+    expect(callTargetsFrom('UserController::add')).toContain('UserService::create');
+    // The wrong-class bindings the bare-name path produced are gone.
+    expect(callTargetsFrom('UserController::list')).not.toContain('ProductService::findAll');
+    expect(callTargetsFrom('UserController::add')).not.toContain('ProductService::create');
+  });
+
+  it('class-body typed field is resolved the same way', () => {
+    expect(callTargetsFrom('ProductController::list')).toContain('ProductService::findAll');
+    expect(callTargetsFrom('ProductController::list')).not.toContain('UserService::findAll');
+  });
+
+  it('the real targets gain their caller (no more zero-caller false positive)', () => {
+    expect(callerCount('UserService::findAll')).toBe(1);
+    expect(callerCount('UserService::create')).toBe(1);
+    expect(callerCount('ProductService::findAll')).toBe(1);
+  });
+
+  it('a method unique to the injected type still resolves', () => {
+    expect(callTargetsFrom('ProductController::purge')).toContain('ProductService::wipe');
+    expect(callerCount('ProductService::wipe')).toBe(1);
+  });
+});

--- a/src/extraction/tree-sitter.ts
+++ b/src/extraction/tree-sitter.ts
@@ -3183,6 +3183,31 @@ export class TreeSitterExtractor {
                 calleeName = methodName;
               }
             } else if (
+              (this.language === 'typescript' || this.language === 'javascript') &&
+              receiver &&
+              receiver.type === 'member_expression'
+            ) {
+              // `this.<field>.method()`: the receiver is itself a member access,
+              // so it degrades to the bare `method` name below. A bare method
+              // name is unresolvable when several classes share it, and worse,
+              // tends to bind to the wrong class (a same-named method elsewhere).
+              // When the receiver is `this.<field>`, re-encode as `<field>.method`
+              // so the resolver can recover the field's declared type from the
+              // enclosing class (constructor parameter property or class-body
+              // field) and resolve the method on THAT type, mirroring the Java
+              // `this.userbo.toLogin2()` unwrap above. Deeper chains
+              // (`this.a.b.method()`) keep the bare name.
+              const innerObj = getChildByField(receiver, 'object');
+              const innerProp = getChildByField(receiver, 'property');
+              const innerObjIsThis =
+                innerObj?.type === 'this' ||
+                (innerObj ? getNodeText(innerObj, this.source) === 'this' : false);
+              if (innerObjIsThis && innerProp && innerProp.type === 'property_identifier') {
+                calleeName = `${getNodeText(innerProp, this.source)}.${methodName}`;
+              } else {
+                calleeName = methodName;
+              }
+            } else if (
               (this.language === 'cpp' ||
                 this.language === 'c' ||
                 this.language === 'kotlin' ||

--- a/src/resolution/name-matcher.ts
+++ b/src/resolution/name-matcher.ts
@@ -448,7 +448,7 @@ function resolveMethodOnType(
     return null;
   }
 
-  if (matches.length > 1 && preferredFqn) {
+  if (matches.length > 1 && preferredFqn && (ref.language === 'java' || ref.language === 'kotlin')) {
     const ext = ref.language === 'kotlin' ? '.kt' : '.java';
     const fqnPath = preferredFqn.replace(/\./g, '/') + ext;
     const chosen = matches.find((m) => {
@@ -465,12 +465,51 @@ function resolveMethodOnType(
     }
   }
 
+  // TS/JS: a per-app `UserService` (and its `findAll`) repeats across a
+  // monorepo, so several methods share `UserService::findAll`. The caller's own
+  // location disambiguates: prefer the candidate whose file shares the longest
+  // directory prefix with the call site (the importer's app). This is the
+  // file-path proximity the bare-name path used before re-encoding, kept here so
+  // the typed path doesn't bind `apps/billing`'s call to `apps/admin`'s method.
+  if (matches.length > 1 && (ref.language === 'typescript' || ref.language === 'javascript')) {
+    return {
+      original: ref,
+      targetNodeId: pickClosestByDir(matches, ref.filePath).id,
+      confidence,
+      resolvedBy,
+    };
+  }
+
   return {
     original: ref,
     targetNodeId: matches[0]!.id,
     confidence,
     resolvedBy,
   };
+}
+
+/** Pick the candidate whose file shares the longest leading directory prefix with `fromPath`. */
+function pickClosestByDir(candidates: Node[], fromPath: string): Node {
+  const fromDirs = fromPath.replace(/\\/g, '/').split('/').slice(0, -1);
+  const sharedPrefix = (p: string): number => {
+    const d = p.replace(/\\/g, '/').split('/').slice(0, -1);
+    let shared = 0;
+    for (let i = 0; i < Math.min(fromDirs.length, d.length); i++) {
+      if (fromDirs[i] === d[i]) shared++;
+      else break;
+    }
+    return shared;
+  };
+  let best = candidates[0]!;
+  let bestProx = sharedPrefix(best.filePath);
+  for (let i = 1; i < candidates.length; i++) {
+    const prox = sharedPrefix(candidates[i]!.filePath);
+    if (prox > bestProx) {
+      best = candidates[i]!;
+      bestProx = prox;
+    }
+  }
+  return best;
 }
 
 // C++ keywords/control-flow tokens that can appear right before a receiver
@@ -924,6 +963,96 @@ function inferJavaFieldReceiverType(
   return lastPart;
 }
 
+/** Normalize a TS type expression to its bare class name, or null if it isn't a class. */
+function bareTsTypeName(typeExpr: string): string | null {
+  const noGenerics = typeExpr.replace(/<[^>]*>/g, '').trim();
+  const noArray = noGenerics.replace(/\[\s*\]/g, '').trim();
+  const lastPart = noArray.split('.').filter(Boolean).pop();
+  if (!lastPart) return null;
+  if (!/^[A-Z][\w$]*$/.test(lastPart)) return null; // primitives / lowercase / unions → skip
+  return lastPart;
+}
+
+/**
+ * TS/JS: infer a receiver's declared type for a `this.<field>.method()` call,
+ * re-encoded by the extractor as `<field>.method`. Two field-declaration sites
+ * are covered, both ubiquitous in NestJS / typed OOP TS:
+ *
+ *   1. Class-body property `private readonly userService: UserService;` is
+ *      extracted as a `property` node whose signature is the Java-style
+ *      "<Type> <name>" form, so the same parse as inferJavaFieldReceiverType
+ *      recovers the type.
+ *   2. Constructor parameter property `constructor(private readonly
+ *      userService: UserService) {}` is NOT a class member node; its type
+ *      lives in the constructor method's signature, so we read it from there.
+ *
+ * Returns the bare class name (generics stripped) or null when the field isn't
+ * declared in the enclosing class with a class-typed annotation. A null result
+ * leaves the ref to the regular strategies, forcing nothing.
+ */
+function inferTsFieldReceiverType(
+  receiverName: string,
+  ref: UnresolvedRef,
+  context: ResolutionContext,
+): string | null {
+  const inFile = context.getNodesInFile(ref.filePath);
+  if (inFile.length === 0) return null;
+
+  // Find the class enclosing the call line (tightest match by latest start).
+  let enclosing: Node | null = null;
+  for (const n of inFile) {
+    if (n.kind !== 'class' && n.kind !== 'interface') continue;
+    if (n.language !== ref.language) continue;
+    const end = n.endLine ?? n.startLine;
+    if (n.startLine <= ref.line && end >= ref.line) {
+      if (!enclosing || n.startLine >= enclosing.startLine) enclosing = n;
+    }
+  }
+  if (!enclosing) return null;
+  const enclosingEnd = enclosing.endLine ?? enclosing.startLine;
+  const inEnclosing = (n: Node): boolean =>
+    n.language === ref.language &&
+    n.startLine >= enclosing!.startLine &&
+    (n.endLine ?? n.startLine) <= enclosingEnd;
+
+  // 1. Class-body property declared with an explicit type.
+  const prop = inFile.find(
+    (n) =>
+      (n.kind === 'property' || n.kind === 'field') &&
+      n.name === receiverName &&
+      inEnclosing(n),
+  );
+  if (prop?.signature) {
+    const beforeName = prop.signature.slice(0, prop.signature.lastIndexOf(prop.name));
+    const fromProp = bareTsTypeName(beforeName.trim());
+    if (fromProp) return fromProp;
+  }
+
+  // 2. Constructor parameter property: the type is in the constructor's signature.
+  const ctor = inFile.find(
+    (n) => n.kind === 'method' && n.name === 'constructor' && inEnclosing(n),
+  );
+  if (ctor?.signature) {
+    const escaped = receiverName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // Match the parameter named `receiverName`, skipping any leading modifiers
+    // (access/readonly) or decorators (`@Inject(TOKEN)`), then capture its type
+    // up to the next top-level `,` or `)`. Stops the type at `<`/`|`/`&` so
+    // generics and unions are handled by bareTsTypeName.
+    const re = new RegExp(
+      '(?:^|[,(])\\s*(?:(?:public|private|protected|readonly|override)\\s+|@[\\w$.]+(?:\\([^)]*\\))?\\s+)*' +
+        escaped +
+        '\\s*[?!]?\\s*:\\s*([A-Za-z_$][\\w$.]*)',
+    );
+    const m = ctor.signature.match(re);
+    if (m && m[1]) {
+      const fromCtor = bareTsTypeName(m[1]);
+      if (fromCtor) return fromCtor;
+    }
+  }
+
+  return null;
+}
+
 /**
  * Try to resolve by method name on a class/object
  */
@@ -978,6 +1107,34 @@ export function matchMethodCall(
       // When two classes share the same simple name, the caller file's
       // import is the only signal that names WHICH one — pass the
       // imported FQN so resolveMethodOnType can disambiguate (#314).
+      const imports = context.getImportMappings(ref.filePath, ref.language);
+      const importedFqn = imports.find((i) => i.localName === inferredType)?.source;
+      const typedMatch = resolveMethodOnType(
+        inferredType,
+        methodName!,
+        ref,
+        context,
+        0.9,
+        'instance-method',
+        importedFqn,
+      );
+      if (typedMatch) {
+        return typedMatch;
+      }
+    }
+  }
+
+  // TS/JS: `this.<field>.method()` re-encoded as `<field>.method` by the
+  // extractor. Recover the field's declared type from the enclosing class
+  // (constructor parameter property or class-body field) and resolve the method
+  // on that type. resolveMethodOnType validates the method exists on the type
+  // (and its supertypes), so a wrong inference yields no edge rather than a
+  // wrong one, which is also what fixes the misbinding to a same-named method
+  // on an unrelated class (the bare-name path's failure mode). Mirrors the
+  // Java/Kotlin field-injection block above.
+  if ((ref.language === 'typescript' || ref.language === 'javascript') && dotMatch) {
+    const inferredType = inferTsFieldReceiverType(objectOrClass!, ref, context);
+    if (inferredType) {
       const imports = context.getImportMappings(ref.filePath, ref.language);
       const importedFqn = imports.find((i) => i.localName === inferredType)?.source;
       const typedMatch = resolveMethodOnType(


### PR DESCRIPTION
## Problem

A method call on an injected or declared field, like `this.userService.findAll()`, degrades to the bare name `findAll` during extraction: the receiver `this.userService` is a `member_expression`, not an identifier, so the receiver is dropped. When several classes define a same-named method, which is the norm in NestJS where every service has `findAll`/`create` and every repository has `findOne`, the bare name binds to an arbitrary one. Two failure modes follow, both visible in the graph:

- the real target is left with **zero callers** (a false "dead code" signal); and
- a **wrong edge** points at a same-named method on an unrelated class.

This is the misbinding #750 describes, in the shape that dominates real-world TypeScript. Minimal repro (two services sharing `findAll`):

```ts
// user.controller.ts
constructor(private readonly userService: UserService) {}
list() { return this.userService.findAll(); }   // bound to ProductService::findAll
```

## Fix

Mirrors the existing Java `this.userbo.toLogin2()` handling, in two parts:

1. **Extraction** (`tree-sitter.ts`): when a member call's receiver is `this.<field>`, re-encode the call as `<field>.method` instead of dropping to the bare method name. Deeper chains (`this.a.b.method()`) keep the bare name.

2. **Resolution** (`name-matcher.ts`): a TS/JS branch in `matchMethodCall` recovers the field's declared type from the enclosing class and resolves the method on it. Two declaration sites are covered, both ubiquitous in NestJS:
   - **constructor parameter property**, `constructor(private readonly userService: UserService)`, read from the constructor method's signature;
   - **class-body field**, `private readonly repo: Repo;`, read from the `property` node's signature.

   Resolution goes through `resolveMethodOnType`, which validates the method exists on the inferred type (and its supertypes), so a wrong inference yields **no edge rather than a wrong one**. When a per-app type repeats across a monorepo (`apps/billing` and `apps/admin` each with a `UserService`), the candidate is disambiguated by directory proximity to the call site, the same file-path proximity the bare-name path relied on before re-encoding.

When the field's type cannot be recovered (untyped field, external or generic type), nothing is forced: the ref falls through to the existing strategies, so behavior there is unchanged.

## Validation

Graph-level A/B, baseline build (`main`) vs this build, indexing five open-source NestJS repos. **Node count is identical in every repo** (the fix adds no nodes):

| repo | nodes (base = new) | calls (base) | calls (new) | retargeted | dropped |
|---|---|---|---|---|---|
| [nestjs/nest](https://github.com/nestjs/nest) | 15570 = 15570 | 12079 | 11816 | 414 | 249 |
| [ghostfolio/ghostfolio](https://github.com/ghostfolio/ghostfolio) | 10443 = 10443 | 3762 | 3605 | 289 | 188 |
| [jmcdo29/testing-nestjs](https://github.com/jmcdo29/testing-nestjs) | 1263 = 1263 | 292 | 285 | 18 | 7 |
| [immich-app/immich](https://github.com/immich-app/immich) (`server/`) | 12091 = 12091 | 16277 | 16244 | 648 | 28 |
| [twentyhq/twenty](https://github.com/twentyhq/twenty) (`packages/twenty-server/`) | 83182 = 83182 | 51982 | 51858 | 2756 | 139 |

About 4,100 call edges across the five repos are **retargeted** from a wrong/self binding to the correct injected dependency. Verified against source:

- immich `UserAdminService::getSessions`: `this.sessionRepository.getByUserId(id)` was bound to `ApiKeyRepository::getByUserId`, now `SessionRepository::getByUserId` (field `sessionRepository: SessionRepository`).
- twenty `BillingGaugeService`: `this.twentyConfigService.get(...)` was bound to `ApplicationConnectionsController::get` (a controller), now `TwentyConfigService::get`.
- nest `RolesGuard::canActivate`: `this.reflector.get(...)` was bound to `ConfigService::get`, now `Reflector::get`.
- ghostfolio `PortfolioController::getHoldings`: was a self-loop, now `PortfolioService::getHoldings`.

The **dropped** edges are bare-name mis-binds, not lost-correct edges. Audited jmcdo29/testing-nestjs: 7/7 drops were calls on an external library type, Mongoose `Model<CatDoc>` and TypeORM `Repository<Cat>`, whose `create`/`update`/`findOne`/`remove` had been bound to same-named **controller** methods. ghostfolio's drops are dominated by Angular frontend components whose `this.x.get()` was bound to a backend service or a test mock (`HttpClientMock::get`); nest's are coincidental binds on common names (`this.subject.next()` to `ExceptionsHandler::next`). The net edge-count decrease is wrong-edge removal plus correct retargeting; the raw counts understate the precision gain, because both a corrected edge and a removed wrong edge lower the total.

## Tests

`__tests__/ts-di-method-resolution.test.ts` (new): constructor-injected and class-body-field resolution, same-name disambiguation, and the type-validation path. The existing `same-name-disambiguation.test.ts` (#764) keeps passing: its NestJS monorepo fixture is exactly this scenario. The only failures on my machine are the pre-existing timing-sensitive mcp-daemon / ppid-watchdog / sync tests, which pass in isolation on a clean checkout as well.
