### PR TITLE
fix(installer,cli): stop suggesting deprecated init -i

### DIFF
--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -249,7 +249,7 @@ export async function runInstallerWithOptions(opts: RunInstallerOptions): Promis
   }
 
   if (location === 'global') {
-    clack.note('cd your-project\ncodegraph init -i', 'Quick start');
+    clack.note('cd your-project\ncodegraph init', 'Quick start');
   }
 
   // Deliver buffered telemetry while we're already in a long interactive
@@ -519,7 +519,7 @@ async function initializeLocalProject(
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     clack.log.error(`Could not load native modules: ${msg}`);
-    clack.log.info('Skipping project initialization. Run "codegraph init -i" later.');
+    clack.log.info('Skipping project initialization. Run "codegraph init" later.');
     return;
   }
 

--- a/src/sync/worktree.ts
+++ b/src/sync/worktree.ts
@@ -86,7 +86,7 @@ export function worktreeMismatchWarning(m: WorktreeIndexMismatch): string {
     `  Running in: ${m.worktreeRoot}\n` +
     `  Index from: ${m.indexRoot}\n` +
     `Results reflect that tree's code (often a different branch), not this worktree — ` +
-    `symbols changed only here are missing. Run "codegraph init -i" in this worktree ` +
+    `symbols changed only here are missing. Run "codegraph init" in this worktree ` +
     `for a worktree-local index.`
   );
 }
@@ -100,7 +100,7 @@ export function worktreeMismatchNotice(m: WorktreeIndexMismatch): string {
   return (
     `⚠ CodeGraph results below come from a different git worktree (${m.indexRoot}), ` +
     `not where you're working (${m.worktreeRoot}) — they may reflect another branch, ` +
-    `and symbols changed only here are missing. Run "codegraph init -i" here for a ` +
+    `and symbols changed only here are missing. Run "codegraph init" here for a ` +
     `worktree-local index.`
   );
 }


### PR DESCRIPTION
## Summary

  - Replace installer quick-start guidance from `codegraph init -i` to `codegraph init`
  - Update fallback/worktree guidance that still mentioned the deprecated `-i` flag

  ## Why

  `codegraph init` now builds the initial index by default, so suggesting `codegraph init -i` points users at a deprecated option.

  ## Tests

  Not run; text-only guidance change.