### PR TITLE
feat(installer): add Pi as a native-extension agent target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### New Features
+
+- Pi users can now choose Pi in `codegraph install`; CodeGraph installs a native Pi tool and the guidance Pi needs to explore indexed projects without scanning files first.
 
 ## [1.1.1] - 2026-06-24
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Already installed? Run `codegraph upgrade` to update in place.
 
 Follow [@getcodegraph](https://x.com/getcodegraph) on X for updates.
 
-### Supercharge Claude Code, Cursor, Codex, OpenCode, Hermes Agent, Gemini, Antigravity, and Kiro with Semantic Code Intelligence
+### Supercharge Claude Code, Cursor, Codex, OpenCode, Hermes Agent, Gemini, Antigravity, Kiro, and Pi with Semantic Code Intelligence
 
 **Surgical context · fewer tool calls · faster answers · 100% local**
 
@@ -30,6 +30,7 @@ Follow [@getcodegraph](https://x.com/getcodegraph) on X for updates.
 [![Gemini](https://img.shields.io/badge/Gemini-supported-blueviolet.svg)](#supported-agents)
 [![Antigravity](https://img.shields.io/badge/Antigravity-supported-blueviolet.svg)](#supported-agents)
 [![Kiro](https://img.shields.io/badge/Kiro-supported-blueviolet.svg)](#supported-agents)
+[![Pi](https://img.shields.io/badge/Pi-supported-blueviolet.svg)](#supported-agents)
 
 <br>
 
@@ -76,7 +77,7 @@ In a **new terminal**, run the installer to connect CodeGraph to the agents you 
 codegraph install
 ```
 
-<sub>Detects and auto-configures Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, and Kiro — wiring the CodeGraph MCP server into each. **This is the step that connects CodeGraph to your agent;** installing the CLI in step 1 does not do it on its own. It only wires up your agent — it does **not** index any code; building each project's graph is the separate `codegraph init` in step 3. (Shortcut: `npx @colbymchenry/codegraph` downloads and runs this in one go.)</sub>
+<sub>Detects and auto-configures Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro, and Pi — wiring the CodeGraph MCP server for MCP-capable agents and a native `codegraph_explore` extension for Pi. **This is the step that connects CodeGraph to your agent;** installing the CLI in step 1 does not do it on its own. It only wires up your agent — it does **not** index any code; building each project's graph is the separate `codegraph init` in step 3. (Shortcut: `npx @colbymchenry/codegraph` downloads and runs this in one go.)</sub>
 
 ### 3. Initialize each project
 
@@ -105,7 +106,7 @@ Changed your mind? One command removes CodeGraph from every agent it configured:
 codegraph uninstall
 ```
 
-<sub>Reverses the installer — strips CodeGraph's MCP server config, instructions, and permissions from each configured agent. Your project indexes (`.codegraph/`) are left untouched; remove those per-project with `codegraph uninit`. Use `--target` to remove from specific agents, or `--yes` to run non-interactively.</sub>
+<sub>Reverses the installer — strips CodeGraph's MCP server config, native Pi extension, instructions, and permissions from each configured agent. Your project indexes (`.codegraph/`) are left untouched; remove those per-project with `codegraph uninit`. Use `--target` to remove from specific agents, or `--yes` to run non-interactively.</sub>
 
 ---
 
@@ -342,10 +343,10 @@ npx @colbymchenry/codegraph
 ```
 
 The installer will:
-- Ask which agent(s) to configure — auto-detects installed ones from: **Claude Code**, **Cursor**, **Codex CLI**, **opencode**, **Hermes Agent**, **Gemini CLI**, **Antigravity IDE**, **Kiro**
-- Prompt to install `codegraph` on your PATH (so agents can launch the MCP server)
+- Ask which agent(s) to configure — auto-detects installed ones from: **Claude Code**, **Cursor**, **Codex CLI**, **opencode**, **Hermes Agent**, **Gemini CLI**, **Antigravity IDE**, **Kiro**, **Pi**
+- Prompt to install `codegraph` on your PATH (so agents can launch CodeGraph)
 - Ask whether configs apply to all your projects or just this one
-- Write each chosen agent's MCP server config, plus a small marker-fenced CodeGraph section in the agent's instructions file (`CLAUDE.md` / `AGENTS.md` / `GEMINI.md`) — that's how subagents and non-MCP agents learn the `codegraph explore` command, since the MCP server's own guidance only reaches the main agent. Removed cleanly by `codegraph uninstall`.
+- Write each chosen agent's integration: MCP server config for MCP-capable agents, a native `codegraph_explore` extension for Pi, plus a small marker-fenced CodeGraph section in the agent's instructions file (`CLAUDE.md` / `AGENTS.md` / `GEMINI.md`) so subagents and non-MCP surfaces learn the `codegraph explore` command. Removed cleanly by `codegraph uninstall`.
 - Set up auto-allow permissions when Claude Code is one of the targets
 
 The installer **wires up your agents only — it does not index your code.** After it finishes, build each project's graph yourself with `codegraph init` (step 3). One global `codegraph install` covers every project; you run `codegraph init` once per project.
@@ -369,7 +370,7 @@ codegraph install --print-config codex               # print snippet, no file wr
 
 ### 2. Restart Your Agent
 
-Restart your agent (Claude Code / Cursor / Codex CLI / opencode / Hermes Agent / Gemini CLI / Antigravity IDE / Kiro) for the MCP server to load.
+Restart your agent (Claude Code / Cursor / Codex CLI / opencode / Hermes Agent / Gemini CLI / Antigravity IDE / Kiro / Pi) for the integration to load.
 
 ### 3. Initialize Projects
 
@@ -662,8 +663,8 @@ See [Get Started](#get-started) for the one-line install commands.
 ## Supported Agents
 
 The interactive installer auto-detects and configures each of these — wiring up
-the MCP server (which delivers its own usage guidance, so no instructions file
-is written):
+MCP config for MCP-capable agents, a native extension for Pi, and short
+instructions where the agent reads them:
 
 - **Claude Code**
 - **Cursor**
@@ -673,6 +674,7 @@ is written):
 - **Gemini CLI**
 - **Antigravity IDE**
 - **Kiro**
+- **Pi**
 
 ## Supported Languages
 
@@ -771,7 +773,7 @@ MIT
 
 <div align="center">
 
-**Made for AI coding agents — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, and Kiro**
+**Made for AI coding agents — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro, and Pi**
 
 [Report Bug](https://github.com/colbymchenry/codegraph/issues) · [Request Feature](https://github.com/colbymchenry/codegraph/issues)
 

--- a/__tests__/installer-targets.test.ts
+++ b/__tests__/installer-targets.test.ts
@@ -38,12 +38,14 @@ function setHome(dir: string): { restore: () => void } {
     APPDATA: process.env.APPDATA,
     XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
     HERMES_HOME: process.env.HERMES_HOME,
+    PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
   };
   process.env.HOME = dir;
   process.env.USERPROFILE = dir;
   process.env.APPDATA = path.join(dir, '.config');
   process.env.XDG_CONFIG_HOME = path.join(dir, '.config');
   delete process.env.HERMES_HOME;
+  delete process.env.PI_CODING_AGENT_DIR;
   return {
     restore() {
       if (prev.HOME === undefined) delete process.env.HOME; else process.env.HOME = prev.HOME;
@@ -51,6 +53,7 @@ function setHome(dir: string): { restore: () => void } {
       if (prev.APPDATA === undefined) delete process.env.APPDATA; else process.env.APPDATA = prev.APPDATA;
       if (prev.XDG_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME; else process.env.XDG_CONFIG_HOME = prev.XDG_CONFIG_HOME;
       if (prev.HERMES_HOME === undefined) delete process.env.HERMES_HOME; else process.env.HERMES_HOME = prev.HERMES_HOME;
+      if (prev.PI_CODING_AGENT_DIR === undefined) delete process.env.PI_CODING_AGENT_DIR; else process.env.PI_CODING_AGENT_DIR = prev.PI_CODING_AGENT_DIR;
     },
   };
 }
@@ -1175,6 +1178,104 @@ describe('Installer targets — partial-state idempotency', () => {
     const stopCmds = (s.hooks?.Stop ?? []).flatMap((g: any) => (g.hooks ?? []).map((h: any) => h.command));
     expect(stopCmds).toContain('codegraph sync-if-dirty');
   });
+
+  it('pi: global install writes a native extension and AGENTS.md guidance', () => {
+    const pi = getTarget('pi')!;
+    const result = pi.install('global', { autoAllow: true });
+    const extension = path.join(tmpHome, '.pi', 'agent', 'extensions', 'codegraph.ts');
+    const agents = path.join(tmpHome, '.pi', 'agent', 'AGENTS.md');
+
+    expect(result.files.some((f) => f.path === extension && f.action === 'created')).toBe(true);
+    expect(result.files.some((f) => f.path === agents && f.action === 'created')).toBe(true);
+    expect(fs.readFileSync(extension, 'utf-8')).toContain('name: "codegraph_explore"');
+    expect(fs.readFileSync(extension, 'utf-8')).toContain('pi.on("session_start"');
+    expect(fs.readFileSync(extension, 'utf-8')).toContain('pi.getAllTools()');
+    expect(fs.readFileSync(extension, 'utf-8')).toContain('spawn("codegraph"');
+    expect(fs.readFileSync(agents, 'utf-8')).toContain('codegraph explore');
+    expect(pi.detect('global').alreadyConfigured).toBe(true);
+  });
+
+  it('pi: honors PI_CODING_AGENT_DIR for global extension and AGENTS.md', () => {
+    const custom = path.join(tmpHome, 'custom-pi-agent');
+    process.env.PI_CODING_AGENT_DIR = custom;
+    const pi = getTarget('pi')!;
+
+    const result = pi.install('global', { autoAllow: true });
+
+    const extension = path.join(custom, 'extensions', 'codegraph.ts');
+    const agents = path.join(custom, 'AGENTS.md');
+    expect(result.files.map((f) => f.path)).toContain(extension);
+    expect(result.files.map((f) => f.path)).toContain(agents);
+    expect(fs.existsSync(extension)).toBe(true);
+    expect(fs.existsSync(agents)).toBe(true);
+    expect(fs.existsSync(path.join(tmpHome, '.pi', 'agent', 'extensions', 'codegraph.ts'))).toBe(false);
+    expect(pi.detect('global').configPath).toBe(extension);
+  });
+
+  it('pi: local install writes ./.pi/extensions/codegraph.ts and ./AGENTS.md', () => {
+    const pi = getTarget('pi')!;
+    const result = pi.install('local', { autoAllow: true });
+    const paths = result.files.map((f) => f.path.replace(/\\/g, '/'));
+
+    expect(paths.some((p) => p.endsWith('/.pi/extensions/codegraph.ts'))).toBe(true);
+    expect(paths.some((p) => p.endsWith('/AGENTS.md'))).toBe(true);
+    expect(fs.readFileSync(path.join(process.cwd(), '.pi', 'extensions', 'codegraph.ts'), 'utf-8')).toContain('codegraph_explore');
+    expect(fs.readFileSync(path.join(process.cwd(), 'AGENTS.md'), 'utf-8')).toContain('codegraph explore');
+  });
+
+  it('pi: install is idempotent for both extension and instructions', () => {
+    const pi = getTarget('pi')!;
+    pi.install('global', { autoAllow: true });
+    const extension = path.join(tmpHome, '.pi', 'agent', 'extensions', 'codegraph.ts');
+    const agents = path.join(tmpHome, '.pi', 'agent', 'AGENTS.md');
+    const firstExtension = fs.readFileSync(extension, 'utf-8');
+    const firstAgents = fs.readFileSync(agents, 'utf-8');
+
+    const second = pi.install('global', { autoAllow: true });
+
+    expect(second.files.every((f) => f.action === 'unchanged')).toBe(true);
+    expect(fs.readFileSync(extension, 'utf-8')).toBe(firstExtension);
+    expect(fs.readFileSync(agents, 'utf-8')).toBe(firstAgents);
+  });
+
+  it('pi: uninstall removes only CodeGraph-owned extension and AGENTS.md block', () => {
+    const pi = getTarget('pi')!;
+    const agents = path.join(tmpHome, '.pi', 'agent', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(agents), { recursive: true });
+    fs.writeFileSync(agents, `# My Pi notes\n\nBe direct.\n\n${LEGACY_BLOCK}\n`);
+
+    pi.install('global', { autoAllow: true });
+    const result = pi.uninstall('global');
+
+    const extension = path.join(tmpHome, '.pi', 'agent', 'extensions', 'codegraph.ts');
+    expect(result.files.find((f) => f.path === extension)?.action).toBe('removed');
+    expect(fs.existsSync(extension)).toBe(false);
+    const body = fs.readFileSync(agents, 'utf-8');
+    expect(body).toContain('# My Pi notes');
+    expect(body).toContain('Be direct.');
+    expect(body).not.toContain('CODEGRAPH_START');
+  });
+
+  it('pi: local detection considers an existing CLAUDE.md CodeGraph block', () => {
+    const pi = getTarget('pi')!;
+    fs.writeFileSync(path.join(process.cwd(), 'CLAUDE.md'), `${LEGACY_BLOCK}\n`);
+
+    expect(pi.detect('local').alreadyConfigured).toBe(true);
+  });
+
+  it('pi: printConfig prints a native extension and instructions without writing files', () => {
+    const pi = getTarget('pi')!;
+    const before = listAllFiles(tmpHome).concat(listAllFiles(tmpCwd));
+
+    const out = pi.printConfig('global');
+
+    expect(out).toContain('extensions/codegraph.ts');
+    expect(out).toContain('AGENTS.md');
+    expect(out).toContain('codegraph_explore');
+    expect(out).toContain('codegraph explore');
+    const after = listAllFiles(tmpHome).concat(listAllFiles(tmpCwd));
+    expect(after.sort()).toEqual(before.sort());
+  });
 });
 
 describe('Installer targets — registry', () => {
@@ -1187,6 +1288,7 @@ describe('Installer targets — registry', () => {
     expect(getTarget('gemini')?.id).toBe('gemini');
     expect(getTarget('antigravity')?.id).toBe('antigravity');
     expect(getTarget('kiro')?.id).toBe('kiro');
+    expect(getTarget('pi')?.id).toBe('pi');
     expect(getTarget('not-a-real-target')).toBeUndefined();
   });
 
@@ -1195,6 +1297,7 @@ describe('Installer targets — registry', () => {
     expect(resolveTargetFlag('all', 'global').length).toBe(ALL_TARGETS.length);
     const csv = resolveTargetFlag('claude,cursor', 'global');
     expect(csv.map((t) => t.id)).toEqual(['claude', 'cursor']);
+    expect(resolveTargetFlag('pi,claude', 'global').map((t) => t.id)).toEqual(['pi', 'claude']);
   });
 
   it('resolveTargetFlag throws on unknown id', () => {

--- a/site/src/content/docs/getting-started/installation.md
+++ b/site/src/content/docs/getting-started/installation.md
@@ -11,10 +11,10 @@ npx @colbymchenry/codegraph
 
 The installer will:
 
-- Ask which agent(s) to configure — auto-detecting installed ones from **Claude Code**, **Cursor**, **Codex CLI**, **opencode**, **Hermes Agent**, **Gemini CLI**, **Antigravity IDE**, and **Kiro**.
-- Prompt to install `codegraph` on your `PATH` (so agents can launch the MCP server).
+- Ask which agent(s) to configure — auto-detecting installed ones from **Claude Code**, **Cursor**, **Codex CLI**, **opencode**, **Hermes Agent**, **Gemini CLI**, **Antigravity IDE**, **Kiro**, and **Pi**.
+- Prompt to install `codegraph` on your `PATH` (so agents can launch CodeGraph).
 - Ask whether configs apply to all your projects or just this one.
-- Write each chosen agent's MCP server config, plus a small marker-fenced CodeGraph section in the agent's instructions file (`CLAUDE.md` / `AGENTS.md` / `GEMINI.md`). Cursor and Kiro get the MCP config only. Removed cleanly by `codegraph uninstall`.
+- Write each chosen agent's integration: MCP server config for MCP-capable agents, a native `codegraph_explore` extension for Pi, plus a small marker-fenced CodeGraph section in the agent's instructions file (`CLAUDE.md` / `AGENTS.md` / `GEMINI.md`) where that agent reads one. Removed cleanly by `codegraph uninstall`.
 - Set up auto-allow permissions when Claude Code is one of the targets.
 
 The installer **wires up your agents only — it does not index your code.** After it finishes, build each project's graph yourself with `codegraph init` (step 3 below).
@@ -38,7 +38,7 @@ codegraph install --print-config codex               # print snippet, no file wr
 
 ## 2. Restart your agent
 
-Restart your agent (Claude Code / Cursor / Codex CLI / opencode / Hermes Agent / Gemini CLI / Antigravity IDE / Kiro) for the MCP server to load.
+Restart your agent (Claude Code / Cursor / Codex CLI / opencode / Hermes Agent / Gemini CLI / Antigravity IDE / Kiro / Pi) for the integration to load.
 
 ## 3. Initialize projects
 
@@ -67,4 +67,4 @@ Changed your mind? One command removes CodeGraph from every agent it configured:
 codegraph uninstall
 ```
 
-This reverses the installer — stripping CodeGraph's MCP server config, instructions, and permissions from each configured agent. Your project indexes (`.codegraph/`) are left untouched; remove those per-project with `codegraph uninit`. Use `--target` to remove from specific agents, or `--yes` to run non-interactively.
+This reverses the installer — stripping CodeGraph's MCP server config, native Pi extension, instructions, and permissions from each configured agent. Your project indexes (`.codegraph/`) are left untouched; remove those per-project with `codegraph uninit`. Use `--target` to remove from specific agents, or `--yes` to run non-interactively.

--- a/site/src/content/docs/getting-started/introduction.md
+++ b/site/src/content/docs/getting-started/introduction.md
@@ -5,7 +5,7 @@ description: What CodeGraph is, and why it makes AI coding agents faster and mor
 
 CodeGraph is a **local-first code-intelligence tool**. It parses your codebase with [tree-sitter](https://tree-sitter.github.io/), stores every symbol, edge, and file in a local SQLite database, and exposes the result as a queryable **knowledge graph** — over the [Model Context Protocol (MCP)](/codegraph/reference/mcp-server/), a CLI, and a TypeScript library.
 
-It exists to make AI coding agents — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, and Kiro — **answer structural questions without scanning files**. Instead of fanning out across `grep`, `glob`, and `Read` to reconstruct how code fits together, an agent queries a pre-built index and gets the answer in a handful of calls.
+It exists to make AI coding agents — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro, and Pi — **answer structural questions without scanning files**. Instead of fanning out across `grep`, `glob`, and `Read` to reconstruct how code fits together, an agent queries a pre-built index and gets the answer in a handful of calls.
 
 ## Why it matters
 

--- a/site/src/content/docs/getting-started/quickstart.md
+++ b/site/src/content/docs/getting-started/quickstart.md
@@ -25,7 +25,7 @@ Already have Node? `npm i -g @colbymchenry/codegraph` works on any version. Code
 codegraph install
 ```
 
-Auto-detects and configures Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, and Kiro — wiring the CodeGraph MCP server into each. This step connects your agents only; it does **not** index any code. (Shortcut: `npx @colbymchenry/codegraph` downloads and runs the installer in one go.)
+Auto-detects and configures Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro, and Pi — wiring the CodeGraph MCP server for MCP-capable agents and a native `codegraph_explore` extension for Pi. This step connects your agents only; it does **not** index any code. (Shortcut: `npx @colbymchenry/codegraph` downloads and runs the installer in one go.)
 
 ## 3. Initialize each project
 

--- a/site/src/content/docs/reference/integrations.md
+++ b/site/src/content/docs/reference/integrations.md
@@ -3,7 +3,7 @@ title: Integrations
 description: Supported agents, and manual MCP setup.
 ---
 
-The interactive installer auto-detects and configures each supported agent — wiring the CodeGraph MCP server into each. For the agents that use an instructions file, it also writes a short marker-fenced CodeGraph section (`CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`) so subagents and non-MCP harnesses learn the `codegraph explore` command; `codegraph uninstall` removes it.
+The interactive installer auto-detects and configures each supported agent — wiring the CodeGraph MCP server for MCP-capable agents and a native `codegraph_explore` extension for Pi. For the agents that use an instructions file, it also writes a short marker-fenced CodeGraph section (`CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`) so subagents and non-MCP harnesses learn the `codegraph explore` command; `codegraph uninstall` removes it.
 
 ## Supported agents
 
@@ -15,12 +15,17 @@ The interactive installer auto-detects and configures each supported agent — w
 - **Gemini CLI**
 - **Antigravity IDE**
 - **Kiro**
+- **Pi**
 
 Run `npx @colbymchenry/codegraph` and pick your agent(s); see [Installation](/codegraph/getting-started/installation/) for the non-interactive flags.
 
+:::note
+Pi does not use MCP directly. The installer writes a native Pi extension that registers `codegraph_explore` and calls `codegraph explore` under the hood, plus an `AGENTS.md` hint so Pi knows when to use it.
+:::
+
 ## Manual setup
 
-If you'd rather wire it up yourself, install globally:
+If you'd rather wire it up yourself for an MCP-capable agent, install globally:
 
 ```bash
 npm install -g @colbymchenry/codegraph

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -1963,12 +1963,12 @@ program
  */
 program
   .command('install')
-  .description('Install codegraph MCP server into one or more agents (Claude Code, Cursor, Codex CLI, opencode, Hermes Agent)')
+  .description('Install CodeGraph into one or more agents (MCP config where supported, native extension for Pi)')
   .option('-t, --target <ids>', 'Target agent(s): comma-separated ids, or "auto"|"all"|"none". Default: prompt')
   .option('-l, --location <where>', 'Install location: "global" or "local". Default: prompt')
   .option('-y, --yes', 'Non-interactive: defaults to --location=global --target=auto, auto-allow on')
   .option('--no-permissions', 'Skip writing the auto-allow permissions list (Claude Code only)')
-  .option('--print-config <id>', 'Print MCP config snippet for the named agent and exit (no file writes)')
+  .option('--print-config <id>', 'Print manual config/instructions snippet for the named agent and exit (no file writes)')
   .action(async (opts: {
     target?: string;
     location?: string;
@@ -2023,14 +2023,14 @@ program
 /**
  * codegraph uninstall
  *
- * Inverse of `install`. Removes the codegraph MCP server entry,
+ * Inverse of `install`. Removes the codegraph MCP server entry / native extension,
  * instructions block, and permissions from every agent (or a
  * `--target` subset). Prompts global-vs-local when not given. Does NOT
  * delete the `.codegraph/` index — that's `codegraph uninit`.
  */
 program
   .command('uninstall')
-  .description('Remove codegraph from your agents (Claude Code, Cursor, Codex CLI, opencode, Hermes Agent)')
+  .description('Remove CodeGraph from your agents')
   .option('-t, --target <ids>', 'Target agent(s): comma-separated ids, or "all". Default: all')
   .option('-l, --location <where>', 'Uninstall location: "global" or "local". Default: prompt')
   .option('-y, --yes', 'Non-interactive: defaults to --location=global --target=all')

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -1,9 +1,9 @@
 /**
  * CodeGraph Interactive Installer
  *
- * Multi-target: writes MCP server config + instructions for the
- * agents the user picks (Claude Code, Cursor, Codex CLI, opencode,
- * Hermes Agent, Gemini CLI, Antigravity IDE).
+ * Multi-target: writes the needed CodeGraph integration for the agents
+ * the user picks (MCP config for MCP-capable agents, a native extension for
+ * Pi, and instructions where the agent reads them).
  * Defaults to the Claude-only behavior for backwards compatibility
  * when no targets are explicitly chosen and nothing else is detected.
  *
@@ -104,7 +104,7 @@ export async function runInstallerWithOptions(opts: RunInstallerOptions): Promis
   // matches existing behavior). Skipped when --yes (assume present).
   if (!useDefaults) {
     const shouldInstallGlobally = await clack.confirm({
-      message: 'Install the codegraph CLI on your PATH? (Required so agents can launch the MCP server)',
+      message: 'Install the codegraph CLI on your PATH? (Required so agents can launch CodeGraph tools)',
       initialValue: true,
     });
     if (clack.isCancel(shouldInstallGlobally)) {
@@ -122,7 +122,7 @@ export async function runInstallerWithOptions(opts: RunInstallerOptions): Promis
         clack.log.warn('Try: sudo npm install -g @colbymchenry/codegraph');
       }
     } else {
-      clack.log.info('Skipped CLI install — agents will not be able to launch the MCP server without it');
+      clack.log.info('Skipped CLI install — agents will not be able to launch CodeGraph without it');
     }
   }
 
@@ -363,8 +363,8 @@ export function uninstallTargets(
  * then sweeps every agent target (or the `--target` subset) and prints
  * one block per agent so the user sees exactly which providers it hit.
  *
- * Removes only what install wrote (MCP server entry, instructions
- * block, permissions) — never the `.codegraph/` index, which `codegraph
+ * Removes only what install wrote (MCP server entry, native extension,
+ * instructions block, permissions) — never the `.codegraph/` index, which `codegraph
  * uninit` owns.
  */
 export async function runUninstaller(opts: RunUninstallerOptions): Promise<void> {
@@ -386,8 +386,8 @@ export async function runUninstaller(opts: RunUninstallerOptions): Promise<void>
     const sel = await clack.select({
       message: 'Remove CodeGraph from all your projects, or just this one?',
       options: [
-        { value: 'global' as const, label: 'All projects (global)', hint: '~/.claude, ~/.cursor, ~/.codex, ~/.config/opencode, ~/.hermes, ~/.gemini, ~/.kiro' },
-        { value: 'local'  as const, label: 'Just this project (local)', hint: './.claude, ./.cursor, ./opencode.jsonc, ./.gemini, ./.kiro' },
+        { value: 'global' as const, label: 'All projects (global)', hint: '~/.claude, ~/.cursor, ~/.codex, ~/.config/opencode, ~/.hermes, ~/.gemini, ~/.kiro, ~/.pi/agent' },
+        { value: 'local'  as const, label: 'Just this project (local)', hint: './.claude, ./.cursor, ./opencode.jsonc, ./.gemini, ./.kiro, ./.pi' },
       ],
       initialValue: 'global' as const,
     });

--- a/src/installer/targets/pi.ts
+++ b/src/installer/targets/pi.ts
@@ -1,0 +1,344 @@
+/**
+ * Pi target.
+ *
+ * Pi has no built-in MCP client. Instead, it supports TypeScript
+ * extensions that can register native model-callable tools, plus AGENTS.md /
+ * CLAUDE.md context files. We install:
+ *
+ *   - a native Pi extension that registers `codegraph_explore` and shells out
+ *     to `codegraph explore`, the CLI face of CodeGraph's MCP explore tool.
+ *   - the short marker-fenced CodeGraph instructions block in Pi's AGENTS.md
+ *     context so the model knows when to use the tool.
+ *
+ * Global Pi config lives in `${PI_CODING_AGENT_DIR:-~/.pi/agent}`. Project-
+ * local extensions live in `./.pi/extensions/` and load after the user trusts
+ * the project; project context lives in `./AGENTS.md` / `./CLAUDE.md`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  AgentTarget,
+  DetectionResult,
+  InstallOptions,
+  Location,
+  WriteResult,
+} from './types';
+import {
+  atomicWriteFileSync,
+  removeMarkedSection,
+  upsertInstructionsEntry,
+} from './shared';
+import {
+  CODEGRAPH_INSTRUCTIONS_BLOCK,
+  CODEGRAPH_SECTION_END,
+  CODEGRAPH_SECTION_START,
+} from '../instructions-template';
+
+const EXTENSION_START = '// CODEGRAPH_PI_EXTENSION_START';
+const EXTENSION_END = '// CODEGRAPH_PI_EXTENSION_END';
+
+function expandHome(p: string): string {
+  if (p === '~') return os.homedir();
+  if (p.startsWith(`~${path.sep}`) || p.startsWith('~/')) {
+    return path.join(os.homedir(), p.slice(2));
+  }
+  return p;
+}
+
+function piAgentDir(): string {
+  const env = process.env.PI_CODING_AGENT_DIR;
+  if (env && env.trim().length > 0) return path.resolve(expandHome(env.trim()));
+  return path.join(os.homedir(), '.pi', 'agent');
+}
+
+function localPiDir(): string {
+  return path.join(process.cwd(), '.pi');
+}
+
+function instructionsPath(loc: Location): string {
+  return loc === 'global'
+    ? path.join(piAgentDir(), 'AGENTS.md')
+    : path.join(process.cwd(), 'AGENTS.md');
+}
+
+function localClaudePath(): string {
+  return path.join(process.cwd(), 'CLAUDE.md');
+}
+
+function extensionPath(loc: Location): string {
+  return loc === 'global'
+    ? path.join(piAgentDir(), 'extensions', 'codegraph.ts')
+    : path.join(localPiDir(), 'extensions', 'codegraph.ts');
+}
+
+function readText(file: string): string {
+  try {
+    return fs.readFileSync(file, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+function hasInstructionsMarker(file: string): boolean {
+  const text = readText(file);
+  return text.includes(CODEGRAPH_SECTION_START) && text.includes(CODEGRAPH_SECTION_END);
+}
+
+function hasExtensionMarker(file: string): boolean {
+  const text = readText(file);
+  return text.includes(EXTENSION_START) && text.includes(EXTENSION_END);
+}
+
+function piExecutableOnPath(): boolean {
+  const pathEnv = process.env.PATH ?? '';
+  if (!pathEnv.trim()) return false;
+  const suffixes = process.platform === 'win32'
+    ? (process.env.PATHEXT ?? '.EXE;.CMD;.BAT;.COM')
+      .split(';')
+      .map((s) => s.trim())
+      .filter(Boolean)
+    : [''];
+
+  for (const dir of pathEnv.split(path.delimiter).filter(Boolean)) {
+    for (const suffix of suffixes) {
+      const candidate = path.join(dir, `pi${suffix}`);
+      try {
+        if (process.platform === 'win32') {
+          if (fs.existsSync(candidate)) return true;
+        } else {
+          fs.accessSync(candidate, fs.constants.X_OK);
+          return true;
+        }
+      } catch {
+        // keep scanning
+      }
+    }
+  }
+  return false;
+}
+
+class PiTarget implements AgentTarget {
+  readonly id = 'pi' as const;
+  readonly displayName = 'Pi';
+  readonly docsUrl = 'https://pi.dev';
+
+  supportsLocation(_loc: Location): boolean {
+    return true;
+  }
+
+  detect(loc: Location): DetectionResult {
+    const ext = extensionPath(loc);
+    const instructions = instructionsPath(loc);
+    const alreadyConfigured = hasExtensionMarker(ext) ||
+      hasInstructionsMarker(instructions) ||
+      (loc === 'local' && hasInstructionsMarker(localClaudePath()));
+
+    const installed = loc === 'global'
+      ? fs.existsSync(piAgentDir()) || fs.existsSync(ext) || alreadyConfigured || piExecutableOnPath()
+      : fs.existsSync(localPiDir()) || fs.existsSync(ext) || alreadyConfigured || piExecutableOnPath();
+
+    return { installed, alreadyConfigured, configPath: ext };
+  }
+
+  install(loc: Location, _opts: InstallOptions): WriteResult {
+    const files: WriteResult['files'] = [];
+    files.push(writeExtensionEntry(loc));
+    files.push(upsertInstructionsEntry(instructionsPath(loc)));
+
+    const notes = loc === 'local'
+      ? ['Restart Pi or run /reload. For project-local extensions, approve project trust if Pi asks.']
+      : ['Restart Pi or run /reload for the CodeGraph tool to load.'];
+
+    return { files, notes };
+  }
+
+  uninstall(loc: Location): WriteResult {
+    const files: WriteResult['files'] = [];
+    files.push(removeExtensionEntry(loc));
+    const action = removeMarkedSection(
+      instructionsPath(loc),
+      CODEGRAPH_SECTION_START,
+      CODEGRAPH_SECTION_END,
+    );
+    files.push({ path: instructionsPath(loc), action });
+    return { files };
+  }
+
+  printConfig(loc: Location): string {
+    return [
+      '# Pi does not use MCP config directly. Add this native extension and context block instead.',
+      '',
+      `# Add to ${extensionPath(loc)}`,
+      '',
+      buildExtensionSource().trimEnd(),
+      '',
+      `# Add to ${instructionsPath(loc)}`,
+      '',
+      CODEGRAPH_INSTRUCTIONS_BLOCK,
+      '',
+    ].join('\n');
+  }
+
+  describePaths(loc: Location): string[] {
+    return [extensionPath(loc), instructionsPath(loc)];
+  }
+}
+
+function writeExtensionEntry(loc: Location): WriteResult['files'][number] {
+  const file = extensionPath(loc);
+  const existed = fs.existsSync(file);
+  const before = readText(file);
+  const after = buildExtensionSource();
+
+  if (before === after) {
+    return { path: file, action: 'unchanged' };
+  }
+
+  // `codegraph.ts` is the file name this target owns. If an older or edited
+  // CodeGraph-generated file is present, replace it. If an unrelated file is
+  // present at the same path, we still update it because the path itself is the
+  // installer-owned integration point, matching Kiro's owned steering file.
+  atomicWriteFileSync(file, after);
+  return { path: file, action: existed ? 'updated' : 'created' };
+}
+
+function removeExtensionEntry(loc: Location): WriteResult['files'][number] {
+  const file = extensionPath(loc);
+  if (!fs.existsSync(file)) return { path: file, action: 'not-found' };
+  if (!hasExtensionMarker(file)) return { path: file, action: 'not-found' };
+  try { fs.unlinkSync(file); } catch { /* ignore */ }
+  return { path: file, action: 'removed' };
+}
+
+function buildExtensionSource(): string {
+  return `${EXTENSION_START}
+// Generated by CodeGraph. Re-run codegraph install --target=pi to update.
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { spawn } from "node:child_process";
+
+const MAX_OUTPUT_CHARS = 200000;
+
+type ExploreParams = {
+  query: string;
+  projectPath?: string;
+  maxFiles?: number;
+};
+
+type RunResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+};
+
+export default function (pi: ExtensionAPI) {
+  // Register at session_start, NOT at extension load. A user may install
+  // CodeGraph for Pi both globally and project-locally; Pi loads both scopes
+  // in a trusted project and rejects two extensions registering the same tool
+  // name at load time (and action methods like getAllTools cannot run during
+  // load). Deferring to session_start lets the second-loaded extension see the
+  // already-registered tool and skip, instead of crashing the whole session.
+  pi.on("session_start", (_event, _ctx) => {
+    try {
+      if (pi.getAllTools().some((tool) => tool.name === "codegraph_explore")) {
+        return;
+      }
+    } catch {
+      // If getAllTools is unavailable for any reason, fall through and register.
+    }
+    registerCodegraphExplore(pi);
+  });
+}
+
+function registerCodegraphExplore(pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "codegraph_explore",
+    label: "CodeGraph Explore",
+    description: "Explore an indexed codebase with CodeGraph, returning relevant source and call paths.",
+    promptSnippet: "Explore indexed code with CodeGraph before grep/read for structural questions",
+    promptGuidelines: [
+      "Use codegraph_explore before grep/find/read when the user asks how code works, where behavior lives, what calls what, impact, or a flow between symbols in a repository with a .codegraph/ index.",
+      "If codegraph_explore says no CodeGraph index exists, continue with normal Pi tools; do not create an index unless the user explicitly asks."
+    ],
+    parameters: Type.Object({
+      query: Type.String({ description: "Symbol names, file names, or a short code question to explore." }),
+      projectPath: Type.Optional(Type.String({ description: "Project path to use instead of Pi's current working directory." })),
+      maxFiles: Type.Optional(Type.Number({ description: "Optional maximum number of files to include." }))
+    }),
+    async execute(_toolCallId, params: ExploreParams, signal, _onUpdate, ctx) {
+      const query = (params.query || "").trim();
+      if (!query) {
+        return textResult("Provide a query for codegraph_explore, such as a symbol name, file name, or short code question.");
+      }
+
+      const projectPath = params.projectPath?.trim() || ctx.cwd;
+      const args = ["explore", "--path", projectPath];
+      if (typeof params.maxFiles === "number" && Number.isFinite(params.maxFiles)) {
+        args.push("--max-files", String(Math.max(1, Math.floor(params.maxFiles))));
+      }
+      args.push(query);
+
+      const result = await runCodegraph(args, projectPath, signal);
+      if (result.error) {
+        const code = (result.error as Error & { code?: string }).code;
+        const message = code === "ENOENT"
+          ? "CodeGraph is not on PATH for Pi. Install it with codegraph install or ensure the codegraph command is available, then restart Pi or run /reload."
+          : "CodeGraph could not start: " + result.error.message;
+        return textResult(message);
+      }
+
+      const combined = [result.stdout, result.stderr].filter((s) => s.trim().length > 0).join("\\n");
+      const output = combined.trim() || "codegraph explore exited with code " + (result.code ?? "unknown") + " and produced no output.";
+      if (result.code && result.code !== 0) {
+        return textResult(cap(output + "\\n\\nCodeGraph did not return a usable graph answer. Continue with normal Pi tools unless the user asks you to initialize or repair CodeGraph."));
+      }
+      return textResult(cap(output));
+    }
+  });
+}
+
+function textResult(text: string) {
+  return {
+    content: [{ type: "text" as const, text }],
+    details: {}
+  };
+}
+
+function runCodegraph(args: string[], cwd: string, signal?: AbortSignal): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn("codegraph", args, { cwd, windowsHide: true });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const finish = (result: RunResult) => {
+      if (settled) return;
+      settled = true;
+      signal?.removeEventListener("abort", abort);
+      resolve({ ...result, stdout: cap(result.stdout), stderr: cap(result.stderr) });
+    };
+
+    const abort = () => {
+      try { child.kill(); } catch { /* ignore */ }
+    };
+
+    signal?.addEventListener("abort", abort, { once: true });
+    child.stdout?.on("data", (chunk) => { stdout = cap(stdout + String(chunk)); });
+    child.stderr?.on("data", (chunk) => { stderr = cap(stderr + String(chunk)); });
+    child.on("error", (error) => finish({ code: null, stdout, stderr, error }));
+    child.on("close", (code) => finish({ code, stdout, stderr }));
+  });
+}
+
+function cap(text: string): string {
+  if (text.length <= MAX_OUTPUT_CHARS) return text;
+  return text.slice(0, MAX_OUTPUT_CHARS) + "\\n…(truncated by Pi CodeGraph extension)";
+}
+${EXTENSION_END}
+`;
+}
+
+export const piTarget: AgentTarget = new PiTarget();

--- a/src/installer/targets/registry.ts
+++ b/src/installer/targets/registry.ts
@@ -16,6 +16,7 @@ import { hermesTarget } from './hermes';
 import { geminiTarget } from './gemini';
 import { antigravityTarget } from './antigravity';
 import { kiroTarget } from './kiro';
+import { piTarget } from './pi';
 
 export const ALL_TARGETS: readonly AgentTarget[] = Object.freeze([
   claudeTarget,
@@ -26,6 +27,7 @@ export const ALL_TARGETS: readonly AgentTarget[] = Object.freeze([
   geminiTarget,
   antigravityTarget,
   kiroTarget,
+  piTarget,
 ]);
 
 export function getTarget(id: string): AgentTarget | undefined {

--- a/src/installer/targets/types.ts
+++ b/src/installer/targets/types.ts
@@ -1,10 +1,10 @@
 /**
  * Agent target abstraction for the installer.
  *
- * Each MCP-capable agent (Claude Code, Cursor, Codex CLI, opencode, ...)
+ * Each supported agent (Claude Code, Cursor, Codex CLI, opencode, Pi, ...)
  * implements this interface so the installer orchestrator can write the
- * right MCP-server config + instructions file + permissions for that
- * agent without baking client-specific paths into core code. Adding a
+ * right integration files (MCP config, native extension, instructions,
+ * permissions) without baking client-specific paths into core code. Adding a
  * new agent = one new file in `targets/` + one entry in `registry.ts`.
  *
  * Closes the Claude-locked installer issue (upstream #137). The
@@ -19,7 +19,7 @@ export type Location = 'global' | 'local';
  * lookup. New targets add a value here when they're added to the
  * registry. Keep these short and lowercase.
  */
-export type TargetId = 'claude' | 'cursor' | 'codex' | 'opencode' | 'hermes' | 'gemini' | 'antigravity' | 'kiro';
+export type TargetId = 'claude' | 'cursor' | 'codex' | 'opencode' | 'hermes' | 'gemini' | 'antigravity' | 'kiro' | 'pi';
 
 /**
  * Result of `target.detect(location)`.
@@ -103,9 +103,10 @@ export interface AgentTarget {
    */
   uninstall(loc: Location): WriteResult;
   /**
-   * Print the MCP-server snippet a user would paste manually for this
-   * target. Used by `codegraph install --print-config <id>` and by
-   * the README. Must NOT touch the filesystem.
+   * Print the manual snippet a user would paste for this target (MCP config,
+   * native extension, instructions, or whichever surface the target uses).
+   * Used by `codegraph install --print-config <id>` and by the README. Must
+   * NOT touch the filesystem.
    */
   printConfig(loc: Location): string;
   /** Filesystem paths this target would write to at this location. */


### PR DESCRIPTION
Pi has no built-in MCP client, so instead of MCP config the installer writes a native Pi TypeScript extension that registers a codegraph_explore tool and shells out to the codegraph explore CLI, plus the CodeGraph guidance block in Pi's AGENTS.md context.

- Global: ${PI_CODING_AGENT_DIR:-~/.pi/agent}/extensions/codegraph.ts + AGENTS.md
- Local:  ./.pi/extensions/codegraph.ts + ./AGENTS.md (detects CLAUDE.md too)
- Extension registers in session_start and dedupes via getAllTools(), so a combined global+local install does not crash with a duplicate-tool conflict
- Idempotent install/uninstall; only marker-owned files are removed

Updates installer/CLI wording and docs to reflect that not all targets are MCP. Adds installer test coverage and a changelog entry.