### PR TITLE
chore: bump version to 1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@colbymchenry/codegraph",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@colbymchenry/codegraph",
-      "version": "1.1.1",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.3.0",
@@ -1431,6 +1431,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colbymchenry/codegraph",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Supercharge AI coding agents with semantic code intelligence — surgical context, fewer tool calls, faster answers. 100% local.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump to 1.1.3 to release the current `[Unreleased]` changelog (the four @jcrabapple CLI/indexing fixes — #1044, #1045, #1046, #1047 — plus everything else staged).

- `package.json`: 1.1.2 → 1.1.3
- `package-lock.json`: synced via `npm install --package-lock-only --ignore-scripts` (top-level + `packages.""`, which had drifted to 1.1.1)

The Release workflow promotes `[Unreleased]` → `[1.1.3]` and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)