### PR TITLE
fix(mcp): fall back to tmpdir socket on filesystems without AF_UNIX support

### DIFF
--- a/__tests__/daemon-socket-probe.test.ts
+++ b/__tests__/daemon-socket-probe.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Socket-support probe — issue #997.
+ *
+ * ExFAT, NTFS-3G, and some FUSE-backed volumes don't support AF_UNIX sockets.
+ * `getDaemonSocketPath` must detect this and fall back to `os.tmpdir()` instead
+ * of returning an in-project path that will fail on `listen()`.
+ *
+ * These tests validate `canSocketInDir` on the local tmpdir (which always
+ * supports sockets on any standard OS) and verify the cache is effective.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  canSocketInDir,
+  clearSocketSupportCache,
+  getDaemonSocketPath,
+} from '../src/mcp/daemon-paths';
+
+afterEach(() => {
+  clearSocketSupportCache();
+});
+
+describe('canSocketInDir (#997)', () => {
+  it.runIf(process.platform !== 'win32')('returns true for a directory on a socket-capable filesystem', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-sock-probe-'));
+    try {
+      expect(canSocketInDir(dir)).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(process.platform !== 'win32')('caches the result per device — second call is free', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-sock-probe-'));
+    try {
+      const first = canSocketInDir(dir);
+      const second = canSocketInDir(dir);
+      expect(first).toBe(second);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns true when the directory does not exist (optimistic fallback)', () => {
+    expect(canSocketInDir('/nonexistent-dir-cg-probe')).toBe(true);
+  });
+});
+
+describe('getDaemonSocketPath (#997)', () => {
+  it.runIf(process.platform !== 'win32')('returns in-project path on a socket-capable filesystem', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-path-'));
+    try {
+      const sockPath = getDaemonSocketPath(root);
+      expect(sockPath).toContain('.codegraph');
+      expect(sockPath).toContain('daemon.sock');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(process.platform === 'win32')('returns a named pipe on Windows', () => {
+    const sockPath = getDaemonSocketPath('/some/project');
+    expect(sockPath).toMatch(/^\\\\.\\pipe\\codegraph-/);
+  });
+});

--- a/src/mcp/daemon-paths.ts
+++ b/src/mcp/daemon-paths.ts
@@ -18,7 +18,9 @@
  * pointer to the socket path the daemon chose.
  */
 
+import { execFileSync } from 'child_process';
 import * as crypto from 'crypto';
+import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { getCodeGraphDir } from '../directory';
@@ -32,6 +34,58 @@ function projectHash(projectRoot: string): string {
 }
 
 /**
+ * Per-device cache for AF_UNIX socket support. Keyed by `fs.statSync().dev`
+ * so the probe runs at most once per mounted filesystem.
+ */
+const socketSupportCache = new Map<number, boolean>();
+
+/**
+ * Probe whether `dir` lives on a filesystem that supports AF_UNIX sockets.
+ * ExFAT, NTFS-3G, some FUSE mounts, and network shares don't — `listen()`
+ * fails with ENOTSUP / EOPNOTSUPP. The result is cached per device so
+ * subsequent calls for the same mount are free.
+ *
+ * Exported for testing.
+ */
+export function canSocketInDir(dir: string): boolean {
+  let dev: number;
+  try {
+    dev = fs.statSync(dir).dev;
+  } catch {
+    return true; // can't stat → optimistic, let listen() fail naturally
+  }
+  const cached = socketSupportCache.get(dev);
+  if (cached !== undefined) return cached;
+
+  const probe = path.join(dir, `.sock-probe-${process.pid}`);
+  try {
+    // getDaemonSocketPath is synchronous but net.Server.listen is async.
+    // Bridge with execFileSync: spawn a short-lived child that attempts to
+    // bind a Unix socket and exits 0 (success) or 1 (ENOTSUP / similar).
+    execFileSync(process.execPath, [
+      '-e',
+      `const n=require("net"),f=require("fs"),p=${JSON.stringify(probe)};` +
+        'const s=n.createServer();' +
+        's.on("error",()=>{try{f.unlinkSync(p)}catch{};process.exit(1)});' +
+        's.listen(p,()=>{s.close();try{f.unlinkSync(p)}catch{};process.exit(0)})',
+    ], { timeout: 3000, stdio: 'ignore' });
+    socketSupportCache.set(dev, true);
+    return true;
+  } catch {
+    try { fs.unlinkSync(probe); } catch { /* probe may not exist */ }
+    socketSupportCache.set(dev, false);
+    return false;
+  }
+}
+
+/**
+ * Clear the socket-support cache. Exported for testing only.
+ */
+export function clearSocketSupportCache(): void {
+  socketSupportCache.clear();
+}
+
+/**
  * Compute the socket / named-pipe path the daemon should listen on (and the
  * proxy should connect to) for `projectRoot`. Deterministic given a project
  * root, so independent processes converge without coordination.
@@ -41,9 +95,11 @@ export function getDaemonSocketPath(projectRoot: string): string {
     return `\\\\.\\pipe\\codegraph-${projectHash(projectRoot)}`;
   }
   const inProject = path.join(getCodeGraphDir(projectRoot), 'daemon.sock');
-  if (inProject.length <= POSIX_SOCKET_PATH_LIMIT) return inProject;
-  // Long project paths (deep monorepos, Bazel out dirs) need tmpdir fallback
-  // or `bind` returns EADDRINUSE / ENAMETOOLONG. Hash keeps it project-scoped.
+  if (inProject.length <= POSIX_SOCKET_PATH_LIMIT && canSocketInDir(path.dirname(inProject))) {
+    return inProject;
+  }
+  // Long project paths, or filesystem doesn't support AF_UNIX sockets
+  // (ExFAT, NTFS-3G, etc. — #997). Hash keeps it project-scoped.
   return path.join(os.tmpdir(), `codegraph-${projectHash(projectRoot)}.sock`);
 }
 


### PR DESCRIPTION
## Summary

Fixes #997.

`getDaemonSocketPath()` now probes whether the target directory supports Unix domain sockets before returning an in-project path. On filesystems that don't support AF_UNIX (ExFAT, NTFS-3G, some FUSE mounts), it transparently falls back to the `os.tmpdir()` hash-based socket — the same path already used for the long-path case.

## Problem

When a project lives on an ExFAT-formatted external volume (common on macOS for USB drives), the daemon fails to start:

```
✗ Failed to start server: listen ENOTSUP: operation not supported on socket /Volumes/drive/project/.codegraph/daemon.sock
```

The existing tmpdir fallback only triggered for paths exceeding 100 characters. Short paths on unsupported filesystems had no fallback.

## Approach

- Added `canSocketInDir(dir)` to `daemon-paths.ts` that spawns a short-lived child process (`execFileSync`) to attempt binding a Unix socket in the target directory
- Result is cached per device number (`fs.statSync().dev`) so the probe runs at most once per mounted filesystem per process lifetime
- Integrated into `getDaemonSocketPath()` alongside the existing length check
- Both daemon and proxy call `getDaemonSocketPath()`, so they automatically agree on the socket path — no changes needed in `daemon.ts` or `index.ts`

## Changes

- **`src/mcp/daemon-paths.ts`**: Added `canSocketInDir()`, `clearSocketSupportCache()` (test helper), updated `getDaemonSocketPath()` guard
- **`__tests__/daemon-socket-probe.test.ts`**: New test file covering probe behavior and cache semantics

## Test plan

- [x] `npm run build` — compiles cleanly
- [x] New tests pass: `canSocketInDir` returns true on tmpdir, caches results, handles nonexistent dirs
- [x] Existing `daemon-bind-failure.test.ts` still passes (no regression)
- [x] Existing `proxy-connect.test.ts` and `daemon-registry.test.ts` still pass
- [x] Manual verification: `getDaemonSocketPath('/Volumes/exfat-drive/project')` returns tmpdir path; local APFS projects still get in-project path