### PR TITLE
fix: add provider fallback for offload LLMs

### DIFF
--- a/__tests__/offload.test.ts
+++ b/__tests__/offload.test.ts
@@ -34,7 +34,8 @@ describe('reasoning offload', () => {
     'CODEGRAPH_OFFLOAD_URL', 'CODEGRAPH_OFFLOAD_MODEL', 'CODEGRAPH_OFFLOAD_KEY',
     'CODEGRAPH_OFFLOAD_EFFORT', 'CODEGRAPH_OFFLOAD_STYLE', 'CODEGRAPH_OFFLOAD_TIMEOUT_MS',
     'CODEGRAPH_OFFLOAD_MAXTOKENS', 'CODEGRAPH_OFFLOAD_STRIP', 'CODEGRAPH_OFFLOAD_DEBUG',
-    'CODEGRAPH_OFFLOAD_DISABLE', 'CODEGRAPH_OFFLOAD_USAGE_LOG', 'CEREBRAS_API_KEY',
+    'CODEGRAPH_OFFLOAD_DISABLE', 'CODEGRAPH_OFFLOAD_USAGE_LOG', 'CODEGRAPH_OFFLOAD_PROVIDERS',
+    'CEREBRAS_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY',
   ];
   let saved: Record<string, string | undefined>;
 
@@ -115,6 +116,44 @@ describe('reasoning offload', () => {
       const c = resolveOffload();
       expect(c.apiKey).toBe('sk-direct');
       expect(c.keySource).toBe('CODEGRAPH_OFFLOAD_KEY');
+    });
+
+    it('resolves an ordered provider chain from config without persisting secrets', () => {
+      writeOffloadConfig({
+        providers: [
+          { name: 'ollama', url: 'http://localhost:11434/v1', model: 'qwen3' },
+          { name: 'openai', url: 'https://api.openai.com/v1', model: 'gpt-4.1-mini', keyEnv: 'OPENAI_API_KEY' },
+          { name: 'gemini', url: 'https://generativelanguage.googleapis.com/v1beta/openai', model: 'gemini-2.5-flash', keyEnv: 'GEMINI_API_KEY' },
+        ],
+      });
+      process.env.OPENAI_API_KEY = 'sk-openai';
+      process.env.GEMINI_API_KEY = 'sk-gemini';
+
+      const c = resolveOffload();
+      expect(c.enabled).toBe(true);
+      expect(c.providers.map((p) => p.name)).toEqual(['ollama', 'openai', 'gemini']);
+      expect(c.url).toBe('http://localhost:11434/v1');
+      expect(c.model).toBe('qwen3');
+      expect(c.providers[1].apiKey).toBe('sk-openai');
+      expect(c.providers[2].apiKey).toBe('sk-gemini');
+
+      const raw = fs.readFileSync(path.join(home, '.codegraph', 'config.json'), 'utf8');
+      expect(raw).toContain('OPENAI_API_KEY');
+      expect(raw).not.toContain('sk-openai');
+      expect(raw).not.toContain('sk-gemini');
+    });
+
+    it('lets CODEGRAPH_OFFLOAD_PROVIDERS replace the file chain for ephemeral provider fallback', () => {
+      writeOffloadConfig({ providers: [{ name: 'file', url: 'https://file.example/v1' }] });
+      process.env.CODEGRAPH_OFFLOAD_PROVIDERS = JSON.stringify([
+        { name: 'ollama', url: 'http://localhost:11434/v1', model: 'qwen3' },
+        { name: 'openai', url: 'https://api.openai.com/v1', model: 'gpt-4.1-mini', key: 'sk-env-only' },
+      ]);
+      const c = resolveOffload();
+      expect(c.origin).toBe('env');
+      expect(c.providers.map((p) => p.name)).toEqual(['ollama', 'openai']);
+      expect(c.providers[1].apiKey).toBe('sk-env-only');
+      expect(c.providers[1].keySource).toBe('CODEGRAPH_OFFLOAD_PROVIDERS');
     });
   });
 
@@ -225,6 +264,53 @@ describe('reasoning offload', () => {
       expect(body.model).toBe('gpt-oss-120b');
       expect(body.messages[1].content).toContain('source here');
       expect(body.messages[1].content).toContain('how does X work');
+    });
+
+    it('falls back across provider endpoints when the first provider is rate-limited', async () => {
+      writeOffloadConfig({
+        providers: [
+          { name: 'ollama', url: 'http://localhost:11434/v1', model: 'qwen3' },
+          { name: 'openai', url: 'https://api.openai.com/v1', model: 'gpt-4.1-mini', keyEnv: 'OPENAI_API_KEY' },
+          { name: 'gemini', url: 'https://generativelanguage.googleapis.com/v1beta/openai', model: 'gemini-2.5-flash', keyEnv: 'GEMINI_API_KEY' },
+        ],
+      });
+      process.env.OPENAI_API_KEY = 'sk-openai';
+      process.env.GEMINI_API_KEY = 'sk-gemini';
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({ ok: false, status: 429, text: async () => 'rate limited' })
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: async () => ({ choices: [{ message: { content: 'Coverage: full.\nOpenAI answer.' }, finish_reason: 'stop' }] }),
+        });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const out = await synthesizeOffload({ query: 'q', context: 'ctx' });
+      expect(out).toContain('OpenAI answer.');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:11434/v1/chat/completions');
+      expect(JSON.parse(fetchMock.mock.calls[0][1].body as string).model).toBe('qwen3');
+      expect(fetchMock.mock.calls[0][1].headers.authorization).toBeUndefined();
+      expect(fetchMock.mock.calls[1][0]).toBe('https://api.openai.com/v1/chat/completions');
+      expect((fetchMock.mock.calls[1][1].headers as Record<string, string>).authorization).toBe('Bearer sk-openai');
+      expect(JSON.parse(fetchMock.mock.calls[1][1].body as string).model).toBe('gpt-4.1-mini');
+    });
+
+    it('tries the next provider after an empty answer and returns null only after all providers fail', async () => {
+      writeOffloadConfig({
+        providers: [
+          { name: 'ollama', url: 'http://localhost:11434/v1', model: 'qwen3' },
+          { name: 'gemini', url: 'https://generativelanguage.googleapis.com/v1beta/openai', model: 'gemini-2.5-flash', keyEnv: 'GEMINI_API_KEY' },
+        ],
+      });
+      process.env.GEMINI_API_KEY = 'sk-gemini';
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ choices: [{ message: { content: '   ' } }] }) })
+        .mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'boom' });
+      vi.stubGlobal('fetch', fetchMock);
+
+      expect(await synthesizeOffload({ query: 'q', context: 'ctx' })).toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1][0]).toBe('https://generativelanguage.googleapis.com/v1beta/openai/chat/completions');
     });
   });
 

--- a/src/reasoning/config.ts
+++ b/src/reasoning/config.ts
@@ -33,10 +33,40 @@ export interface OffloadConfig {
   model?: string;
   /** Name of the env var holding the provider API key (never persisted). BYO only. */
   keyEnv?: string;
+  /** Ordered provider fallback chain. Each entry is tried before falling back to local source. */
+  providers?: OffloadProviderConfig[];
   /** reasoning_effort: low | medium | high (default `low`). */
   effort?: string;
   /** Output style: plain | report (default `plain`). */
   style?: string;
+}
+
+export interface OffloadProviderConfig {
+  /** Human-readable label for debug/status and usage attribution. */
+  name?: string;
+  /** Managed tier: route through CodeGraph AI (metered) with the logged-in org token. */
+  managed?: boolean;
+  /** OpenAI-compatible base URL ending in `/v1`. */
+  url?: string;
+  /** Model id to request for this provider. */
+  model?: string;
+  /** Name of the env var holding this provider's API key (never persisted). */
+  keyEnv?: string;
+  /** Direct key override, accepted only from CODEGRAPH_OFFLOAD_PROVIDERS env JSON. */
+  key?: string;
+}
+
+export interface ResolvedOffloadProvider {
+  /** Human-readable label for debug/status and usage attribution. */
+  name?: string;
+  /** Managed tier (CodeGraph AI, metered) vs BYO endpoint. */
+  managed: boolean;
+  url: string;
+  model: string;
+  /** Resolved API key / org token, if any. */
+  apiKey?: string;
+  /** Where the key/token came from — never the secret itself. */
+  keySource?: string;
 }
 
 export interface ResolvedOffload {
@@ -44,6 +74,8 @@ export interface ResolvedOffload {
   enabled: boolean;
   /** Managed tier (CodeGraph AI, metered) vs BYO endpoint. */
   managed: boolean;
+  /** Ordered provider fallback chain. First item mirrors the legacy top-level fields below. */
+  providers: ResolvedOffloadProvider[];
   url?: string;
   model: string;
   /** Resolved API key / org token (from env, the configured `keyEnv`, or login), if any. */
@@ -100,6 +132,54 @@ const trimmed = (v: string | undefined): string | undefined => {
   return t ? t : undefined;
 };
 
+function parseProviderChain(raw: string | undefined): OffloadProviderConfig[] | undefined {
+  const t = trimmed(raw);
+  if (!t) return undefined;
+  try {
+    const parsed = JSON.parse(t) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((p): p is Record<string, unknown> => !!p && typeof p === 'object')
+      .map((p) => ({
+        name: typeof p.name === 'string' ? p.name : undefined,
+        managed: !!p.managed,
+        url: typeof p.url === 'string' ? p.url : undefined,
+        model: typeof p.model === 'string' ? p.model : undefined,
+        keyEnv: typeof p.keyEnv === 'string' ? p.keyEnv : undefined,
+        key: typeof p.key === 'string' ? p.key : undefined,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+function resolveProvider(
+  provider: OffloadProviderConfig,
+  env: NodeJS.ProcessEnv,
+  defaults: { url?: string; model: string; managed: boolean } = { model: 'gpt-oss-120b', managed: false }
+): ResolvedOffloadProvider | null {
+  const managed = !!provider.managed;
+  const url = trimmed(provider.url) ?? (managed ? MANAGED_DEFAULT_URL : defaults.url);
+  const model = trimmed(provider.model) ?? (managed ? MANAGED_DEFAULT_MODEL : defaults.model);
+  let apiKey: string | undefined;
+  let keySource: string | undefined;
+
+  if (provider.key) {
+    apiKey = trimmed(provider.key);
+    keySource = 'CODEGRAPH_OFFLOAD_PROVIDERS';
+  } else if (provider.keyEnv && trimmed(env[provider.keyEnv])) {
+    apiKey = trimmed(env[provider.keyEnv]);
+    keySource = provider.keyEnv;
+  } else if (managed) {
+    const t = readOffloadToken();
+    if (t) { apiKey = t; keySource = 'codegraph login'; }
+  }
+
+  if (!url) return null;
+  if (managed && !apiKey) return null;
+  return { name: trimmed(provider.name), managed, url, model, apiKey, keySource };
+}
+
 /** Merge the persisted config with `CODEGRAPH_OFFLOAD_*` env overrides (env wins). */
 export function resolveOffload(env: NodeJS.ProcessEnv = process.env): ResolvedOffload {
   // Hard kill-switch: disable the offload for this process/session without touching
@@ -107,7 +187,7 @@ export function resolveOffload(env: NodeJS.ProcessEnv = process.env): ResolvedOf
   // codegraph_explore to return raw source for a session. Env-only by design.
   if (env.CODEGRAPH_OFFLOAD_DISABLE === '1') {
     return {
-      enabled: false, managed: false, url: undefined, model: MANAGED_DEFAULT_MODEL,
+      enabled: false, managed: false, providers: [], url: undefined, model: MANAGED_DEFAULT_MODEL,
       apiKey: undefined, keySource: undefined, effort: 'low', style: 'plain',
       timeoutMs: 20000, maxTokens: 12000, strip: false,
       debug: env.CODEGRAPH_OFFLOAD_DEBUG === '1', origin: 'none',
@@ -117,11 +197,13 @@ export function resolveOffload(env: NodeJS.ProcessEnv = process.env): ResolvedOf
   const managed = !!c.managed;
   const envUrl = trimmed(env.CODEGRAPH_OFFLOAD_URL);
   const envKey = trimmed(env.CODEGRAPH_OFFLOAD_KEY);
+  const envProviders = parseProviderChain(env.CODEGRAPH_OFFLOAD_PROVIDERS);
 
   let url: string | undefined;
   let apiKey: string | undefined;
   let keySource: string | undefined;
   let model: string;
+  let providers: ResolvedOffloadProvider[] = [];
 
   if (managed) {
     // Managed tier: default to the CodeGraph AI gateway + its public model id; the
@@ -138,17 +220,33 @@ export function resolveOffload(env: NodeJS.ProcessEnv = process.env): ResolvedOf
     else if (c.keyEnv && trimmed(env[c.keyEnv])) { apiKey = trimmed(env[c.keyEnv]); keySource = c.keyEnv; }
   }
 
-  const origin: ResolvedOffload['origin'] = envUrl ? 'env' : (managed || trimmed(c.url)) ? 'config' : 'none';
+  if (envProviders !== undefined) {
+    providers = envProviders
+      .map((p) => resolveProvider(p, env, { url, model, managed: false }))
+      .filter((p): p is ResolvedOffloadProvider => !!p);
+  } else if (!envUrl && !envKey && Array.isArray(c.providers) && c.providers.length > 0) {
+    providers = c.providers
+      .map((p) => resolveProvider(p, env, { url, model, managed }))
+      .filter((p): p is ResolvedOffloadProvider => !!p);
+  }
+
+  if (providers.length === 0 && url && (!managed || apiKey)) {
+    providers = [{ managed, url, model, apiKey, keySource }];
+  }
+
+  const primary = providers[0];
+  const origin: ResolvedOffload['origin'] = envProviders !== undefined || envUrl ? 'env' : (managed || trimmed(c.url) || (c.providers?.length ?? 0) > 0) ? 'config' : 'none';
 
   return {
     // Managed needs both an endpoint AND a token (no token → effectively logged out);
     // BYO needs only an endpoint (some endpoints require no auth).
-    enabled: managed ? (!!url && !!apiKey) : !!url,
-    managed,
-    url,
-    model,
-    apiKey,
-    keySource,
+    enabled: providers.length > 0,
+    managed: primary?.managed ?? managed,
+    providers,
+    url: primary?.url ?? url,
+    model: primary?.model ?? model,
+    apiKey: primary?.apiKey ?? apiKey,
+    keySource: primary?.keySource ?? keySource,
     effort: trimmed(env.CODEGRAPH_OFFLOAD_EFFORT) ?? trimmed(c.effort) ?? 'low',
     style: trimmed(env.CODEGRAPH_OFFLOAD_STYLE) ?? trimmed(c.style) ?? 'plain',
     timeoutMs: Number(env.CODEGRAPH_OFFLOAD_TIMEOUT_MS) || 20000,

--- a/src/reasoning/reasoner.ts
+++ b/src/reasoning/reasoner.ts
@@ -29,7 +29,7 @@
  * session and an agent can abandon the tool entirely).
  */
 import * as fs from 'fs';
-import { resolveOffload } from './config';
+import { resolveOffload, type ResolvedOffloadProvider } from './config';
 
 interface SynthArgs {
   query: string;
@@ -195,35 +195,59 @@ export function stripAgentDirectives(context: string): string {
  */
 export async function synthesizeOffload({ query, context }: SynthArgs): Promise<string | null> {
   const cfg = resolveOffload();
-  if (!cfg.url) return null;
+  const providers = cfg.providers.length > 0 ? cfg.providers : (
+    cfg.url ? [{ managed: cfg.managed, url: cfg.url, model: cfg.model, apiKey: cfg.apiKey, keySource: cfg.keySource }] : []
+  );
+  if (providers.length === 0) return null;
 
-  const url = cfg.url.replace(/\/+$/, '') + '/chat/completions';
   const { system, footer } = promptFor(cfg.style);
   const ctx = cfg.strip ? stripAgentDirectives(context) : context;
   // Optional operator/eval flag forwarded verbatim to the managed Worker (see body below);
   // the Worker validates it and falls back to its default for anything it doesn't recognize.
   const workerStyle = (process.env.CODEGRAPH_OFFLOAD_STYLE || '').trim();
 
+  for (const provider of providers) {
+    const answer = await synthesizeWithProvider(provider, { query, context, ctx, system, footer, workerStyle, cfg });
+    if (answer) return answer;
+  }
+  return null;
+}
+
+async function synthesizeWithProvider(
+  provider: ResolvedOffloadProvider,
+  args: {
+    query: string;
+    context: string;
+    ctx: string;
+    system: string;
+    footer: string;
+    workerStyle: string;
+    cfg: ReturnType<typeof resolveOffload>;
+  }
+): Promise<string | null> {
+  const { query, context, ctx, system, footer, workerStyle, cfg } = args;
+  const url = provider.url.replace(/\/+$/, '') + '/chat/completions';
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), cfg.timeoutMs);
   const started = Date.now();
+  const providerLabel = provider.name ?? provider.url;
   try {
     const headers: Record<string, string> = { 'content-type': 'application/json' };
-    if (cfg.apiKey) headers.authorization = `Bearer ${cfg.apiKey}`;
+    if (provider.apiKey) headers.authorization = `Bearer ${provider.apiKey}`;
 
     const res = await fetch(url, {
       method: 'POST',
       headers,
       signal: controller.signal,
       body: JSON.stringify({
-        model: cfg.model,
+        model: provider.model,
         max_tokens: cfg.maxTokens,
         temperature: 0.2,
         reasoning_effort: cfg.effort,
         // Optional managed-tier flag, forwarded ONLY to the managed gateway (which strips it
         // before the upstream model call) and ONLY when an operator/eval sets it — so BYO
         // endpoints, which may reject unknown fields, never see it.
-        ...(cfg.managed && workerStyle ? { offload_style: workerStyle } : {}),
+        ...(provider.managed && workerStyle ? { offload_style: workerStyle } : {}),
         messages: [
           { role: 'system', content: system },
           {
@@ -235,7 +259,7 @@ export async function synthesizeOffload({ query, context }: SynthArgs): Promise<
     });
 
     if (!res.ok) {
-      debug('upstream not ok', res.status, (await res.text().catch(() => '')).slice(0, 200));
+      debug('upstream not ok', providerLabel, res.status, (await res.text().catch(() => '')).slice(0, 200));
       return null;
     }
     const data = (await res.json()) as {
@@ -253,9 +277,11 @@ export async function synthesizeOffload({ query, context }: SynthArgs): Promise<
     recordUsage({
       ts: new Date().toISOString(),
       ms: Date.now() - started,
-      model: cfg.model,
+      provider: provider.name ?? null,
+      providerUrl: provider.url,
+      model: provider.model,
       style: cfg.style,
-      managed: cfg.managed,
+      managed: provider.managed,
       promptTokens: data.usage?.prompt_tokens ?? null,
       completionTokens: data.usage?.completion_tokens ?? null,
       totalTokens: data.usage?.total_tokens ?? null,
@@ -268,15 +294,15 @@ export async function synthesizeOffload({ query, context }: SynthArgs): Promise<
       finishReason: data.choices?.[0]?.finish_reason ?? null,
     });
     if (!answer) {
-      debug('empty answer', JSON.stringify(data).slice(0, 200));
+      debug('empty answer', providerLabel, JSON.stringify(data).slice(0, 200));
       return null;
     }
     debug(
-      `ok in ${Date.now() - started}ms [${cfg.style}] — answer ${answer.length} chars (ctx ${ctx.length} of ${context.length}, finish=${data.choices?.[0]?.finish_reason}), ${data.usage?.total_tokens ?? '?'} tok, ${Number.isFinite(creditsCharged) ? creditsCharged + ' cr' : 'no-charge-hdr'}`
+      `ok in ${Date.now() - started}ms [${cfg.style}] via ${providerLabel} — answer ${answer.length} chars (ctx ${ctx.length} of ${context.length}, finish=${data.choices?.[0]?.finish_reason}), ${data.usage?.total_tokens ?? '?'} tok, ${Number.isFinite(creditsCharged) ? creditsCharged + ' cr' : 'no-charge-hdr'}`
     );
     return answer + footer;
   } catch (err) {
-    debug('error', (err as Error)?.message);
+    debug('error', providerLabel, (err as Error)?.message);
     return null;
   } finally {
     clearTimeout(timer);


### PR DESCRIPTION
## Summary
- add ordered provider fallback chains for reasoning offload
- keep legacy single-endpoint offload config compatible
- fall through from Ollama/provider 429s or failures to OpenAI/Gemini-style OpenAI-compatible endpoints

## Test Plan
- npm test -- __tests__/offload.test.ts
- npm run build
- npm test (one mcp-daemon timeout; focused rerun passed)