### PR TITLE
 feat(config): add ignore field to codegraph.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### New Features
+
+- `codegraph.json` now supports an `ignore` field — an array of gitignore-style patterns that exclude matching paths from indexing and embedded-repo discovery. Useful for large gitignored directories containing cloned reference repos or data files that should never be indexed (e.g. `{"ignore": ["resource/"]}`).
+
 
 ## [1.1.0] - 2026-06-23
 

--- a/__tests__/ignore-patterns.test.ts
+++ b/__tests__/ignore-patterns.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { loadIgnorePatterns, clearProjectConfigCache } from '../src/project-config';
+import { scanDirectory, buildDefaultIgnore, discoverEmbeddedRepoRoots } from '../src/extraction';
+import { execFileSync } from 'child_process';
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cg-ignore-'));
+}
+
+function cleanupTempDir(dir: string): void {
+  if (fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const writeConfig = (dir: string, obj: unknown) =>
+  fs.writeFileSync(
+    path.join(dir, 'codegraph.json'),
+    typeof obj === 'string' ? obj : JSON.stringify(obj),
+  );
+
+const write = (dir: string, rel: string, body: string) => {
+  const p = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, body);
+};
+
+// ---------------------------------------------------------------------------
+// Unit: loadIgnorePatterns
+// ---------------------------------------------------------------------------
+
+describe('loadIgnorePatterns', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = createTempDir();
+    clearProjectConfigCache();
+  });
+  afterEach(() => {
+    clearProjectConfigCache();
+    cleanupTempDir(dir);
+  });
+
+  it('returns empty array when no codegraph.json exists', () => {
+    expect(loadIgnorePatterns(dir)).toEqual([]);
+  });
+
+  it('returns empty array when codegraph.json has no ignore field', () => {
+    writeConfig(dir, { extensions: { '.foo': 'typescript' } });
+    expect(loadIgnorePatterns(dir)).toEqual([]);
+  });
+
+  it('loads valid ignore patterns', () => {
+    writeConfig(dir, { ignore: ['resource/', 'data/', '*.generated.*'] });
+    expect(loadIgnorePatterns(dir)).toEqual(['resource/', 'data/', '*.generated.*']);
+  });
+
+  it('skips non-string entries with a warning', () => {
+    writeConfig(dir, { ignore: ['valid/', 123, null, 'also-valid/'] });
+    const result = loadIgnorePatterns(dir);
+    expect(result).toEqual(['valid/', 'also-valid/']);
+  });
+
+  it('skips empty/whitespace-only strings', () => {
+    writeConfig(dir, { ignore: ['keep/', '', '   ', 'also-keep/'] });
+    expect(loadIgnorePatterns(dir)).toEqual(['keep/', 'also-keep/']);
+  });
+
+  it('returns empty array for malformed JSON', () => {
+    fs.writeFileSync(path.join(dir, 'codegraph.json'), '{not valid json');
+    expect(loadIgnorePatterns(dir)).toEqual([]);
+  });
+
+  it('returns empty array when ignore is not an array', () => {
+    writeConfig(dir, { ignore: 'resource/' });
+    expect(loadIgnorePatterns(dir)).toEqual([]);
+  });
+
+  it('is mtime-cached (same result without re-reading)', () => {
+    writeConfig(dir, { ignore: ['a/'] });
+    const first = loadIgnorePatterns(dir);
+    const second = loadIgnorePatterns(dir);
+    expect(first).toBe(second);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: buildDefaultIgnore respects codegraph.json ignore
+// ---------------------------------------------------------------------------
+
+describe('buildDefaultIgnore with codegraph.json ignore', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = createTempDir();
+    clearProjectConfigCache();
+  });
+  afterEach(() => {
+    clearProjectConfigCache();
+    cleanupTempDir(dir);
+  });
+
+  it('ignores paths matching codegraph.json patterns', () => {
+    writeConfig(dir, { ignore: ['vendor/', '*.log'] });
+    const ig = buildDefaultIgnore(dir);
+    expect(ig.ignores('vendor/lib.ts')).toBe(true);
+    expect(ig.ignores('output.log')).toBe(true);
+    expect(ig.ignores('src/index.ts')).toBe(false);
+  });
+
+  it('merges with .gitignore patterns', () => {
+    write(dir, '.gitignore', 'build/\n');
+    writeConfig(dir, { ignore: ['data/'] });
+    const ig = buildDefaultIgnore(dir);
+    expect(ig.ignores('build/out.js')).toBe(true);
+    expect(ig.ignores('data/file.csv')).toBe(true);
+    expect(ig.ignores('src/app.ts')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: scanDirectory excludes files matching codegraph.json ignore
+// ---------------------------------------------------------------------------
+
+describe('scanDirectory with codegraph.json ignore', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = createTempDir();
+    clearProjectConfigCache();
+  });
+  afterEach(() => {
+    clearProjectConfigCache();
+    cleanupTempDir(dir);
+  });
+
+  it('excludes files in ignored directories', () => {
+    write(dir, 'src/index.ts', 'export const x = 1;');
+    write(dir, 'vendor/lib.ts', 'export const y = 2;');
+    writeConfig(dir, { ignore: ['vendor/'] });
+
+    const files = scanDirectory(dir);
+    expect(files).toContain('src/index.ts');
+    expect(files.every((f) => !f.startsWith('vendor/'))).toBe(true);
+  });
+
+  it('excludes files matching glob patterns', () => {
+    write(dir, 'src/app.ts', 'export const a = 1;');
+    write(dir, 'src/app.generated.ts', 'export const b = 2;');
+    writeConfig(dir, { ignore: ['*.generated.*'] });
+
+    const files = scanDirectory(dir);
+    expect(files).toContain('src/app.ts');
+    expect(files.every((f) => !f.includes('.generated.'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: embedded-repo discovery respects codegraph.json ignore
+// ---------------------------------------------------------------------------
+
+describe('discoverEmbeddedRepoRoots with codegraph.json ignore', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = createTempDir();
+    clearProjectConfigCache();
+  });
+  afterEach(() => {
+    clearProjectConfigCache();
+    cleanupTempDir(dir);
+  });
+
+  it('skips embedded repos in user-ignored directories', () => {
+    // Initialize a parent git repo
+    execFileSync('git', ['init'], { cwd: dir, stdio: 'pipe' });
+    execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: dir, stdio: 'pipe' });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir, stdio: 'pipe' });
+
+    // Create a file and commit so the repo is non-empty
+    write(dir, 'main.ts', 'export const main = 1;');
+    execFileSync('git', ['add', '.'], { cwd: dir, stdio: 'pipe' });
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: dir, stdio: 'pipe' });
+
+    // Create a nested git repo inside repos/child/
+    const childDir = path.join(dir, 'repos', 'child');
+    fs.mkdirSync(childDir, { recursive: true });
+    execFileSync('git', ['init'], { cwd: childDir, stdio: 'pipe' });
+    write(dir, 'repos/child/lib.ts', 'export const lib = 1;');
+
+    // Gitignore the repos/ dir (so it becomes an "ignored embedded repo")
+    write(dir, '.gitignore', 'repos/\n');
+
+    // Without codegraph.json ignore — the embedded repo IS discovered
+    clearProjectConfigCache();
+    const withoutIgnore = discoverEmbeddedRepoRoots(dir);
+    expect(withoutIgnore.some((r) => r.includes('repos/'))).toBe(true);
+
+    // With codegraph.json ignore — the embedded repo is NOT discovered
+    writeConfig(dir, { ignore: ['repos/'] });
+    clearProjectConfigCache();
+    const withIgnore = discoverEmbeddedRepoRoots(dir);
+    expect(withIgnore.every((r) => !r.includes('repos/'))).toBe(true);
+  });
+});

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -19,7 +19,7 @@ import {
 import { QueryBuilder } from '../db/queries';
 import { extractFromSource } from './tree-sitter';
 import { detectLanguage, isSourceFile, isLanguageSupported, isFileLevelOnlyLanguage, initGrammars, loadGrammarsForLanguages } from './grammars';
-import { loadExtensionOverrides } from '../project-config';
+import { loadExtensionOverrides, loadIgnorePatterns } from '../project-config';
 import { isCodeGraphDataDir } from '../directory';
 import { logDebug, logWarn } from '../errors';
 import { validatePathWithinRoot, normalizePath } from '../utils';
@@ -257,6 +257,8 @@ export function buildDefaultIgnore(rootDir: string): Ignore {
   const ig = ignore().add(DEFAULT_IGNORE_PATTERNS);
   const rootGitignore = path.join(rootDir, '.gitignore');
   if (fs.existsSync(rootGitignore)) ig.add(readGitignorePatterns(rootGitignore));
+  const extra = loadIgnorePatterns(rootDir);
+  if (extra.length > 0) ig.add(extra);
   return ig;
 }
 
@@ -458,6 +460,8 @@ export function discoverEmbeddedRepoRoots(rootDir: string): string[] {
   }
   const out: string[] = [];
   const defaults = defaultsOnlyIgnore();
+  const userPatterns = loadIgnorePatterns(rootDir);
+  const userIgnore = userPatterns.length > 0 ? ignore().add(userPatterns) : null;
   const visit = (repoAbs: string, prefix: string): void => {
     const candidates: string[] = [];
     try {
@@ -467,12 +471,12 @@ export function discoverEmbeddedRepoRoots(rootDir: string): string[] {
         { cwd: repoAbs, encoding: 'utf-8', timeout: 30000, maxBuffer: 50 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
       );
       for (const e of o.split('\0')) {
-        if (e.endsWith('/') && !isWholeCwdEntry(e) && !defaults.ignores(e)) {
+        if (e.endsWith('/') && !isWholeCwdEntry(e) && !defaults.ignores(e) && !userIgnore?.ignores(e)) {
           candidates.push(...findNestedGitRepos(path.join(repoAbs, e), e));
         }
       }
     } catch { /* untracked listing failed — ignored-side discovery still runs */ }
-    candidates.push(...findIgnoredEmbeddedRepos(repoAbs));
+    candidates.push(...findIgnoredEmbeddedRepos(repoAbs, userIgnore));
     for (const rel of candidates) {
       const full = normalizePath(prefix + rel);
       out.push(full);
@@ -488,11 +492,12 @@ export function discoverEmbeddedRepoRoots(rootDir: string): string[] {
  * gitignored directory (skipping built-in default excludes), search for nested
  * `.git` roots. Returns repo paths relative to `repoDir`, trailing-slashed.
  */
-function findIgnoredEmbeddedRepos(repoDir: string): string[] {
+function findIgnoredEmbeddedRepos(repoDir: string, userIgnore?: Ignore | null): string[] {
   const defaults = defaultsOnlyIgnore();
   const repos: string[] = [];
   for (const dir of listIgnoredDirs(repoDir)) {
     if (defaults.ignores(dir)) continue;
+    if (userIgnore?.ignores(dir)) continue;
     repos.push(...findNestedGitRepos(path.join(repoDir, dir), dir));
   }
   return repos;
@@ -514,7 +519,7 @@ function findIgnoredEmbeddedRepos(repoDir: string): string[] {
  * embedded repo root (however found) is recorded in `embeddedRoots` so callers
  * can exempt its files from the parent's own gitignore rules.
  */
-function collectGitFiles(repoDir: string, prefix: string, files: Set<string>, embeddedRoots?: Set<string>): void {
+function collectGitFiles(repoDir: string, prefix: string, files: Set<string>, embeddedRoots?: Set<string>, userIgnore?: Ignore | null): void {
   const gitOpts = { cwd: repoDir, encoding: 'utf-8' as const, timeout: 30000, maxBuffer: 50 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] as ['pipe', 'pipe', 'pipe'], windowsHide: true };
 
   // Tracked files. --recurse-submodules pulls in files from active submodules,
@@ -546,9 +551,9 @@ function collectGitFiles(repoDir: string, prefix: string, files: Set<string>, em
       const childDir = path.join(repoDir, rel);
       // A git worktree surfaces here as an opaque untracked dir too — skip it,
       // it's a duplicate working view of an already-indexed repo (#848).
-      if (classifyGitDir(childDir) === 'embedded' && !defaultsOnlyIgnore().ignores(rel)) {
+      if (classifyGitDir(childDir) === 'embedded' && !defaultsOnlyIgnore().ignores(rel) && !userIgnore?.ignores(rel)) {
         embeddedRoots?.add(normalizePath(prefix + rel));
-        collectGitFiles(childDir, prefix + rel, files, embeddedRoots);
+        collectGitFiles(childDir, prefix + rel, files, embeddedRoots, userIgnore);
       }
       continue;
     }
@@ -558,9 +563,9 @@ function collectGitFiles(repoDir: string, prefix: string, files: Set<string>, em
   // Embedded repos hidden by THIS repo's ignore rules (`/packages/` in a
   // super-repo .gitignore) never appear in any listing above — discover and
   // recurse into them too. (#514)
-  for (const rel of findIgnoredEmbeddedRepos(repoDir)) {
+  for (const rel of findIgnoredEmbeddedRepos(repoDir, userIgnore)) {
     embeddedRoots?.add(normalizePath(prefix + rel));
-    collectGitFiles(path.join(repoDir, rel), prefix + rel, files, embeddedRoots);
+    collectGitFiles(path.join(repoDir, rel), prefix + rel, files, embeddedRoots, userIgnore);
   }
 }
 
@@ -598,7 +603,9 @@ function getGitVisibleFiles(rootDir: string): Set<string> | null {
 
     const files = new Set<string>();
     const embeddedRoots = new Set<string>();
-    collectGitFiles(rootDir, '', files, embeddedRoots);
+    const userPatterns = loadIgnorePatterns(rootDir);
+    const userIgnore = userPatterns.length > 0 ? ignore().add(userPatterns) : null;
+    collectGitFiles(rootDir, '', files, embeddedRoots, userIgnore);
     // Apply built-in default ignores uniformly — to tracked files too, since
     // committing a dependency/build dir doesn't make it project code. A
     // `.gitignore` negation (e.g. `!vendor/`) is the explicit opt-in. (issue #407)
@@ -641,14 +648,16 @@ function getGitChangedFiles(rootDir: string): GitChanges | null {
     // Custom extension → language overrides from the project's codegraph.json,
     // so change detection sees the same custom-extension files the full index does.
     const overrides = loadExtensionOverrides(rootDir);
-    collectGitStatus(rootDir, '', changes, overrides);
+    const userPatterns = loadIgnorePatterns(rootDir);
+    const userIgnore = userPatterns.length > 0 ? ignore().add(userPatterns) : null;
+    collectGitStatus(rootDir, '', changes, overrides, userIgnore);
     return changes;
   } catch {
     return null;
   }
 }
 
-function collectGitStatus(repoDir: string, prefix: string, out: GitChanges, overrides?: Record<string, Language>): void {
+function collectGitStatus(repoDir: string, prefix: string, out: GitChanges, overrides?: Record<string, Language>, userIgnore?: Ignore | null): void {
   const output = execFileSync(
     'git',
     ['status', '--porcelain', '--no-renames'],
@@ -708,11 +717,11 @@ function collectGitStatus(repoDir: string, prefix: string, out: GitChanges, over
   // nested deeper) and under this repo's gitignored dirs.
   for (const rel of untrackedDirs) {
     for (const repoRel of findNestedGitRepos(path.join(repoDir, rel), rel)) {
-      collectGitStatus(path.join(repoDir, repoRel), prefix + repoRel, out, overrides);
+      collectGitStatus(path.join(repoDir, repoRel), prefix + repoRel, out, overrides, userIgnore);
     }
   }
-  for (const rel of findIgnoredEmbeddedRepos(repoDir)) {
-    collectGitStatus(path.join(repoDir, rel), prefix + rel, out, overrides);
+  for (const rel of findIgnoredEmbeddedRepos(repoDir, userIgnore)) {
+    collectGitStatus(path.join(repoDir, rel), prefix + rel, out, overrides, userIgnore);
   }
 }
 

--- a/src/project-config.ts
+++ b/src/project-config.ts
@@ -34,6 +34,8 @@ export const PROJECT_CONFIG_FILENAME = 'codegraph.json';
 export interface ProjectConfig {
   /** Map of custom file extension (`.foo`) to a supported language id. */
   extensions?: Record<string, string>;
+  /** Gitignore-style patterns to exclude from indexing and embedded-repo discovery. */
+  ignore?: string[];
 }
 
 interface CacheEntry {
@@ -148,8 +150,83 @@ export function loadExtensionOverrides(rootDir: string): Record<string, Language
   return overrides;
 }
 
+// ---------------------------------------------------------------------------
+// Ignore patterns
+// ---------------------------------------------------------------------------
+
+interface IgnoreCacheEntry {
+  mtimeMs: number;
+  patterns: string[];
+}
+
+const ignoreCache = new Map<string, string[]>();
+const ignoreCacheMeta = new Map<string, IgnoreCacheEntry>();
+
+const EMPTY_PATTERNS: string[] = Object.freeze([]) as unknown as string[];
+
+function parseIgnorePatterns(file: string): string[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, 'utf-8');
+  } catch {
+    return EMPTY_PATTERNS;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return EMPTY_PATTERNS;
+  }
+
+  if (!parsed || typeof parsed !== 'object') return EMPTY_PATTERNS;
+  const patterns = (parsed as ProjectConfig).ignore;
+  if (!Array.isArray(patterns)) return EMPTY_PATTERNS;
+
+  const out: string[] = [];
+  for (const entry of patterns) {
+    if (typeof entry === 'string' && entry.trim().length > 0) {
+      out.push(entry.trim());
+    } else {
+      logWarn(`Ignoring non-string entry in ${PROJECT_CONFIG_FILENAME} "ignore" array`, { file });
+    }
+  }
+
+  return out.length > 0 ? out : EMPTY_PATTERNS;
+}
+
+/**
+ * Load user-configured ignore patterns from `codegraph.json`, mtime-cached.
+ *
+ * Returns an array of gitignore-style pattern strings that should be excluded
+ * from indexing and embedded-repo discovery. Returns an empty array when there
+ * is no `codegraph.json` or no `ignore` field (the zero-config default).
+ */
+export function loadIgnorePatterns(rootDir: string): string[] {
+  const file = path.join(rootDir, PROJECT_CONFIG_FILENAME);
+
+  let mtimeMs: number;
+  try {
+    mtimeMs = fs.statSync(file).mtimeMs;
+  } catch {
+    ignoreCacheMeta.delete(rootDir);
+    ignoreCache.delete(rootDir);
+    return EMPTY_PATTERNS;
+  }
+
+  const meta = ignoreCacheMeta.get(rootDir);
+  if (meta && meta.mtimeMs === mtimeMs) return meta.patterns;
+
+  const patterns = parseIgnorePatterns(file);
+  ignoreCacheMeta.set(rootDir, { mtimeMs, patterns });
+  ignoreCache.set(rootDir, patterns);
+  return patterns;
+}
+
 /** Test/maintenance hook: forget cached config (e.g. after rewriting it in a test). */
 export function clearProjectConfigCache(): void {
   cacheMeta.clear();
   overridesCache.clear();
+  ignoreCacheMeta.clear();
+  ignoreCache.clear();
 }


### PR DESCRIPTION
Problem

  When a project has a large gitignored directory containing nested git repos (e.g. cloned reference repos for knowledge-base analysis), codegraph index
  is extremely slow. This happens because findIgnoredEmbeddedRepos actively walks into every gitignored directory looking for .git dirs, then recursively
  indexes all nested repos it finds — even if the user explicitly gitignored them.

  Example: a resource/ directory (4.2 GB, ~26k files, 27 nested git repos) that is already in .gitignore still gets fully traversed and indexed. There
  was no way to tell codegraph "don't look inside this path."

  Solution

  Add an ignore field to codegraph.json — an array of gitignore-style patterns:

  {
    "ignore": ["resource/", "data/"]
  }

  These patterns are injected into:
  1. buildDefaultIgnore — excludes matching files from indexing (also propagates to the file watcher via buildScopeIgnore)
  2. discoverEmbeddedRepoRoots / findIgnoredEmbeddedRepos — skips matching directories during embedded-repo discovery, preventing the expensive recursive
  walk
  3. collectGitFiles / collectGitStatus — ensures consistent exclusion during incremental sync

  Why this approach

  - Single injection point for file filtering — buildDefaultIgnore is the root of both the indexer and watcher scope, so one change covers both
  - Separate injection for embedded-repo discovery — the discovery path uses defaultsOnlyIgnore() (intentionally no .gitignore) so it needed explicit
  threading of user patterns
  - Follows existing patterns — same codegraph.json file, same mtime-cached loader design as the existing extensions field
  - Zero-config preserved — no codegraph.json = no change in behavior

  Test plan

  - 13 new tests in __tests__/ignore-patterns.test.ts:
    - Unit: loadIgnorePatterns parsing, validation, caching
    - Integration: scanDirectory excludes matching files
    - Integration: discoverEmbeddedRepoRoots skips user-ignored directories
    
  link #970 