### PR TITLE
Add Qwen Code installer target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### New Features
+
+- `codegraph install` can now configure **Qwen Code**, wiring CodeGraph in while preserving existing Qwen settings and adding the short CodeGraph hint Qwen can read in agent context.
 
 ## [1.1.2] - 2026-06-28
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Already installed? Run `codegraph upgrade` to update in place.
 
 Follow [@getcodegraph](https://x.com/getcodegraph) on X for updates.
 
-### Supercharge Claude Code, Cursor, Codex, OpenCode, Hermes Agent, Gemini, Antigravity, and Kiro with Semantic Code Intelligence
+### Supercharge Claude Code, Cursor, Codex, OpenCode, Hermes Agent, Gemini, Qwen Code, Antigravity, and Kiro with Semantic Code Intelligence
 
 **Surgical context · fewer tool calls · faster answers · 100% local**
 
@@ -28,6 +28,7 @@ Follow [@getcodegraph](https://x.com/getcodegraph) on X for updates.
 [![opencode](https://img.shields.io/badge/opencode-supported-blueviolet.svg)](#supported-agents)
 [![Hermes Agent](https://img.shields.io/badge/Hermes_Agent-supported-blueviolet.svg)](#supported-agents)
 [![Gemini](https://img.shields.io/badge/Gemini-supported-blueviolet.svg)](#supported-agents)
+[![Qwen Code](https://img.shields.io/badge/Qwen_Code-supported-blueviolet.svg)](#supported-agents)
 [![Antigravity](https://img.shields.io/badge/Antigravity-supported-blueviolet.svg)](#supported-agents)
 [![Kiro](https://img.shields.io/badge/Kiro-supported-blueviolet.svg)](#supported-agents)
 
@@ -76,7 +77,7 @@ In a **new terminal**, run the installer to connect CodeGraph to the agents you 
 codegraph install
 ```
 
-<sub>Detects and auto-configures Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, and Kiro — wiring the CodeGraph MCP server into each. **This is the step that connects CodeGraph to your agent;** installing the CLI in step 1 does not do it on its own. It only wires up your agent — it does **not** index any code; building each project's graph is the separate `codegraph init` in step 3. (Shortcut: `npx @colbymchenry/codegraph` downloads and runs this in one go.)</sub>
+<sub>Detects and auto-configures Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Qwen Code, Antigravity IDE, and Kiro — wiring the CodeGraph MCP server into each. **This is the step that connects CodeGraph to your agent;** installing the CLI in step 1 does not do it on its own. It only wires up your agent — it does **not** index any code; building each project's graph is the separate `codegraph init` in step 3. (Shortcut: `npx @colbymchenry/codegraph` downloads and runs this in one go.)</sub>
 
 ### 3. Initialize each project
 
@@ -252,7 +253,7 @@ The reliable, universal payoff is **surgical context and speed**: CodeGraph coll
 <details>
 <summary><strong>How auto-syncing works — and why you don't need to run <code>codegraph sync</code> manually</strong></summary>
 
-When your agent (Claude Code, Cursor, Codex, opencode) launches `codegraph serve --mcp`, three layers keep the index in step with your code — and make sure the agent never gets a silent wrong answer in the brief window between an edit and the next sync:
+When your agent (Claude Code, Cursor, Codex, opencode, Gemini CLI, Qwen Code, and others) launches `codegraph serve --mcp`, three layers keep the index in step with your code — and make sure the agent never gets a silent wrong answer in the brief window between an edit and the next sync:
 
 1. **File watcher with debounced auto-sync.** A native FSEvents / inotify / ReadDirectoryChangesW watcher captures every source-file create / modify / delete and triggers a re-index after a debounce window (default `2000ms`, tunable via `CODEGRAPH_WATCH_DEBOUNCE_MS`, clamped to `[100ms, 60s]`). Bursts of edits collapse into a single sync.
 
@@ -342,10 +343,10 @@ npx @colbymchenry/codegraph
 ```
 
 The installer will:
-- Ask which agent(s) to configure — auto-detects installed ones from: **Claude Code**, **Cursor**, **Codex CLI**, **opencode**, **Hermes Agent**, **Gemini CLI**, **Antigravity IDE**, **Kiro**
+- Ask which agent(s) to configure — auto-detects installed ones from: **Claude Code**, **Cursor**, **Codex CLI**, **opencode**, **Hermes Agent**, **Gemini CLI**, **Qwen Code**, **Antigravity IDE**, **Kiro**
 - Prompt to install `codegraph` on your PATH (so agents can launch the MCP server)
 - Ask whether configs apply to all your projects or just this one
-- Write each chosen agent's MCP server config, plus a small marker-fenced CodeGraph section in the agent's instructions file (`CLAUDE.md` / `AGENTS.md` / `GEMINI.md`) — that's how subagents and non-MCP agents learn the `codegraph explore` command, since the MCP server's own guidance only reaches the main agent. Removed cleanly by `codegraph uninstall`.
+- Write each chosen agent's MCP server config, plus a small marker-fenced CodeGraph section in the agent's instructions file where supported (`CLAUDE.md` / `AGENTS.md` / `GEMINI.md` / `QWEN.md`) — that's how subagents and non-MCP agents learn the `codegraph explore` command, since the MCP server's own guidance only reaches the main agent. Removed cleanly by `codegraph uninstall`.
 - Set up auto-allow permissions when Claude Code is one of the targets
 
 The installer **wires up your agents only — it does not index your code.** After it finishes, build each project's graph yourself with `codegraph init` (step 3). One global `codegraph install` covers every project; you run `codegraph init` once per project.
@@ -369,7 +370,7 @@ codegraph install --print-config codex               # print snippet, no file wr
 
 ### 2. Restart Your Agent
 
-Restart your agent (Claude Code / Cursor / Codex CLI / opencode / Hermes Agent / Gemini CLI / Antigravity IDE / Kiro) for the MCP server to load.
+Restart your agent (Claude Code / Cursor / Codex CLI / opencode / Hermes Agent / Gemini CLI / Qwen Code / Antigravity IDE / Kiro) for the MCP server to load.
 
 ### 3. Initialize Projects
 
@@ -674,8 +675,7 @@ See [Get Started](#get-started) for the one-line install commands.
 ## Supported Agents
 
 The interactive installer auto-detects and configures each of these — wiring up
-the MCP server (which delivers its own usage guidance, so no instructions file
-is written):
+the MCP server plus a short context-file hint where the agent supports one:
 
 - **Claude Code**
 - **Cursor**
@@ -683,6 +683,7 @@ is written):
 - **opencode**
 - **Hermes Agent**
 - **Gemini CLI**
+- **Qwen Code**
 - **Antigravity IDE**
 - **Kiro**
 
@@ -783,7 +784,7 @@ MIT
 
 <div align="center">
 
-**Made for AI coding agents — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, and Kiro**
+**Made for AI coding agents — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Qwen Code, Antigravity IDE, and Kiro**
 
 [Report Bug](https://github.com/colbymchenry/codegraph/issues) · [Request Feature](https://github.com/colbymchenry/codegraph/issues)
 

--- a/__tests__/installer-targets.test.ts
+++ b/__tests__/installer-targets.test.ts
@@ -413,6 +413,85 @@ describe('Installer targets — partial-state idempotency', () => {
     expect(body).not.toContain('CODEGRAPH_START');
   });
 
+  it('qwen: install writes settings.json (mcpServers.codegraph) and the QWEN.md block (#704)', () => {
+    const qwen = getTarget('qwen')!;
+    const result = qwen.install('global', { autoAllow: true });
+    const settings = path.join(tmpHome, '.qwen', 'settings.json');
+    const qwenMd = path.join(tmpHome, '.qwen', 'QWEN.md');
+    expect(result.files.some((f) => f.path === settings)).toBe(true);
+    expect(result.files.some((f) => f.path === qwenMd)).toBe(true);
+    expect(fs.existsSync(qwenMd)).toBe(true);
+    expect(fs.readFileSync(qwenMd, 'utf-8')).toContain('codegraph explore');
+
+    const cfg = JSON.parse(fs.readFileSync(settings, 'utf-8'));
+    expect(cfg.mcpServers.codegraph).toEqual({ command: 'codegraph', args: ['serve', '--mcp'] });
+    expect(cfg.mcpServers.codegraph.type).toBeUndefined();
+  });
+
+  it('qwen: printConfig uses the documented command/args MCP shape without type', () => {
+    const qwen = getTarget('qwen')!;
+    const out = qwen.printConfig('global');
+    const jsonStart = out.indexOf('{');
+    const cfg = JSON.parse(out.slice(jsonStart));
+
+    expect(cfg.mcpServers.codegraph).toEqual({ command: 'codegraph', args: ['serve', '--mcp'] });
+    expect(cfg.mcpServers.codegraph.type).toBeUndefined();
+  });
+
+  it('qwen: install preserves pre-existing settings (security.auth survives)', () => {
+    const qwen = getTarget('qwen')!;
+    const settings = path.join(tmpHome, '.qwen', 'settings.json');
+    fs.mkdirSync(path.dirname(settings), { recursive: true });
+    fs.writeFileSync(settings, JSON.stringify({
+      security: { auth: { selectedType: 'oauth-personal' } },
+    }, null, 2) + '\n');
+
+    qwen.install('global', { autoAllow: true });
+
+    const after = JSON.parse(fs.readFileSync(settings, 'utf-8'));
+    expect(after.security?.auth?.selectedType).toBe('oauth-personal');
+    expect(after.mcpServers?.codegraph).toBeDefined();
+  });
+
+  it('qwen: uninstall strips codegraph but leaves pre-existing settings (security.auth) intact', () => {
+    const qwen = getTarget('qwen')!;
+    const settings = path.join(tmpHome, '.qwen', 'settings.json');
+    fs.mkdirSync(path.dirname(settings), { recursive: true });
+    fs.writeFileSync(settings, JSON.stringify({
+      security: { auth: { selectedType: 'oauth-personal' } },
+    }, null, 2) + '\n');
+
+    qwen.install('global', { autoAllow: true });
+    qwen.uninstall('global');
+
+    const after = JSON.parse(fs.readFileSync(settings, 'utf-8'));
+    expect(after.security?.auth?.selectedType).toBe('oauth-personal');
+    expect(after.mcpServers).toBeUndefined();
+  });
+
+  it('qwen: local install writes ./.qwen/settings.json and the project-root ./QWEN.md block (#704)', () => {
+    const qwen = getTarget('qwen')!;
+    const result = qwen.install('local', { autoAllow: true });
+    const paths = result.files.map((f) => f.path.replace(/\\/g, '/'));
+    expect(paths.some((p) => p.endsWith('/.qwen/settings.json'))).toBe(true);
+    expect(paths.some((p) => p.endsWith('/QWEN.md'))).toBe(true);
+    expect(fs.existsSync(path.join(process.cwd(), 'QWEN.md'))).toBe(true);
+  });
+
+  it('qwen: uninstall strips a leftover QWEN.md codegraph block, keeping user content', () => {
+    const qwen = getTarget('qwen')!;
+    const qwenMd = path.join(tmpHome, '.qwen', 'QWEN.md');
+    fs.mkdirSync(path.dirname(qwenMd), { recursive: true });
+    fs.writeFileSync(qwenMd, `# My personal Qwen context\n\nAlways respond concisely.\n\n${LEGACY_BLOCK}\n`);
+
+    qwen.uninstall('global');
+
+    const body = fs.readFileSync(qwenMd, 'utf-8');
+    expect(body).toContain('# My personal Qwen context');
+    expect(body).toContain('Always respond concisely.');
+    expect(body).not.toContain('CODEGRAPH_START');
+  });
+
   it('kiro: install writes settings/mcp.json (mcpServers.codegraph) and no steering doc (#529)', () => {
     const kiro = getTarget('kiro')!;
     const result = kiro.install('global', { autoAllow: true });
@@ -1185,6 +1264,7 @@ describe('Installer targets — registry', () => {
     expect(getTarget('opencode')?.id).toBe('opencode');
     expect(getTarget('hermes')?.id).toBe('hermes');
     expect(getTarget('gemini')?.id).toBe('gemini');
+    expect(getTarget('qwen')?.id).toBe('qwen');
     expect(getTarget('antigravity')?.id).toBe('antigravity');
     expect(getTarget('kiro')?.id).toBe('kiro');
     expect(getTarget('not-a-real-target')).toBeUndefined();

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -1987,7 +1987,7 @@ program
  */
 program
   .command('install')
-  .description('Install codegraph MCP server into one or more agents (Claude Code, Cursor, Codex CLI, opencode, Hermes Agent)')
+  .description('Install codegraph MCP server into one or more supported agents')
   .option('-t, --target <ids>', 'Target agent(s): comma-separated ids, or "auto"|"all"|"none". Default: prompt')
   .option('-l, --location <where>', 'Install location: "global" or "local". Default: prompt')
   .option('-y, --yes', 'Non-interactive: defaults to --location=global --target=auto, auto-allow on')
@@ -2054,7 +2054,7 @@ program
  */
 program
   .command('uninstall')
-  .description('Remove codegraph from your agents (Claude Code, Cursor, Codex CLI, opencode, Hermes Agent)')
+  .description('Remove codegraph from your supported agents')
   .option('-t, --target <ids>', 'Target agent(s): comma-separated ids, or "all". Default: all')
   .option('-l, --location <where>', 'Uninstall location: "global" or "local". Default: prompt')
   .option('-y, --yes', 'Non-interactive: defaults to --location=global --target=all')

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -3,7 +3,7 @@
  *
  * Multi-target: writes MCP server config + instructions for the
  * agents the user picks (Claude Code, Cursor, Codex CLI, opencode,
- * Hermes Agent, Gemini CLI, Antigravity IDE).
+ * Hermes Agent, Gemini CLI, Qwen Code, Antigravity IDE).
  * Defaults to the Claude-only behavior for backwards compatibility
  * when no targets are explicitly chosen and nothing else is detected.
  *

--- a/src/installer/targets/qwen.ts
+++ b/src/installer/targets/qwen.ts
@@ -1,0 +1,154 @@
+/**
+ * Qwen Code target. Writes:
+ *
+ *   - MCP server entry to `~/.qwen/settings.json` (global) or
+ *     `./.qwen/settings.json` (local) under the standard
+ *     `mcpServers.codegraph` key. Qwen Code is Gemini CLI-derived but
+ *     documents stdio servers as `command` + `args` entries, without a
+ *     `type: "stdio"` discriminator.
+ *   - Instructions to `~/.qwen/QWEN.md` (global) or `./QWEN.md`
+ *     (local). Qwen Code's hierarchical context loader reads QWEN.md,
+ *     matching Gemini CLI's GEMINI.md behavior.
+ *
+ * No permissions concept — Qwen Code gates MCP invocations through the
+ * per-server `trust` field and UI prompts. We leave `trust` unset so
+ * the user controls confirmation prompts.
+ *
+ * Docs:
+ *   https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  AgentTarget,
+  DetectionResult,
+  InstallOptions,
+  Location,
+  WriteResult,
+} from './types';
+import {
+  jsonDeepEqual,
+  readJsonFile,
+  removeMarkedSection,
+  writeJsonFile,
+  upsertInstructionsEntry,
+} from './shared';
+import {
+  CODEGRAPH_SECTION_END,
+  CODEGRAPH_SECTION_START,
+} from '../instructions-template';
+
+function configDir(loc: Location): string {
+  return loc === 'global'
+    ? path.join(os.homedir(), '.qwen')
+    : path.join(process.cwd(), '.qwen');
+}
+
+function settingsJsonPath(loc: Location): string {
+  return path.join(configDir(loc), 'settings.json');
+}
+
+function instructionsPath(loc: Location): string {
+  return loc === 'global'
+    ? path.join(configDir('global'), 'QWEN.md')
+    : path.join(process.cwd(), 'QWEN.md');
+}
+
+class QwenTarget implements AgentTarget {
+  readonly id = 'qwen' as const;
+  readonly displayName = 'Qwen Code';
+  readonly docsUrl = 'https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/';
+
+  supportsLocation(_loc: Location): boolean {
+    return true;
+  }
+
+  detect(loc: Location): DetectionResult {
+    const file = settingsJsonPath(loc);
+    const config = readJsonFile(file);
+    const alreadyConfigured = !!config.mcpServers?.codegraph;
+    const installed = loc === 'global'
+      ? fs.existsSync(configDir('global')) || fs.existsSync(file)
+      : fs.existsSync(file) || fs.existsSync(configDir('local'));
+    return { installed, alreadyConfigured, configPath: file };
+  }
+
+  install(loc: Location, _opts: InstallOptions): WriteResult {
+    const files: WriteResult['files'] = [];
+    files.push(writeMcpEntry(loc));
+    files.push(upsertInstructionsEntry(instructionsPath(loc)));
+    return { files };
+  }
+
+  uninstall(loc: Location): WriteResult {
+    const files: WriteResult['files'] = [];
+
+    const file = settingsJsonPath(loc);
+    const config = readJsonFile(file);
+    if (config.mcpServers?.codegraph) {
+      delete config.mcpServers.codegraph;
+      if (Object.keys(config.mcpServers).length === 0) {
+        delete config.mcpServers;
+      }
+      writeJsonFile(file, config);
+      files.push({ path: file, action: 'removed' });
+    } else {
+      files.push({ path: file, action: 'not-found' });
+    }
+
+    files.push(removeInstructionsEntry(loc));
+
+    return { files };
+  }
+
+  printConfig(loc: Location): string {
+    const target = settingsJsonPath(loc);
+    const snippet = JSON.stringify({ mcpServers: { codegraph: buildQwenMcpEntry() } }, null, 2);
+    return `# Add to ${target}\n\n${snippet}\n`;
+  }
+
+  describePaths(loc: Location): string[] {
+    return [settingsJsonPath(loc), instructionsPath(loc)];
+  }
+}
+
+function writeMcpEntry(loc: Location): WriteResult['files'][number] {
+  const file = settingsJsonPath(loc);
+  const dir = path.dirname(file);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  const existing = readJsonFile(file);
+  const before = existing.mcpServers?.codegraph;
+  const after = buildQwenMcpEntry();
+
+  if (jsonDeepEqual(before, after)) {
+    return { path: file, action: 'unchanged' };
+  }
+  const action: 'created' | 'updated' =
+    before ? 'updated' : (fs.existsSync(file) ? 'updated' : 'created');
+  if (!existing.mcpServers) existing.mcpServers = {};
+  existing.mcpServers.codegraph = after;
+  writeJsonFile(file, existing);
+  return { path: file, action };
+}
+
+function buildQwenMcpEntry(): { command: string; args: string[] } {
+  return {
+    command: 'codegraph',
+    args: ['serve', '--mcp'],
+  };
+}
+
+/**
+ * Strip the marker-delimited CodeGraph block from QWEN.md if a prior
+ * install wrote one.
+ */
+function removeInstructionsEntry(loc: Location): WriteResult['files'][number] {
+  const file = instructionsPath(loc);
+  const action = removeMarkedSection(file, CODEGRAPH_SECTION_START, CODEGRAPH_SECTION_END);
+  return { path: file, action };
+}
+
+export const qwenTarget: AgentTarget = new QwenTarget();

--- a/src/installer/targets/registry.ts
+++ b/src/installer/targets/registry.ts
@@ -14,6 +14,7 @@ import { codexTarget } from './codex';
 import { opencodeTarget } from './opencode';
 import { hermesTarget } from './hermes';
 import { geminiTarget } from './gemini';
+import { qwenTarget } from './qwen';
 import { antigravityTarget } from './antigravity';
 import { kiroTarget } from './kiro';
 
@@ -24,6 +25,7 @@ export const ALL_TARGETS: readonly AgentTarget[] = Object.freeze([
   opencodeTarget,
   hermesTarget,
   geminiTarget,
+  qwenTarget,
   antigravityTarget,
   kiroTarget,
 ]);

--- a/src/installer/targets/types.ts
+++ b/src/installer/targets/types.ts
@@ -19,7 +19,16 @@ export type Location = 'global' | 'local';
  * lookup. New targets add a value here when they're added to the
  * registry. Keep these short and lowercase.
  */
-export type TargetId = 'claude' | 'cursor' | 'codex' | 'opencode' | 'hermes' | 'gemini' | 'antigravity' | 'kiro';
+export type TargetId =
+  | 'claude'
+  | 'cursor'
+  | 'codex'
+  | 'opencode'
+  | 'hermes'
+  | 'gemini'
+  | 'qwen'
+  | 'antigravity'
+  | 'kiro';
 
 /**
  * Result of `target.detect(location)`.


### PR DESCRIPTION
## Summary
- Add Qwen Code as a supported installer target with global and local settings support.
- Preserve existing Qwen settings while adding the CodeGraph MCP server and QWEN.md context hint.
- Document Qwen Code support in the README and changelog.

## Test Plan
- /opt/homebrew/opt/node@22/bin/npm run build
- /opt/homebrew/opt/node@22/bin/npm test — 113 files passed; 1,825 tests passed; 4 skipped
- /opt/homebrew/opt/node@22/bin/npx vitest run __tests__/index-orphan-watchdog.test.ts
- git diff --check

## Local validation
- Configured /Users/zebinhuang/code/realmforge-server with the new Qwen target.
- Rebuilt its CodeGraph index: 580 files, 10,873 nodes, 25,518 edges.

## Branch status
- Rebased on latest upstream main at c5bd6e2.
