### PR TITLE
fix(search): ignore blank queries for name bonus

### DIFF
--- a/__tests__/context-ranking.test.ts
+++ b/__tests__/context-ranking.test.ts
@@ -16,7 +16,7 @@ import * as path from 'path';
 import * as os from 'os';
 import CodeGraph from '../src/index';
 import { LOW_CONFIDENCE_MARKER } from '../src/context';
-import { isDistinctiveIdentifier, scorePathRelevance, deriveProjectNameTokens } from '../src/search/query-utils';
+import { isDistinctiveIdentifier, nameMatchBonus, scorePathRelevance, deriveProjectNameTokens } from '../src/search/query-utils';
 
 describe('isDistinctiveIdentifier', () => {
   it('treats plain dictionary words as non-distinctive', () => {
@@ -36,6 +36,13 @@ describe('isDistinctiveIdentifier', () => {
     expect(isDistinctiveIdentifier('user_store')).toBe(true);
     expect(isDistinctiveIdentifier('REST')).toBe(true);
     expect(isDistinctiveIdentifier('v2')).toBe(true);
+  });
+});
+
+describe('nameMatchBonus', () => {
+  it('does not award a name match bonus for empty or whitespace-only queries', () => {
+    expect(nameMatchBonus('Anything', '')).toBe(0);
+    expect(nameMatchBonus('Anything', '   \n\t  ')).toBe(0);
   });
 });
 

--- a/src/search/query-utils.ts
+++ b/src/search/query-utils.ts
@@ -343,6 +343,8 @@ function matchesNonProductionDir(lowerPath: string): boolean {
 export function nameMatchBonus(nodeName: string, query: string): number {
   const nameLower = nodeName.toLowerCase();
 
+  if (query.trim().length === 0) return 0;
+
   // Split query into word-level terms (handles "CacheBuilder build" → ["cache","builder","build"])
   const rawTerms = query
     .replace(/([a-z])([A-Z])/g, '$1 $2')


### PR DESCRIPTION
## Summary
- return no name-match boost for empty or whitespace-only queries
- add a regression test covering both empty and whitespace-only inputs

Fixes #984

## Testing
- pnpm exec vitest run __tests__/context-ranking.test.ts
- pnpm exec tsc --noEmit