### PR TITLE
fix(mcp): drain the loop on Windows daemon shutdown instead of aborting mid-watcher-close

### DIFF
--- a/__tests__/daemon-bind-failure.test.ts
+++ b/__tests__/daemon-bind-failure.test.ts
@@ -13,11 +13,11 @@
  * so it survives and `listen()` fails with EADDRINUSE.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { Daemon, tryAcquireDaemonLock } from '../src/mcp/daemon';
+import { Daemon, tryAcquireDaemonLock, finalizeDaemonExit } from '../src/mcp/daemon';
 import { getDaemonPidPath, getDaemonSocketPath } from '../src/mcp/daemon-paths';
 
 const tmpRoots: string[] = [];
@@ -51,5 +51,45 @@ describe('Daemon.start() bind failure (#974)', () => {
 
     // The lockfile must be gone so the next launcher doesn't spin on a stale lock.
     expect(fs.existsSync(pidPath)).toBe(false);
+  });
+});
+
+/**
+ * Windows shutdown must not force `process.exit()` while the recursive file
+ * watcher is still tearing down — that aborts the daemon with a libuv
+ * `UV_HANDLE_CLOSING` assertion (0xC0000409), reproducible when the indexed tree
+ * contains a nested repo. `finalizeDaemonExit` drains on Windows and exits
+ * immediately elsewhere; both branches are exercised here by injecting the
+ * platform + exit fn (so it runs on any host).
+ */
+describe('finalizeDaemonExit — Windows drains instead of aborting mid-watcher-close', () => {
+  for (const platform of ['linux', 'darwin'] as const) {
+    it(`exits immediately on ${platform}`, () => {
+      const exit = vi.fn();
+      const backstop = finalizeDaemonExit(platform, exit);
+      expect(exit).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenCalledWith(0);
+      expect(backstop).toBeNull();
+    });
+  }
+
+  it('on win32 defers exit (lets the loop drain), then force-exits via an unref\'d backstop', () => {
+    vi.useFakeTimers();
+    const prevExitCode = process.exitCode;
+    const exit = vi.fn();
+    try {
+      const backstop = finalizeDaemonExit('win32', exit);
+      // No synchronous exit — the process must drain its closing watch handles first.
+      expect(exit).not.toHaveBeenCalled();
+      expect(backstop).not.toBeNull();
+      // Success code is set so a natural drain exits 0.
+      expect(process.exitCode).toBe(0);
+      // If a stray handle keeps the loop alive, the backstop still forces exit.
+      vi.advanceTimersByTime(2_000);
+      expect(exit).toHaveBeenCalledWith(0);
+    } finally {
+      vi.useRealTimers();
+      process.exitCode = prevExitCode; // don't leak a 0 exit code into the runner
+    }
   });
 });

--- a/src/mcp/daemon.ts
+++ b/src/mcp/daemon.ts
@@ -70,6 +70,45 @@ const DEFAULT_IDLE_TIMEOUT_MS = 300_000;
  */
 const DEFAULT_MAX_IDLE_MS = 1_800_000; // 30 min
 
+/**
+ * Windows-only shutdown backstop. On Windows, calling `process.exit()` while a
+ * recursive `fs.watch` handle is still tearing down aborts the process with a
+ * libuv `UV_HANDLE_CLOSING` assertion (`0xC0000409`) — reproducible whenever the
+ * watched tree contains a nested repo (submodule / embedded clone), since that's
+ * what keeps a watch active at shutdown. The fix is to let the event loop drain
+ * so libuv finishes closing those handles, then exit naturally; this timer only
+ * force-exits if some unexpected handle keeps the loop alive past the grace
+ * window. Kept short so shutdown stays snappy in that fallback. See
+ * `finalizeDaemonExit`.
+ */
+const DAEMON_SHUTDOWN_BACKSTOP_MS = 2_000;
+
+/**
+ * Finalize daemon shutdown. On POSIX, exit immediately — it's clean and fast.
+ * On Windows, do NOT force an exit while watchers may still be closing (that
+ * trips the libuv assertion above); instead mark success and let the loop drain
+ * to a natural exit, with an UNREF'd backstop that force-exits only if a stray
+ * handle would otherwise hang shutdown. Pure and platform-injected so both
+ * branches are unit-testable off-Windows. Returns the backstop timer (Windows)
+ * so callers/tests can clear it.
+ */
+export function finalizeDaemonExit(
+  platform: NodeJS.Platform,
+  exit: (code: number) => void,
+): NodeJS.Timeout | null {
+  if (platform === 'win32') {
+    process.exitCode = 0;
+    const backstop = setTimeout(() => exit(0), DAEMON_SHUTDOWN_BACKSTOP_MS);
+    // Unref so it never keeps the loop alive: a natural drain (watchers closed,
+    // nothing else pending) exits before it fires; it only fires when some other
+    // handle is keeping the loop running, which is exactly when we need it.
+    backstop.unref?.();
+    return backstop;
+  }
+  exit(0);
+  return null;
+}
+
 /** How often the daemon sweeps connected clients for a dead peer process (#692). */
 const DEFAULT_CLIENT_SWEEP_MS = 30_000;
 
@@ -306,7 +345,10 @@ export class Daemon {
     if (process.platform !== 'win32') {
       try { fs.unlinkSync(this.socketPath); } catch { /* may already be gone */ }
     }
-    process.exit(0);
+    // POSIX exits here; Windows drains first (engine.stop() above began closing
+    // the file watcher, and exiting mid-teardown aborts the process). See
+    // finalizeDaemonExit / DAEMON_SHUTDOWN_BACKSTOP_MS.
+    finalizeDaemonExit(process.platform, (code) => process.exit(code));
   }
 
   private handleConnection(socket: net.Socket): void {


### PR DESCRIPTION
Discovered while validating the submodule-workspace story (#1033).

## Problem

On **Windows**, the daemon's `process.exit(0)` fires while the recursive `fs.watch` handle is still tearing down, which aborts the process with a libuv assertion `!(handle->flags & UV_HANDLE_CLOSING)` (`src\win\async.c`), exit code `0xC0000409`. The trigger is a **nested repo (submodule / embedded clone / gitlink) in the indexed tree** — that keeps a watch active at shutdown, so the race is live. Plain repos don't reproduce it, which is why it stayed hidden until the nested-repo indexing work.

It's a race, but near-deterministic when a nested repo is present (a VM loop measured **8/8 aborts**). A small exit delay (`setTimeout(exit, 0)` / `300`) doesn't help — only *not* force-exiting during the close is clean.

## Fix

`finalizeDaemonExit(platform, exit)`:
- **POSIX** — exit immediately (unchanged; clean and fast there).
- **Windows** — mark success (`exitCode = 0`) and let the event loop **drain** to a natural exit so libuv finishes closing the watch handles, with an **unref'd** backstop that force-exits only if some stray handle would otherwise hang shutdown.

Safe because the daemon's own timers (idle/maxIdle/clientSweep) are already `unref`'d and its PPID watchdog lives in the proxy — nothing keeps the loop alive past the closing handles, so natural drain is fast. `daemon.stop()` calls the helper in place of the old `process.exit(0)`.

## Validation

| | aborts | shutdown |
|---|---|---|
| before (current) | **8/8** | crash (`0xC0000409`) |
| after (fix) | **0/8** | ~20ms natural-drain |

- Real Windows VM: looped the watcher + real `finalizeDaemonExit` on a submodule workspace — 0/8 aborts, ~20ms clean shutdown.
- 3 new unit tests (both platform branches via platform injection + fake timers) in `daemon-bind-failure.test.ts`. Full suite: 1820 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)