### PR TITLE
docs: document the `exclude` codegraph.json option (#999)

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,18 @@ add a negation — `!vendor/`. The defaults apply uniformly, so committing a
 dependency or build directory doesn't force it into the graph; the `.gitignore`
 negation is the explicit opt-in.
 
+`.gitignore` can't drop a directory you've **committed**, though. For a vendored
+theme or SDK that's checked into the repo (e.g. a Metronic theme under
+`static/`), list it under `exclude` in `codegraph.json` — gitignore-style
+patterns, matched against repo-root-relative paths, honored on index, sync, and
+watch:
+
+```json
+{
+  "exclude": ["static/", "**/vendor/**"]
+}
+```
+
 ### Custom file extensions
 
 If your project uses a non-standard extension for a [supported

--- a/site/src/content/docs/getting-started/configuration.md
+++ b/site/src/content/docs/getting-started/configuration.md
@@ -1,9 +1,9 @@
 ---
 title: Configuration
-description: CodeGraph is zero-config by default, with one optional codegraph.json for custom extensions and indexing nested git repositories.
+description: CodeGraph is zero-config by default, with one optional codegraph.json for custom extensions, excluding tracked directories, and indexing nested git repositories.
 ---
 
-Next to none — CodeGraph is **zero-config by default**, with nothing to write or keep in sync to get started. Language support is automatic from the file extension; there's nothing to wire up per language. The one optional file, `codegraph.json`, covers [custom file extensions](#custom-file-extensions) and [indexing nested git repositories](#indexing-nested-git-repositories).
+Next to none — CodeGraph is **zero-config by default**, with nothing to write or keep in sync to get started. Language support is automatic from the file extension; there's nothing to wire up per language. The one optional file, `codegraph.json`, covers [custom file extensions](#custom-file-extensions), [excluding tracked directories](#excluding-a-tracked-directory), and [indexing nested git repositories](#indexing-nested-git-repositories).
 
 ## What it skips out of the box
 
@@ -16,6 +16,20 @@ Next to none — CodeGraph is **zero-config by default**, with nothing to write 
 To keep something else out, add it to `.gitignore`. To pull a default-excluded directory back **in** (e.g. you really want a vendored dependency indexed), add a negation — `!vendor/`.
 
 The defaults apply uniformly, so committing a dependency or build directory doesn't force it into the graph — the `.gitignore` negation is the explicit opt-in.
+
+## Excluding a tracked directory
+
+`.gitignore` only affects files git **doesn't already track** — it can't drop a directory you've committed. So a vendored theme, SDK, or asset bundle that's checked into the repo (say a Metronic admin theme under `static/`, with hundreds of `.js` files) can't be excluded that way. For those, list them under `exclude` in `codegraph.json`:
+
+```json
+{
+  "exclude": ["static/", "**/vendor/**"]
+}
+```
+
+Each entry is a gitignore-style pattern, matched against project-root-relative paths, and honored everywhere CodeGraph looks at files — the full index, incremental `sync`, and file-watching. It applies even to tracked files (that's the whole point) and takes precedence over everything else, so it's the right tool for a large committed dependency that bloats the graph but isn't really your code. (This is the opposite of [`includeIgnored`](#indexing-nested-git-repositories), which pulls gitignored directories back *in*.)
+
+Re-index (`codegraph index`) after adding or changing `exclude`.
 
 ## Custom file extensions
 


### PR DESCRIPTION
Follow-up to #1009, which added the `exclude` option but didn't document it.

- **Site config page** (`getting-started/configuration.md`): new "Excluding a tracked directory" section, parallel to `includeIgnored`, explaining the committed-theme/SDK case `.gitignore` can't handle, with a `codegraph.json` example. Updated the intro + frontmatter to list it.
- **README**: brief note + example extending the existing "to keep something else out" paragraph.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)