### PR TITLE
feat: add Micronaut framework route extraction

### DIFF
--- a/__tests__/micronaut.test.ts
+++ b/__tests__/micronaut.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from 'vitest';
+import { micronautResolver } from '../src/resolution/frameworks/micronaut';
+
+describe('micronautResolver.extract', () => {
+  it('extracts GET route with @Controller prefix and @Get annotation', () => {
+    const src = `
+package io.kestra.webserver.controllers.api;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+@Controller("/api/v1/executions")
+public class ExecutionController {
+
+    @Get(uri = "/search")
+    public PagedResults<Execution> searchExecutions(
+            @QueryValue String query) {
+        return service.search(query);
+    }
+}
+`;
+    const { nodes, references } = micronautResolver.extract!('controllers/ExecutionController.java', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].kind).toBe('route');
+    expect(nodes[0].name).toBe('GET /api/v1/executions/search');
+    expect(references).toHaveLength(1);
+    expect(references[0].referenceName).toBe('searchExecutions');
+    expect(references[0].fromNodeId).toBe(nodes[0].id);
+  });
+
+  it('extracts route with bare string path (no uri= prefix)', () => {
+    const src = `
+@Controller("/api/users")
+public class UserController {
+
+    @Get("/{id}")
+    public User getUser(@PathVariable Long id) {
+        return repo.findById(id);
+    }
+}
+`;
+    const { nodes, references } = micronautResolver.extract!('controllers/UserController.java', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe('GET /api/users/{id}');
+    expect(references[0].referenceName).toBe('getUser');
+  });
+
+  it('extracts multiple routes from one controller', () => {
+    const src = `
+@Controller("/api/v1/flows")
+public class FlowController {
+
+    @Get("/search")
+    public PagedResults<Flow> find(@QueryValue String q) {
+        return service.find(q);
+    }
+
+    @Post
+    public Flow create(@Body Flow flow) {
+        return service.create(flow);
+    }
+
+    @Put("/{id}")
+    public Flow update(@PathVariable String id, @Body Flow flow) {
+        return service.update(id, flow);
+    }
+
+    @Delete("/{id}")
+    public void delete(@PathVariable String id) {
+        service.delete(id);
+    }
+}
+`;
+    const { nodes, references } = micronautResolver.extract!('controllers/FlowController.java', src);
+    expect(nodes).toHaveLength(4);
+    expect(nodes[0].name).toBe('GET /api/v1/flows/search');
+    expect(nodes[1].name).toBe('POST /api/v1/flows');
+    expect(nodes[2].name).toBe('PUT /api/v1/flows/{id}');
+    expect(nodes[3].name).toBe('DELETE /api/v1/flows/{id}');
+    expect(references.map(r => r.referenceName)).toEqual(['find', 'create', 'update', 'delete']);
+  });
+
+  it('extracts route with path template variables', () => {
+    const src = `
+@Controller("/api/v1/{tenant}/executions")
+public class ExecutionController {
+
+    @Post(uri = "/{id}/restart")
+    public Execution restart(@PathVariable String tenant, @PathVariable String id) {
+        return service.restart(id);
+    }
+}
+`;
+    const { nodes } = micronautResolver.extract!('controllers/ExecutionController.java', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe('POST /api/v1/{tenant}/executions/{id}/restart');
+  });
+
+  it('handles @Get with no path (empty route inherits class prefix only)', () => {
+    const src = `
+@Controller("/health")
+public class HealthController {
+
+    @Get
+    public String health() {
+        return "OK";
+    }
+}
+`;
+    const { nodes, references } = micronautResolver.extract!('controllers/HealthController.java', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe('GET /health');
+    expect(references[0].referenceName).toBe('health');
+  });
+
+  it('handles controller with no class-level prefix', () => {
+    const src = `
+@Controller
+public class RootController {
+
+    @Get("/status")
+    public String status() {
+        return "up";
+    }
+}
+`;
+    const { nodes } = micronautResolver.extract!('controllers/RootController.java', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe('GET /status');
+  });
+
+  it('extracts routes from Kotlin files', () => {
+    const src = `
+@Controller("/api/tasks")
+class TaskController(private val service: TaskService) {
+
+    @Get("/{id}")
+    fun getTask(@PathVariable id: String): Task {
+        return service.findById(id)
+    }
+
+    @Post
+    fun createTask(@Body task: Task): Task {
+        return service.create(task)
+    }
+}
+`;
+    const { nodes, references } = micronautResolver.extract!('controllers/TaskController.kt', src);
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0].name).toBe('GET /api/tasks/{id}');
+    expect(nodes[1].name).toBe('POST /api/tasks');
+    expect(references[0].referenceName).toBe('getTask');
+    expect(references[1].referenceName).toBe('createTask');
+    expect(nodes[0].language).toBe('kotlin');
+  });
+
+  it('handles value= parameter syntax', () => {
+    const src = `
+@Controller("/api")
+public class ApiController {
+
+    @Get(value = "/info")
+    public Info getInfo() {
+        return new Info();
+    }
+}
+`;
+    const { nodes } = micronautResolver.extract!('controllers/ApiController.java', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe('GET /api/info');
+  });
+
+  it('handles @Head and @Options verbs', () => {
+    const src = `
+@Controller("/api")
+public class OptionsController {
+
+    @Head("/ping")
+    public void headPing() {}
+
+    @Options("/cors")
+    public void corsOptions() {}
+}
+`;
+    const { nodes } = micronautResolver.extract!('controllers/OptionsController.java', src);
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0].name).toBe('HEAD /api/ping');
+    expect(nodes[1].name).toBe('OPTIONS /api/cors');
+  });
+
+  it('extracts @Client interface routes', () => {
+    const src = `
+@Client("/api/v1/users")
+public interface UserClient {
+
+    @Get("/{id}")
+    User getById(@PathVariable String id);
+
+    @Post
+    User create(@Body User user);
+}
+`;
+    const { nodes, references } = micronautResolver.extract!('client/UserClient.java', src);
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0].name).toBe('GET /api/v1/users/{id}');
+    expect(nodes[1].name).toBe('POST /api/v1/users');
+    expect(references[0].referenceName).toBe('getById');
+  });
+
+  it('returns empty for non-Java/Kotlin files', () => {
+    const { nodes, references } = micronautResolver.extract!('config/application.yml', 'micronaut.server.port: 8080');
+    expect(nodes).toEqual([]);
+    expect(references).toEqual([]);
+  });
+
+  it('handles @Patch annotation', () => {
+    const src = `
+@Controller("/api/items")
+public class ItemController {
+
+    @Patch("/{id}")
+    public Item patchItem(@PathVariable String id, @Body Map<String, Object> updates) {
+        return service.patch(id, updates);
+    }
+}
+`;
+    const { nodes } = micronautResolver.extract!('controllers/ItemController.java', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe('PATCH /api/items/{id}');
+  });
+
+  it('handles @HttpMethodMapping for custom verbs', () => {
+    const src = `
+@Controller("/api/custom")
+public class CustomController {
+
+    @HttpMethodMapping("/action")
+    public void customAction() {}
+}
+`;
+    const { nodes } = micronautResolver.extract!('controllers/CustomController.java', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe('ANY /api/custom/action');
+  });
+});
+
+describe('micronautResolver.detect', () => {
+  it('detects via pom.xml with io.micronaut', () => {
+    const context = createMockContext({
+      'pom.xml': '<dependency><groupId>io.micronaut</groupId></dependency>',
+    });
+    expect(micronautResolver.detect(context)).toBe(true);
+  });
+
+  it('detects via build.gradle with io.micronaut', () => {
+    const context = createMockContext({
+      'build.gradle': 'implementation "io.micronaut:micronaut-http-server-netty"',
+    });
+    expect(micronautResolver.detect(context)).toBe(true);
+  });
+
+  it('does not detect for Spring-only projects', () => {
+    const context = createMockContext({
+      'pom.xml': '<dependency><groupId>org.springframework.boot</groupId></dependency>',
+    });
+    expect(micronautResolver.detect(context)).toBe(false);
+  });
+});
+
+function createMockContext(files: Record<string, string>) {
+  return {
+    readFile: (path: string) => files[path] ?? null,
+    getAllFiles: () => Object.keys(files),
+    getNodesByName: () => [],
+    getNodesByQualifiedName: () => [],
+    getNodesByKind: () => [],
+    getNodesInFile: () => [],
+    fileExists: (path: string) => path in files,
+    getProjectRoot: () => '/project',
+    getNodesByLowerName: () => [],
+    getImportMappings: () => [],
+  } as any;
+}

--- a/src/resolution/frameworks/index.ts
+++ b/src/resolution/frameworks/index.ts
@@ -17,6 +17,7 @@ import { astroResolver } from './astro';
 import { djangoResolver, flaskResolver, fastapiResolver } from './python';
 import { railsResolver } from './ruby';
 import { springResolver } from './java';
+import { micronautResolver } from './micronaut';
 import { playResolver } from './play';
 import { goResolver } from './go';
 import { goframeResolver } from './goframe';
@@ -50,6 +51,7 @@ const FRAMEWORK_RESOLVERS: FrameworkResolver[] = [
   railsResolver,
   // Java
   springResolver,
+  micronautResolver,
   playResolver,
   // Go
   goResolver,
@@ -136,6 +138,7 @@ export { astroResolver } from './astro';
 export { djangoResolver, flaskResolver, fastapiResolver } from './python';
 export { railsResolver } from './ruby';
 export { springResolver } from './java';
+export { micronautResolver } from './micronaut';
 export { playResolver } from './play';
 export { goResolver } from './go';
 export { goframeResolver } from './goframe';

--- a/src/resolution/frameworks/micronaut.ts
+++ b/src/resolution/frameworks/micronaut.ts
@@ -1,0 +1,266 @@
+/**
+ * Micronaut Framework Resolver
+ *
+ * Handles Micronaut HTTP route extraction and DI resolution.
+ */
+
+import { Node } from '../../types';
+import { FrameworkResolver, UnresolvedRef, ResolvedRef, ResolutionContext } from '../types';
+import { stripCommentsForRegex } from '../strip-comments';
+
+export const micronautResolver: FrameworkResolver = {
+  name: 'micronaut',
+  languages: ['java', 'kotlin'],
+
+  detect(context: ResolutionContext): boolean {
+    const pomXml = context.readFile('pom.xml');
+    if (pomXml && pomXml.includes('io.micronaut')) {
+      return true;
+    }
+
+    const buildGradle = context.readFile('build.gradle');
+    if (buildGradle && buildGradle.includes('io.micronaut')) {
+      return true;
+    }
+
+    const buildGradleKts = context.readFile('build.gradle.kts');
+    if (buildGradleKts && buildGradleKts.includes('io.micronaut')) {
+      return true;
+    }
+
+    // Multi-module: check settings.gradle for micronaut plugin
+    const settingsGradle = context.readFile('settings.gradle');
+    if (settingsGradle && settingsGradle.includes('micronaut')) {
+      return true;
+    }
+
+    const settingsGradleKts = context.readFile('settings.gradle.kts');
+    if (settingsGradleKts && settingsGradleKts.includes('micronaut')) {
+      return true;
+    }
+
+    // Check for Micronaut annotations in Java/Kotlin files
+    const allFiles = context.getAllFiles();
+    for (const file of allFiles) {
+      if (file.endsWith('.java') || file.endsWith('.kt')) {
+        const content = context.readFile(file);
+        if (content && (
+          content.includes('io.micronaut.http.annotation') ||
+          content.includes('@MicronautApplication') ||
+          content.includes('@Controller')
+        )) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  },
+
+  resolve(ref: UnresolvedRef, context: ResolutionContext): ResolvedRef | null {
+    // Pattern 1: Service/Bean references (DI)
+    if (ref.referenceName.endsWith('Service')) {
+      const result = resolveByNameAndKind(ref.referenceName, INJECTABLE_KINDS, SERVICE_DIRS, context);
+      if (result) {
+        return { original: ref, targetNodeId: result, confidence: 0.85, resolvedBy: 'framework' };
+      }
+    }
+
+    // Pattern 2: Repository references
+    if (ref.referenceName.endsWith('Repository')) {
+      const result = resolveByNameAndKind(ref.referenceName, INJECTABLE_KINDS, REPO_DIRS, context);
+      if (result) {
+        return { original: ref, targetNodeId: result, confidence: 0.85, resolvedBy: 'framework' };
+      }
+    }
+
+    // Pattern 3: Controller references
+    if (ref.referenceName.endsWith('Controller')) {
+      const result = resolveByNameAndKind(ref.referenceName, CLASS_KINDS, CONTROLLER_DIRS, context);
+      if (result) {
+        return { original: ref, targetNodeId: result, confidence: 0.85, resolvedBy: 'framework' };
+      }
+    }
+
+    // Pattern 4: Client references (@Client interfaces)
+    if (ref.referenceName.endsWith('Client')) {
+      const result = resolveByNameAndKind(ref.referenceName, INJECTABLE_KINDS, CLIENT_DIRS, context);
+      if (result) {
+        return { original: ref, targetNodeId: result, confidence: 0.8, resolvedBy: 'framework' };
+      }
+    }
+
+    return null;
+  },
+
+  extract(filePath, content) {
+    if (!filePath.endsWith('.java') && !filePath.endsWith('.kt')) return { nodes: [], references: [] };
+    const nodes: Node[] = [];
+    const references: UnresolvedRef[] = [];
+    const now = Date.now();
+    const lang: 'java' | 'kotlin' = filePath.endsWith('.kt') ? 'kotlin' : 'java';
+    const safe = stripCommentsForRegex(content, 'java');
+
+    // Class-level @Controller prefix
+    let classPrefix = '';
+    const controllerMatch = /@Controller\s*\(\s*([^)]*)\s*\)/.exec(safe);
+    if (controllerMatch) {
+      classPrefix = parseMicronautPath(controllerMatch[1]!);
+    }
+
+    // Also check @Client for declarative HTTP clients (same route extraction logic)
+    if (!controllerMatch) {
+      const clientMatch = /@Client\s*\(\s*([^)]*)\s*\)/.exec(safe);
+      if (clientMatch) {
+        classPrefix = parseMicronautPath(clientMatch[1]!);
+      }
+    }
+
+    const VERB: Record<string, string> = {
+      Get: 'GET',
+      Post: 'POST',
+      Put: 'PUT',
+      Delete: 'DELETE',
+      Patch: 'PATCH',
+      Head: 'HEAD',
+      Options: 'OPTIONS',
+      Trace: 'TRACE',
+    };
+
+    // Match @Get, @Post, @Put, @Delete, @Patch, @Head, @Options, @Trace
+    // Handles: @Get("/path"), @Get(uri="/path"), @Get(value="/path"), @Get (bare)
+    const verbRegex = /@(Get|Post|Put|Delete|Patch|Head|Options|Trace)\b\s*(\([^)]*\))?/g;
+    let match: RegExpExecArray | null;
+    while ((match = verbRegex.exec(safe)) !== null) {
+      const method = VERB[match[1]!]!;
+      const args = (match[2] || '').replace(/^\(|\)$/g, '');
+      const sub = parseMicronautPath(args);
+      const routePath = joinPath(classPrefix, sub);
+      const line = safe.slice(0, match.index).split('\n').length;
+      const routeNode: Node = {
+        id: `route:${filePath}:${line}:${method}:${routePath}`,
+        kind: 'route',
+        name: `${method} ${routePath}`,
+        qualifiedName: `${filePath}::route:${routePath}`,
+        filePath,
+        startLine: line,
+        endLine: line,
+        startColumn: 0,
+        endColumn: match[0].length,
+        language: lang,
+        updatedAt: now,
+      };
+      nodes.push(routeNode);
+
+      // Find the handler method following the annotation.
+      // Handles: Kotlin `fun x(`, Java with modifiers `public X x(`, and
+      // interface methods without modifiers `ReturnType name(`.
+      const tail = safe.slice(match.index + match[0].length, match.index + match[0].length + 600);
+      const methodMatch = tail.match(
+        /\bfun\s+(\w+)\s*\(|\b(?:public|private|protected|internal)\s+[^;{=]*?\s+(\w+)\s*\(|^\s*\w[\w<>,?\s]*\s+(\w+)\s*\(/m,
+      );
+      if (methodMatch) {
+        references.push({
+          fromNodeId: routeNode.id,
+          referenceName: (methodMatch[1] ?? methodMatch[2] ?? methodMatch[3])!,
+          referenceKind: 'references',
+          line,
+          column: 0,
+          filePath,
+          language: lang,
+        });
+      }
+    }
+
+    // Micronaut also supports @HttpMethodMapping for custom verbs
+    const customVerbRegex = /@HttpMethodMapping\s*\(\s*([^)]*)\s*\)/g;
+    while ((match = customVerbRegex.exec(safe)) !== null) {
+      const args = match[1]!;
+      const sub = parseMicronautPath(args);
+      const routePath = joinPath(classPrefix, sub);
+      const line = safe.slice(0, match.index).split('\n').length;
+      const routeNode: Node = {
+        id: `route:${filePath}:${line}:ANY:${routePath}`,
+        kind: 'route',
+        name: `ANY ${routePath}`,
+        qualifiedName: `${filePath}::route:${routePath}`,
+        filePath,
+        startLine: line,
+        endLine: line,
+        startColumn: 0,
+        endColumn: match[0].length,
+        language: lang,
+        updatedAt: now,
+      };
+      nodes.push(routeNode);
+
+      const tail = safe.slice(match.index + match[0].length, match.index + match[0].length + 600);
+      const methodMatch = tail.match(
+        /\bfun\s+(\w+)\s*\(|\b(?:public|private|protected|internal)\s+[^;{=]*?\s+(\w+)\s*\(|^\s*\w[\w<>,?\s]*\s+(\w+)\s*\(/m,
+      );
+      if (methodMatch) {
+        references.push({
+          fromNodeId: routeNode.id,
+          referenceName: (methodMatch[1] ?? methodMatch[2] ?? methodMatch[3])!,
+          referenceKind: 'references',
+          line,
+          column: 0,
+          filePath,
+          language: lang,
+        });
+      }
+    }
+
+    return { nodes, references };
+  },
+};
+
+// Directory patterns for Micronaut conventions
+const SERVICE_DIRS = ['/service/', '/services/'];
+const REPO_DIRS = ['/repository/', '/repositories/'];
+const CONTROLLER_DIRS = ['/controller/', '/controllers/'];
+const CLIENT_DIRS = ['/client/', '/clients/'];
+
+const CLASS_KINDS = new Set(['class']);
+const INJECTABLE_KINDS = new Set(['class', 'interface']);
+
+/**
+ * Parse a path from Micronaut annotation arguments.
+ * Handles: "/path", uri="/path", uri = "/path", value="/path", bare empty
+ */
+function parseMicronautPath(args: string): string {
+  if (!args.trim()) return '';
+  // uri = "/path" or value = "/path"
+  const namedParam = args.match(/(?:uri|value)\s*=\s*["']([^"']*)["']/);
+  if (namedParam) return namedParam[1]!;
+  // bare string: "/path"
+  const bareString = args.match(/["']([^"']*)["']/);
+  if (bareString) return bareString[1]!;
+  return '';
+}
+
+/** Join a class-level prefix and a method sub-path into one normalized /path. */
+function joinPath(prefix: string, sub: string): string {
+  const parts = [prefix, sub].map((p) => p.replace(/^\/+|\/+$/g, '')).filter(Boolean);
+  return '/' + parts.join('/');
+}
+
+function resolveByNameAndKind(
+  name: string,
+  kinds: Set<string>,
+  preferredDirPatterns: string[],
+  context: ResolutionContext,
+): string | null {
+  const candidates = context.getNodesByName(name);
+  if (candidates.length === 0) return null;
+
+  const kindFiltered = candidates.filter((n) => kinds.has(n.kind));
+  if (kindFiltered.length === 0) return null;
+
+  const preferred = kindFiltered.filter((n) =>
+    preferredDirPatterns.some((d) => n.filePath.includes(d)),
+  );
+
+  if (preferred.length > 0) return preferred[0]!.id;
+  return kindFiltered[0]!.id;
+}


### PR DESCRIPTION
## Summary

Adds a new `micronautResolver` framework resolver that extracts HTTP route nodes from Micronaut annotations, enabling `codegraph_explore` to resolve URL paths (e.g. `/api/v1/executions/search`) directly to their handler methods.

**Supported annotations:**
- Class-level: `@Controller("/prefix")`, `@Client("/prefix")`
- Method-level: `@Get`, `@Post`, `@Put`, `@Delete`, `@Patch`, `@Head`, `@Options`, `@Trace`, `@HttpMethodMapping`
- Path syntax: `@Get("/path")`, `@Get(uri = "/path")`, `@Get(value = "/path")`, bare `@Get`

**What it does:**
- Detects Micronaut projects via `pom.xml` / `build.gradle` / annotation scanning
- Emits `kind: 'route'` nodes with full resolved paths (class prefix + method path)
- Creates `references` edges linking route nodes to handler method names
- Supports both Java and Kotlin source files
- Handles interface methods (e.g. `@Client` declarative HTTP clients) without access modifiers

## Files changed

- `src/resolution/frameworks/micronaut.ts` — New resolver (extract + detect + resolve)
- `src/resolution/frameworks/index.ts` — Register `micronautResolver` in the framework list
- `__tests__/micronaut.test.ts` — 16 test cases covering all annotation patterns

## Test plan

- [x] All 16 new Micronaut tests pass
- [x] Existing framework tests (129 tests) pass with no regression
- [x] Manual verification with [Kestra](https://github.com/kestra-io/kestra) codebase (Micronaut project)

## Verification on Kestra (real-world Micronaut project)

Ran `codegraph init` on Kestra (2,877 files) with this branch:

- **399 route nodes** extracted from Micronaut controllers
- Route-to-handler edges correctly established, e.g.:

```
route: GET /api/v1/{tenant}/executions/search
  → file: ExecutionController.java:204
  → handler: searchExecutions (method)
  → edge: references
```

Sample indexed routes:
```
GET /api/v1/{tenant}/executions/search           → ExecutionController.java:204
DELETE /api/v1/{tenant}/flows/{namespace}/{id}    → FlowController.java:564
DELETE /api/v1/{tenant}/dashboards/{id}           → DashboardController.java:192
POST /api/v1/{tenant}/executions/{id}/restart    → ExecutionController.java
```

Before this change, querying `/executions/search` via CodeGraph returned irrelevant FTS5 matches on the word "search" across unrelated symbols. After this change, the route resolves directly to the handler method with full call-chain traversal.

Closes #971