### PR TITLE
fix: stop nameMatchBonus awarding a spurious +10 on a whitespace-only query

### DIFF
--- a/__tests__/context-ranking.test.ts
+++ b/__tests__/context-ranking.test.ts
@@ -16,7 +16,7 @@ import * as path from 'path';
 import * as os from 'os';
 import CodeGraph from '../src/index';
 import { LOW_CONFIDENCE_MARKER } from '../src/context';
-import { isDistinctiveIdentifier, scorePathRelevance, deriveProjectNameTokens } from '../src/search/query-utils';
+import { isDistinctiveIdentifier, scorePathRelevance, deriveProjectNameTokens, nameMatchBonus } from '../src/search/query-utils';
 
 describe('isDistinctiveIdentifier', () => {
   it('treats plain dictionary words as non-distinctive', () => {
@@ -36,6 +36,26 @@ describe('isDistinctiveIdentifier', () => {
     expect(isDistinctiveIdentifier('user_store')).toBe(true);
     expect(isDistinctiveIdentifier('REST')).toBe(true);
     expect(isDistinctiveIdentifier('v2')).toBe(true);
+  });
+});
+
+// An empty / whitespace-only query has no name to match, so the bonus must be
+// 0. Before the guard, `queryLower` collapsed to '' and `nameLower.startsWith('')`
+// (always true) awarded a spurious flat +10 to every node. This is reachable via
+// `searchNodes('   ')`, where the rescoring guard `text || query` passes a
+// whitespace-only query through to nameMatchBonus.
+describe('nameMatchBonus empty/whitespace query', () => {
+  it('returns 0 for an empty query', () => {
+    expect(nameMatchBonus('authenticate', '')).toBe(0);
+  });
+
+  it('returns 0 for a whitespace-only query', () => {
+    expect(nameMatchBonus('authenticate', '   ')).toBe(0);
+    expect(nameMatchBonus('anything', '\t\n')).toBe(0);
+  });
+
+  it('still scores a real query (exact match unaffected by the guard)', () => {
+    expect(nameMatchBonus('authenticate', 'authenticate')).toBe(80);
   });
 });
 

--- a/src/search/query-utils.ts
+++ b/src/search/query-utils.ts
@@ -343,6 +343,16 @@ function matchesNonProductionDir(lowerPath: string): boolean {
 export function nameMatchBonus(nodeName: string, query: string): number {
   const nameLower = nodeName.toLowerCase();
 
+  // Full query as a single token (for compound identifiers like "CacheBuilder")
+  const queryLower = query.replace(/[\s]+/g, '').toLowerCase();
+
+  // An empty / whitespace-only query carries no name to match against. Bail
+  // before the `startsWith` check below, since `anyString.startsWith('')` is
+  // always true and would otherwise award a spurious flat +10 to every node
+  // (reachable via `searchNodes('   ')`, where the rescoring guard `text ||
+  // query` lets a whitespace-only query through).
+  if (!queryLower) return 0;
+
   // Split query into word-level terms (handles "CacheBuilder build" → ["cache","builder","build"])
   const rawTerms = query
     .replace(/([a-z])([A-Z])/g, '$1 $2')
@@ -352,9 +362,6 @@ export function nameMatchBonus(nodeName: string, query: string): number {
 
   // Also keep original space-separated tokens for exact-term matching
   const queryTokens = query.split(/\s+/).map(t => t.toLowerCase()).filter(t => t.length >= 2);
-
-  // Full query as a single token (for compound identifiers like "CacheBuilder")
-  const queryLower = query.replace(/[\s]+/g, '').toLowerCase();
 
   // Exact match: query exactly equals the node name
   if (nameLower === queryLower) return 80;


### PR DESCRIPTION
## Summary

`nameMatchBonus` (search ranking, `src/search/query-utils.ts`) awards a spurious flat **+10** "name match" bonus to **every** node when the query is empty or whitespace-only.

## The bug

The function collapses the query into a single comparable token and then checks `startsWith`:

```ts
const queryLower = query.replace(/[\s]+/g, '').toLowerCase();
...
if (nameLower.startsWith(queryLower)) {
  const ratio = queryLower.length / nameLower.length;
  return Math.round(10 + 30 * ratio);   // → 10 when queryLower === ''
}
```

For an empty / whitespace-only query, `queryLower` is `''`, and in JS `anyString.startsWith('')` is **always true**. So the branch fires for every node, with `ratio = 0`, returning `Math.round(10 + 0) = 10` — a uniform, undeserved name-match bonus for a query that matches no name at all.

### Reachability

This is reachable end-to-end through the public `searchNodes` API:

- `searchNodes('   ')` → `parseQuery('   ')` yields `text = ''`, while the raw `query` is `'   '` (truthy).
- The rescoring guard in `src/db/queries.ts` is `if (results.length > 0 && (text || query))`, so a whitespace-only query passes the guard (`'' || '   '` → truthy).
- `scoringQuery = text || query = '   '` is then handed to `nameMatchBonus(name, '   ')` for every candidate.

`scorePathRelevance` already handles this case correctly (it returns 0 for a whitespace-only query); `nameMatchBonus` did not.

## The fix

A one-line early guard, before the always-true `startsWith('')` check:

```ts
if (!queryLower) return 0;
```

## Repro / tests

Added a `nameMatchBonus empty/whitespace query` block to `__tests__/context-ranking.test.ts`:

```ts
expect(nameMatchBonus('authenticate', '')).toBe(0);     // was 10
expect(nameMatchBonus('authenticate', '   ')).toBe(0);  // was 10
expect(nameMatchBonus('authenticate', 'authenticate')).toBe(80); // unchanged — guard isn't over-broad
```

- **Before the fix:** the empty/whitespace cases return `10` (test fails).
- **After the fix:** they return `0`, and a real exact-match query is unaffected.

## Verification

- `npx vitest run __tests__/context-ranking.test.ts __tests__/search-query-parser.test.ts` → **39 passed**.
- Confirmed the new tests fail on `main` (stash the source change → `expected 10 to be 0`) and pass with it.
- `tsc --noEmit` clean.

Diff is two files, +31/-4. No behavior change for any non-empty query.
