### PR TITLE
fix(cpp): emit instantiates edge for stack-allocation constructor syntax

### DIFF
--- a/src/extraction/tree-sitter.ts
+++ b/src/extraction/tree-sitter.ts
@@ -28,6 +28,7 @@ import { AstroExtractor } from './astro-extractor';
 import { DfmExtractor } from './dfm-extractor';
 import { VueExtractor } from './vue-extractor';
 import { MyBatisExtractor } from './mybatis-extractor';
+import { normalizeCppReturnType } from './languages/c-cpp';
 import {
   getAllFrameworkResolvers,
   getApplicableFrameworks,
@@ -4241,6 +4242,33 @@ export class TreeSitterExtractor {
         if (anonBody) {
           this.extractAnonymousClass(node, anonBody);
           return;
+        }
+      } else if (this.language === 'cpp' && nodeType === 'declaration') {
+        // C++ stack-allocation `ClassName var(args)` is parsed as a `declaration`
+        // node — unlike `new ClassName(args)` (a `new_expression` in
+        // INSTANTIATION_KINDS), it never reaches extractInstantiation.
+        // Detect by finding an `init_declarator` with an `argument_list` child
+        // and a non-primitive declared type, then emit an `instantiates` edge.
+        const typeNode = getChildByField(node, 'type');
+        const typeName = typeNode
+          ? normalizeCppReturnType(getNodeText(typeNode, this.source))
+          : undefined;
+        if (typeName && this.nodeStack.length > 0) {
+          for (let i = 0; i < node.namedChildCount; i++) {
+            const child = node.namedChild(i);
+            if (child?.type === 'init_declarator') {
+              const hasArgList = child.namedChildren.some((c) => c.type === 'argument_list');
+              if (hasArgList) {
+                this.unresolvedReferences.push({
+                  fromNodeId: this.nodeStack[this.nodeStack.length - 1]!,
+                  referenceName: typeName,
+                  referenceKind: 'instantiates',
+                  line: node.startPosition.row + 1,
+                  column: node.startPosition.column,
+                });
+              }
+            }
+          }
         }
       } else if (this.extractor!.extractBareCall) {
         const calleeName = this.extractor!.extractBareCall(node, this.source);


### PR DESCRIPTION
## Summary

C++ stack-allocation syntax (`ClassName var(args)`) does not produce an
`instantiates` edge. Heap allocation (`new ClassName(args)`) works correctly
because `new_expression` is in `INSTANTIATION_KINDS`, but the stack form is
parsed by tree-sitter as a `declaration` node, which is never matched.

This fix adds a branch inside `visitFunctionBody`'s body walker that detects
the pattern: a `declaration` node whose `type` field resolves to a class name
(via the existing `normalizeCppReturnType` primitive filter) and whose
`init_declarator` child contains an `argument_list`. When matched, an
`instantiates` unresolved reference is pushed — the same shape that
`extractInstantiation` produces for `new_expression`.

## What's covered

- `Calculator calc(0)` → `caller --[instantiates]--> Calculator` ✓
- `int x(5)` → skipped (`int` is in `CPP_NON_CLASS_RETURN`) ✓
- `Calculator calc = other` → skipped (no `argument_list` in declarator) ✓

## Known limitations

- **Default constructor** (`Calculator calc;`) — no `init_declarator` child,
  so no edge is emitted. Can be addressed in a follow-up.
- **Brace initialization** (`Calculator calc{0}`) — uses `initializer_list`
  rather than `argument_list`, not covered here.

Closes #1035