### PR TITLE
feat(directory): allow local-only codegraph gitignore

### DIFF
--- a/__tests__/foundation.test.ts
+++ b/__tests__/foundation.test.ts
@@ -27,13 +27,18 @@ function cleanupTempDir(dir: string): void {
 
 describe('CodeGraph Foundation', () => {
   let tempDir: string;
+  let savedLocalGitignore: string | undefined;
 
   beforeEach(() => {
     tempDir = createTempDir();
+    savedLocalGitignore = process.env.CODEGRAPH_LOCAL_GITIGNORE;
+    delete process.env.CODEGRAPH_LOCAL_GITIGNORE;
   });
 
   afterEach(() => {
     cleanupTempDir(tempDir);
+    if (savedLocalGitignore === undefined) delete process.env.CODEGRAPH_LOCAL_GITIGNORE;
+    else process.env.CODEGRAPH_LOCAL_GITIGNORE = savedLocalGitignore;
   });
 
   describe('Initialization', () => {
@@ -58,6 +63,20 @@ describe('CodeGraph Foundation', () => {
       // files (db, daemon.pid, sockets, logs) never show up in git. (#492, #484)
       expect(content).toContain('*');
       expect(content).toContain('!.gitignore');
+
+      cg.close();
+    });
+
+    it('can create a local-only .codegraph/.gitignore', () => {
+      process.env.CODEGRAPH_LOCAL_GITIGNORE = '1';
+      const cg = CodeGraph.initSync(tempDir);
+
+      const gitignorePath = path.join(getCodeGraphDir(tempDir), '.gitignore');
+      expect(fs.existsSync(gitignorePath)).toBe(true);
+
+      const content = fs.readFileSync(gitignorePath, 'utf-8');
+      expect(content).toContain('*');
+      expect(content).not.toContain('!.gitignore');
 
       cg.close();
     });

--- a/src/directory.ts
+++ b/src/directory.ts
@@ -401,8 +401,18 @@ const GITIGNORE_CONTENT = `# CodeGraph data files — local to each machine, not
 !.gitignore
 `;
 
+const LOCAL_GITIGNORE_CONTENT = `# CodeGraph data files — local to this machine, not for committing.
+# Ignore everything in .codegraph/, including this file itself.
+*
+`;
+
 /** Header line that prefixes every .gitignore CodeGraph has auto-generated. */
 const GITIGNORE_MARKER = '# CodeGraph data files';
+
+function localGitignoreEnabled(): boolean {
+  const raw = process.env.CODEGRAPH_LOCAL_GITIGNORE?.trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
 
 /**
  * Is `content` a stale CodeGraph-generated `.gitignore` that should be
@@ -434,7 +444,7 @@ function ensureGitignore(gitignorePath: string): boolean {
   // Current default or a user-authored file: nothing to do.
   if (existing !== null && !isStaleDefaultGitignore(existing)) return true;
   try {
-    fs.writeFileSync(gitignorePath, GITIGNORE_CONTENT, 'utf-8');
+    fs.writeFileSync(gitignorePath, localGitignoreEnabled() ? LOCAL_GITIGNORE_CONTENT : GITIGNORE_CONTENT, 'utf-8');
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- add CODEGRAPH_LOCAL_GITIGNORE=1 as an opt-in local-only .codegraph/.gitignore mode
- keep the default shared .gitignore behavior unchanged
- cover the opt-in behavior in foundation tests

Fixes #910

## Testing
- pnpm exec tsc --noEmit
- pnpm exec vitest run __tests__/foundation.test.ts
