### PR TITLE
feat: in-memory indexing API + call-site metadata + GraphQL resolver

### DIFF
--- a/__tests__/foundation.test.ts
+++ b/__tests__/foundation.test.ts
@@ -282,7 +282,7 @@ describe('Database Connection', () => {
 
     const version = db.getSchemaVersion();
     expect(version).not.toBeNull();
-    expect(version?.version).toBe(5);
+    expect(version?.version).toBe(6);
 
     db.close();
   });

--- a/__tests__/frameworks.test.ts
+++ b/__tests__/frameworks.test.ts
@@ -1741,3 +1741,165 @@ export class UsersController {
     expect(references.map((r) => r.referenceName)).toEqual(['real']);
   });
 });
+
+import { strawberryResolver, grapheneResolver } from '../src/resolution/frameworks/graphql';
+
+describe('strawberryResolver.extract', () => {
+  it('extracts @strawberry.field methods on Query class', () => {
+    const src = `
+import strawberry
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    async def product_by_id(self, info, product_id: strawberry.ID) -> Product:
+        pass
+
+    @strawberry.field(description='Get all products')
+    async def products(self, info) -> list[Product]:
+        pass
+`;
+    const { nodes, references } = strawberryResolver.extract!('app/graphql/query.py', src);
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0]!.kind).toBe('route');
+    expect(nodes[0]!.name).toBe('QUERY product_by_id');
+    expect(nodes[1]!.name).toBe('QUERY products');
+    expect(references).toHaveLength(2);
+    expect(references[0]!.referenceName).toBe('product_by_id');
+    expect(references[0]!.fromNodeId).toBe(nodes[0]!.id);
+    expect(references[1]!.referenceName).toBe('products');
+  });
+
+  it('extracts strawberry.field(resolver=...) assignments', () => {
+    const src = `
+import strawberry
+from resolvers import alt_resolver
+
+@strawberry.type
+class Query:
+    alternative_products: list[Product] = strawberry.field(
+        resolver=alt_resolver.resolve_alternatives,
+    )
+`;
+    const { nodes, references } = strawberryResolver.extract!('app/graphql/query.py', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]!.name).toBe('QUERY alternative_products');
+    expect(references).toHaveLength(1);
+    expect(references[0]!.referenceName).toBe('resolve_alternatives');
+    expect(references[0]!.metadata?.graphqlResolver).toBe('alt_resolver.resolve_alternatives');
+  });
+
+  it('extracts Mutation fields', () => {
+    const src = `
+import strawberry
+
+@strawberry.type
+class Mutation:
+    @strawberry.field
+    async def create_product(self, info, input: ProductInput) -> Product:
+        pass
+`;
+    const { nodes } = strawberryResolver.extract!('app/graphql/mutation.py', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]!.name).toBe('MUTATION create_product');
+  });
+
+  it('skips non-root types (no Query/Mutation/Subscription in name)', () => {
+    const src = `
+import strawberry
+
+@strawberry.type
+class Product:
+    @strawberry.field
+    async def manufacturer(self, info) -> Producer:
+        pass
+`;
+    const { nodes } = strawberryResolver.extract!('app/graphql/models/product.py', src);
+    expect(nodes).toHaveLength(0);
+  });
+
+  it('ignores files without strawberry import', () => {
+    const src = `
+class Query:
+    def get_products(self):
+        pass
+`;
+    const { nodes } = strawberryResolver.extract!('app/views.py', src);
+    expect(nodes).toHaveLength(0);
+  });
+
+  it('handles mixed decorated methods and field assignments', () => {
+    const src = `
+import strawberry
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    async def product_by_id(self, info, product_id: strawberry.ID) -> Product:
+        pass
+
+    alternative_products: list[Product] = strawberry.field(
+        resolver=resolve_alternatives,
+    )
+
+    @strawberry.field
+    async def categories(self, info) -> list[Category]:
+        pass
+`;
+    const { nodes } = strawberryResolver.extract!('app/graphql/query.py', src);
+    expect(nodes).toHaveLength(3);
+    expect(nodes.map((n) => n.name)).toEqual([
+      'QUERY product_by_id',
+      'QUERY categories',
+      'QUERY alternative_products',
+    ]);
+  });
+
+  it('skips private/dunder methods', () => {
+    const src = `
+import strawberry
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    async def products(self, info) -> list[Product]:
+        pass
+
+    def __init__(self):
+        pass
+`;
+    const { nodes } = strawberryResolver.extract!('app/graphql/query.py', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]!.name).toBe('QUERY products');
+  });
+});
+
+describe('grapheneResolver.extract', () => {
+  it('extracts resolve_ methods on ObjectType subclass named Query', () => {
+    const src = `
+import graphene
+
+class Query(graphene.ObjectType):
+    products = graphene.List(ProductType)
+
+    def resolve_products(self, info):
+        return Product.objects.all()
+`;
+    const { nodes, references } = grapheneResolver.extract!('app/schema.py', src);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]!.name).toBe('QUERY products');
+    expect(references[0]!.referenceName).toBe('resolve_products');
+  });
+
+  it('skips non-root ObjectType classes', () => {
+    const src = `
+import graphene
+
+class ProductType(graphene.ObjectType):
+    def resolve_name(self, info):
+        return self.name
+`;
+    const { nodes } = grapheneResolver.extract!('app/schema.py', src);
+    expect(nodes).toHaveLength(0);
+  });
+});

--- a/__tests__/pr19-improvements.test.ts
+++ b/__tests__/pr19-improvements.test.ts
@@ -299,7 +299,7 @@ describe('Best-Candidate Resolution', () => {
 describe('Schema v2 Migration', () => {
   it.skipIf(!HAS_SQLITE)('should have correct current schema version', async () => {
     const { CURRENT_SCHEMA_VERSION } = await import('../src/db/migrations');
-    expect(CURRENT_SCHEMA_VERSION).toBe(5);
+    expect(CURRENT_SCHEMA_VERSION).toBe(6);
   });
 
   it.skipIf(!HAS_SQLITE)('should have migration for version 2', async () => {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -93,6 +93,25 @@ export class DatabaseConnection {
   }
 
   /**
+   * Create an ephemeral in-memory database (no disk writes).
+   * Caller is responsible for calling close() when done.
+   */
+  static initializeInMemory(): DatabaseConnection {
+    const { db, backend } = createDatabase(':memory:');
+    configureConnection(db);
+    const schemaPath = path.join(__dirname, 'schema.sql');
+    const schema = fs.readFileSync(schemaPath, 'utf-8');
+    db.exec(schema);
+    const currentVersion = getCurrentVersion(db);
+    if (currentVersion < CURRENT_SCHEMA_VERSION) {
+      db.prepare(
+        'INSERT OR IGNORE INTO schema_versions (version, applied_at, description) VALUES (?, ?, ?)'
+      ).run(CURRENT_SCHEMA_VERSION, Date.now(), 'Initial schema includes all migrations');
+    }
+    return new DatabaseConnection(db, ':memory:', backend);
+  }
+
+  /**
    * Open an existing database
    */
   static open(dbPath: string): DatabaseConnection {

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -9,7 +9,7 @@ import { SqliteDatabase } from './sqlite-adapter';
 /**
  * Current schema version
  */
-export const CURRENT_SCHEMA_VERSION = 5;
+export const CURRENT_SCHEMA_VERSION = 6;
 
 /**
  * Migration definition
@@ -72,6 +72,16 @@ const migrations: Migration[] = [
     up: (db) => {
       db.exec(`
         ALTER TABLE nodes ADD COLUMN return_type TEXT;
+      `);
+    },
+  },
+  {
+    version: 6,
+    description:
+      'Add unresolved_refs.metadata — call-site metadata (receiver, method, literal args) for resolution pipeline',
+    up: (db) => {
+      db.exec(`
+        ALTER TABLE unresolved_refs ADD COLUMN metadata TEXT;
       `);
     },
   },

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -108,6 +108,7 @@ interface UnresolvedRefRow {
   candidates: string | null;
   file_path: string;
   language: string;
+  metadata: string | null;
 }
 
 /**
@@ -1552,8 +1553,8 @@ export class QueryBuilder {
   insertUnresolvedRef(ref: UnresolvedReference): void {
     if (!this.stmts.insertUnresolved) {
       this.stmts.insertUnresolved = this.db.prepare(`
-        INSERT INTO unresolved_refs (from_node_id, reference_name, reference_kind, line, col, candidates, file_path, language)
-        VALUES (@fromNodeId, @referenceName, @referenceKind, @line, @col, @candidates, @filePath, @language)
+        INSERT INTO unresolved_refs (from_node_id, reference_name, reference_kind, line, col, candidates, file_path, language, metadata)
+        VALUES (@fromNodeId, @referenceName, @referenceKind, @line, @col, @candidates, @filePath, @language, @metadata)
       `);
     }
 
@@ -1566,6 +1567,7 @@ export class QueryBuilder {
       candidates: ref.candidates ? JSON.stringify(ref.candidates) : null,
       filePath: ref.filePath ?? '',
       language: ref.language ?? 'unknown',
+      metadata: ref.metadata ? JSON.stringify(ref.metadata) : null,
     });
   }
 
@@ -1613,6 +1615,7 @@ export class QueryBuilder {
       candidates: row.candidates ? safeJsonParse(row.candidates, undefined) : undefined,
       filePath: row.file_path,
       language: row.language as Language,
+      metadata: row.metadata ? safeJsonParse(row.metadata, undefined) : undefined,
     }));
   }
 
@@ -1630,6 +1633,7 @@ export class QueryBuilder {
       candidates: row.candidates ? safeJsonParse(row.candidates, undefined) : undefined,
       filePath: row.file_path,
       language: row.language as Language,
+      metadata: row.metadata ? safeJsonParse(row.metadata, undefined) : undefined,
     }));
   }
 
@@ -1666,6 +1670,7 @@ export class QueryBuilder {
       candidates: row.candidates ? safeJsonParse(row.candidates, undefined) : undefined,
       filePath: row.file_path,
       language: row.language as Language,
+      metadata: row.metadata ? safeJsonParse(row.metadata, undefined) : undefined,
     }));
   }
 
@@ -1721,6 +1726,7 @@ export class QueryBuilder {
       candidates: row.candidates ? safeJsonParse(row.candidates, undefined) : undefined,
       filePath: row.file_path,
       language: row.language as Language,
+      metadata: row.metadata ? safeJsonParse(row.metadata, undefined) : undefined,
     }));
   }
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -727,6 +727,11 @@ export class QueryBuilder {
     return rows.map(rowToNode);
   }
 
+  getAllEdges(): Edge[] {
+    const rows = this.db.prepare('SELECT * FROM edges').all() as EdgeRow[];
+    return rows.map(rowToEdge);
+  }
+
   /**
    * Get nodes by exact name match (uses idx_nodes_name index)
    */

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -78,6 +78,7 @@ CREATE TABLE IF NOT EXISTS unresolved_refs (
     candidates TEXT, -- JSON array
     file_path TEXT NOT NULL DEFAULT '',
     language TEXT NOT NULL DEFAULT 'unknown',
+    metadata TEXT,
     FOREIGN KEY (from_node_id) REFERENCES nodes(id) ON DELETE CASCADE
 );
 

--- a/src/extraction/tree-sitter.ts
+++ b/src/extraction/tree-sitter.ts
@@ -242,6 +242,35 @@ function swiftPropertyInfo(
 
 /** True when `node` is (transitively) inside a C function body — i.e. a local,
  * not a file/namespace-scope declaration. Walks the parent chain to the root. */
+function stripQuotes(s: string): string {
+  if (s.length >= 6) {
+    if ((s.startsWith('"""') && s.endsWith('"""')) || (s.startsWith("'''") && s.endsWith("'''"))) {
+      return s.slice(3, -3);
+    }
+  }
+  if (s.length >= 2) {
+    const f = s[0], l = s[s.length - 1];
+    if ((f === '"' && l === '"') || (f === "'" && l === "'") || (f === '`' && l === '`')) {
+      return s.slice(1, -1);
+    }
+  }
+  return s;
+}
+
+const STRING_LITERAL_TYPES = new Set([
+  'string', 'string_literal', 'raw_string_literal', 'interpreted_string_literal',
+  'string_content', 'encapsed_string', 'char_literal', 'rune_literal',
+  'string_value', 'quoted_string',
+]);
+
+const RAW_STRING_TYPES = new Set(['raw_string_literal', 'raw_string']);
+
+const TEMPLATE_TYPES = new Set(['template_string', 'template_literal_type']);
+
+const INTERPOLATION_TYPES = new Set([
+  'template_substitution', 'string_interpolation', 'interpolation',
+]);
+
 function hasFunctionAncestor(node: SyntaxNode): boolean {
   let p = node.parent;
   while (p) {
@@ -3436,6 +3465,8 @@ export class TreeSitterExtractor {
 
     // Get the function/method being called
     let calleeName = '';
+    let callReceiver: string | undefined;
+    let callMethod: string | undefined;
 
     // Java/Kotlin method_invocation has 'object' + 'name' fields instead of 'function'
     // PHP member_call_expression has 'object' + 'name', scoped_call_expression has 'scope' + 'name'
@@ -3466,12 +3497,19 @@ export class TreeSitterExtractor {
           calleeName = methodName;
         }
         if (calleeName) {
+          const literalArgs = this.extractLiteralArgs(node);
           this.unresolvedReferences.push({
             fromNodeId: callerId,
             referenceName: calleeName,
             referenceKind: 'calls',
             line: node.startPosition.row + 1,
             column: node.startPosition.column,
+            ...(methodName || literalArgs ? {
+              metadata: {
+                ...(methodName ? { method: methodName } : {}),
+                ...(literalArgs ? { literalArgs } : {}),
+              },
+            } : {}),
           });
         }
         return;
@@ -3493,12 +3531,19 @@ export class TreeSitterExtractor {
         const innerName = getChildByField(objectField, 'name');
         if (innerObj && innerName) {
           calleeName = `${getNodeText(innerObj, this.source)}.${getNodeText(innerName, this.source)}().${methodName}`;
+          const literalArgs = this.extractLiteralArgs(node);
           this.unresolvedReferences.push({
             fromNodeId: callerId,
             referenceName: calleeName,
             referenceKind: 'calls',
             line: node.startPosition.row + 1,
             column: node.startPosition.column,
+            ...(methodName || literalArgs ? {
+              metadata: {
+                ...(methodName ? { method: methodName } : {}),
+                ...(literalArgs ? { literalArgs } : {}),
+              },
+            } : {}),
           });
           return;
         }
@@ -3526,7 +3571,9 @@ export class TreeSitterExtractor {
           calleeName = methodName;
         } else {
           calleeName = `${receiverName}.${methodName}`;
+          callReceiver = receiverName;
         }
+        callMethod = methodName;
       }
     } else if (node.type === 'message_expression') {
       // ObjC message expressions emit one `method` field child per selector
@@ -3564,6 +3611,8 @@ export class TreeSitterExtractor {
           const receiverName = getNodeText(receiverField, this.source);
           if (receiverName && !SKIP_RECEIVERS.has(receiverName)) {
             calleeName = `${receiverName}.${methodName}`;
+            callReceiver = receiverName;
+            callMethod = methodName;
             // A CLASS-message receiver (`[SDImageCache alloc]`,
             // `[SDImageCache sharedCache]`) is a capitalized class name. The
             // call resolves the method (`alloc`/`sharedCache`), but the CLASS
@@ -3649,9 +3698,11 @@ export class TreeSitterExtractor {
               const receiverName = getNodeText(receiver, this.source);
               if (!SKIP_RECEIVERS.has(receiverName)) {
                 calleeName = `${receiverName}.${methodName}`;
+                callReceiver = receiverName;
               } else {
                 calleeName = methodName;
               }
+              callMethod = methodName;
             } else if (
               (this.language === 'cpp' ||
                 this.language === 'c' ||
@@ -3732,6 +3783,7 @@ export class TreeSitterExtractor {
           } else {
             calleeName = getNodeText(func, this.source);
           }
+          if (methodName) callMethod = methodName;
         } else {
           calleeName = getNodeText(func, this.source);
         }
@@ -3749,14 +3801,73 @@ export class TreeSitterExtractor {
     }
 
     if (calleeName) {
+      const literalArgs = this.extractLiteralArgs(node);
+      const hasCallSite = callReceiver || callMethod || literalArgs;
       this.unresolvedReferences.push({
         fromNodeId: callerId,
         referenceName: calleeName,
         referenceKind: 'calls',
         line: node.startPosition.row + 1,
         column: node.startPosition.column,
+        ...(hasCallSite ? {
+          metadata: {
+            ...(callReceiver ? { receiver: callReceiver } : {}),
+            ...(callMethod ? { method: callMethod } : {}),
+            ...(literalArgs ? { literalArgs } : {}),
+          },
+        } : {}),
       });
     }
+  }
+
+  private extractStringLiteral(node: SyntaxNode): { value: string; kind: 'string' | 'raw_string' | 'template_no_expr' } | null {
+    const type = node.type;
+
+    if (TEMPLATE_TYPES.has(type)) {
+      if (node.namedChildren.some(c => INTERPOLATION_TYPES.has(c.type))) return null;
+      return { value: stripQuotes(getNodeText(node, this.source)), kind: 'template_no_expr' };
+    }
+
+    if (RAW_STRING_TYPES.has(type)) {
+      return { value: stripQuotes(getNodeText(node, this.source)), kind: 'raw_string' };
+    }
+
+    if (STRING_LITERAL_TYPES.has(type)) {
+      if (node.namedChildren.some(c => INTERPOLATION_TYPES.has(c.type))) return null;
+      return { value: stripQuotes(getNodeText(node, this.source)), kind: 'string' };
+    }
+
+    if (node.namedChildCount === 1) {
+      const child = node.namedChild(0);
+      if (child && STRING_LITERAL_TYPES.has(child.type)) {
+        if (child.namedChildren.some(c => INTERPOLATION_TYPES.has(c.type))) return null;
+        return { value: stripQuotes(getNodeText(node, this.source)), kind: 'string' };
+      }
+    }
+
+    return null;
+  }
+
+  private extractLiteralArgs(node: SyntaxNode, maxArgs: number = 3): Array<{ index: number; value: string; kind: 'string' | 'raw_string' | 'template_no_expr' }> | undefined {
+    const argsNode = getChildByField(node, 'arguments')
+      || node.namedChildren.find(c => c.type === 'argument_list' || c.type === 'arguments' || c.type === 'actual_parameters');
+    if (!argsNode) return undefined;
+
+    const result: Array<{ index: number; value: string; kind: 'string' | 'raw_string' | 'template_no_expr' }> = [];
+    let argIndex = 0;
+
+    for (let i = 0; i < argsNode.namedChildCount && result.length < maxArgs; i++) {
+      const arg = argsNode.namedChild(i);
+      if (!arg) continue;
+      if (arg.type === ',' || arg.type === '(' || arg.type === ')') continue;
+      const literal = this.extractStringLiteral(arg);
+      if (literal) {
+        result.push({ index: argIndex, ...literal });
+      }
+      argIndex++;
+    }
+
+    return result.length > 0 ? result : undefined;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import {
   ResolutionResult,
 } from './resolution';
 import { GraphTraverser, GraphQueryManager } from './graph';
+export { GraphTraverser } from './graph';
 import { ContextBuilder, createContextBuilder } from './context';
 import { Mutex, FileLock } from './utils';
 import { FileWatcher, WatchOptions, PendingFile, LockUnavailableError } from './sync';
@@ -114,6 +115,17 @@ export interface InMemoryIndexResult {
     edgesCreated: number;
     durationMs: number;
   };
+}
+
+/**
+ * Handle returned by indexInMemoryOpen(). Keeps the in-memory DB alive so
+ * callers can run graph traversals (callers, callees, impact, path-finding)
+ * before closing.
+ */
+export interface InMemoryGraph extends InMemoryIndexResult {
+  traverser: GraphTraverser;
+  queries: QueryBuilder;
+  close(): void;
 }
 
 /**
@@ -347,6 +359,53 @@ export class CodeGraph {
     } finally {
       db.close();
     }
+  }
+
+  /**
+   * Index a project in memory and return a handle with live graph traversal.
+   * The caller MUST call close() when done.
+   */
+  static async indexInMemoryOpen(projectRoot: string): Promise<InMemoryGraph> {
+    await initGrammars();
+    const resolvedRoot = path.resolve(projectRoot);
+    const db = DatabaseConnection.initializeInMemory();
+    const queries = new QueryBuilder(db.getDb());
+
+    const orchestrator = new ExtractionOrchestrator(resolvedRoot, queries);
+    const resolver = createResolver(resolvedRoot, queries);
+
+    const start = Date.now();
+    const result = await orchestrator.indexAll();
+
+    if (result.success && result.filesIndexed > 0) {
+      resolver.initialize();
+      resolver.runPostExtract();
+      await resolver.resolveAndPersistBatched();
+      resolver.resolveChainedCallsViaConformance();
+      resolver.resolveDeferredThisMemberRefs();
+    }
+
+    const nodes = queries.getAllNodes();
+    const edges = queries.getAllEdges();
+    const durationMs = Date.now() - start;
+    const fileCount = (db.getDb().prepare('SELECT COUNT(*) AS c FROM files').get() as any)?.c ?? 0;
+
+    return {
+      success: result.success,
+      nodes,
+      edges,
+      files: fileCount,
+      errors: result.errors,
+      stats: {
+        filesIndexed: result.filesIndexed,
+        nodesCreated: nodes.length,
+        edgesCreated: edges.length,
+        durationMs,
+      },
+      traverser: new GraphTraverser(queries),
+      queries,
+      close() { db.close(); },
+    };
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import {
   Node,
   Edge,
+  ExtractionError,
   FileRecord,
   ExtractionResult,
   Subgraph,
@@ -96,6 +97,23 @@ export interface InitOptions {
 
   /** Progress callback for indexing */
   onProgress?: (progress: IndexProgress) => void;
+}
+
+/**
+ * Result of an in-memory index: all nodes, edges, and stats without disk I/O.
+ */
+export interface InMemoryIndexResult {
+  success: boolean;
+  nodes: Node[];
+  edges: Edge[];
+  files: number;
+  errors: ExtractionError[];
+  stats: {
+    filesIndexed: number;
+    nodesCreated: number;
+    edgesCreated: number;
+    durationMs: number;
+  };
 }
 
 /**
@@ -280,6 +298,55 @@ export class CodeGraph {
     const queries = new QueryBuilder(db.getDb());
 
     return new CodeGraph(db, queries, resolvedRoot);
+  }
+
+  /**
+   * Index a project entirely in memory — no .codegraph/ directory, no disk DB.
+   * Runs the full pipeline (extraction + resolution) and returns all nodes and
+   * edges. The in-memory DB is closed before returning.
+   */
+  static async indexInMemory(projectRoot: string): Promise<InMemoryIndexResult> {
+    await initGrammars();
+    const resolvedRoot = path.resolve(projectRoot);
+    const db = DatabaseConnection.initializeInMemory();
+    const queries = new QueryBuilder(db.getDb());
+
+    try {
+      const orchestrator = new ExtractionOrchestrator(resolvedRoot, queries);
+      const resolver = createResolver(resolvedRoot, queries);
+
+      const start = Date.now();
+      const result = await orchestrator.indexAll();
+
+      if (result.success && result.filesIndexed > 0) {
+        resolver.initialize();
+        resolver.runPostExtract();
+        await resolver.resolveAndPersistBatched();
+        resolver.resolveChainedCallsViaConformance();
+        resolver.resolveDeferredThisMemberRefs();
+      }
+
+      const nodes = queries.getAllNodes();
+      const edges = queries.getAllEdges();
+      const durationMs = Date.now() - start;
+      const fileCount = (db.getDb().prepare('SELECT COUNT(*) AS c FROM files').get() as any)?.c ?? 0;
+
+      return {
+        success: result.success,
+        nodes,
+        edges,
+        files: fileCount,
+        errors: result.errors,
+        stats: {
+          filesIndexed: result.filesIndexed,
+          nodesCreated: nodes.length,
+          edgesCreated: edges.length,
+          durationMs,
+        },
+      };
+    } finally {
+      db.close();
+    }
   }
 
   /**

--- a/src/resolution/frameworks/graphql.ts
+++ b/src/resolution/frameworks/graphql.ts
@@ -1,0 +1,327 @@
+/**
+ * GraphQL Framework Resolver
+ *
+ * Handles Strawberry, Graphene, and Ariadne patterns (Python).
+ * Creates route nodes for Query/Mutation/Subscription fields so
+ * CodeGraph's graph traversal connects GraphQL operations to their
+ * downstream service/DB calls.
+ */
+
+import { Node } from '../../types';
+import { FrameworkResolver, UnresolvedRef } from '../types';
+import { stripCommentsForRegex } from '../strip-comments';
+
+type RootKind = 'QUERY' | 'MUTATION' | 'SUBSCRIPTION';
+
+interface TypeBlock {
+  kind: RootKind;
+  className: string;
+  startLine: number;
+  endLine: number;
+}
+
+const RESOLVER_DIRS = ['/graphql/', '/resolvers/', '/schema/', '/api/'];
+const FUNCTION_KINDS = new Set(['function', 'method']);
+
+export const strawberryResolver: FrameworkResolver = {
+  name: 'strawberry-graphql',
+  languages: ['python'],
+
+  detect(context) {
+    for (const f of ['requirements.txt', 'pyproject.toml', 'Pipfile', 'setup.py']) {
+      const c = context.readFile(f);
+      if (c && /\bstrawberry(?:-graphql)?\b/i.test(c)) return true;
+    }
+    const files = context.getAllFiles().filter((f) => /\bgraphql\b/.test(f) && f.endsWith('.py')).slice(0, 20);
+    for (const f of files) {
+      const c = context.readFile(f);
+      if (c && /\bimport\s+strawberry\b|\bfrom\s+strawberry\b/.test(c)) return true;
+    }
+    return false;
+  },
+
+  resolve(ref, context) {
+    if (ref.metadata?.graphqlResolver) {
+      const name = String(ref.metadata.graphqlResolver);
+      const candidates = context.getNodesByName(name);
+      const match = candidates.find((n) => FUNCTION_KINDS.has(n.kind));
+      if (match) {
+        return { original: ref, targetNodeId: match.id, confidence: 0.85, resolvedBy: 'framework' };
+      }
+      const dotted = name.split('.');
+      if (dotted.length > 1) {
+        const funcName = dotted[dotted.length - 1]!;
+        const funcCandidates = context.getNodesByName(funcName);
+        const preferred = funcCandidates.find(
+          (n) => FUNCTION_KINDS.has(n.kind) && RESOLVER_DIRS.some((d) => n.filePath.includes(d))
+        );
+        if (preferred) return { original: ref, targetNodeId: preferred.id, confidence: 0.8, resolvedBy: 'framework' };
+        const any = funcCandidates.find((n) => FUNCTION_KINDS.has(n.kind));
+        if (any) return { original: ref, targetNodeId: any.id, confidence: 0.7, resolvedBy: 'framework' };
+      }
+    }
+    return null;
+  },
+
+  extract(filePath, content) {
+    if (!filePath.endsWith('.py')) return { nodes: [], references: [] };
+    if (!/\bstrawberry\b/.test(content)) return { nodes: [], references: [] };
+
+    const safe = stripCommentsForRegex(content, 'python');
+    const nodes: Node[] = [];
+    const references: UnresolvedRef[] = [];
+    const now = Date.now();
+
+    const rootBlocks = findRootTypeBlocks(safe);
+    if (rootBlocks.length === 0) return { nodes: [], references: [] };
+
+    for (const block of rootBlocks) {
+      extractDecoratedMethods(filePath, safe, block, nodes, references, now);
+      extractFieldAssignments(filePath, safe, block, nodes, references, now);
+    }
+
+    return { nodes, references };
+  },
+};
+
+export const grapheneResolver: FrameworkResolver = {
+  name: 'graphene',
+  languages: ['python'],
+
+  detect(context) {
+    for (const f of ['requirements.txt', 'pyproject.toml', 'Pipfile', 'setup.py']) {
+      const c = context.readFile(f);
+      if (c && /\bgraphene\b/i.test(c)) return true;
+    }
+    return false;
+  },
+
+  resolve() {
+    return null;
+  },
+
+  extract(filePath, content) {
+    if (!filePath.endsWith('.py')) return { nodes: [], references: [] };
+    if (!/\bgraphene\b/.test(content)) return { nodes: [], references: [] };
+
+    const safe = stripCommentsForRegex(content, 'python');
+    const nodes: Node[] = [];
+    const references: UnresolvedRef[] = [];
+    const now = Date.now();
+
+    const classRegex = /^class\s+(\w+)\s*\(\s*(?:graphene\.)?ObjectType\s*\)/gm;
+    let cm: RegExpExecArray | null;
+    while ((cm = classRegex.exec(safe)) !== null) {
+      const className = cm[1]!;
+      const kind = classifyRootType(className);
+      if (!kind) continue;
+
+      const startLine = safe.slice(0, cm.index).split('\n').length;
+      const endLine = findClassEnd(safe, cm.index);
+      const classBody = safe.slice(cm.index, endLineOffset(safe, endLine));
+
+      const resolverRegex = /^\s+(?:async\s+)?def\s+(resolve_(\w+))\s*\(/gm;
+      let rm: RegExpExecArray | null;
+      while ((rm = resolverRegex.exec(classBody)) !== null) {
+        const methodName = rm[1]!;
+        const fieldName = rm[2]!;
+        const line = startLine + classBody.slice(0, rm.index).split('\n').length - 1;
+        const routeNode = makeRouteNode(filePath, line, kind, fieldName, now);
+        nodes.push(routeNode);
+        references.push({
+          fromNodeId: routeNode.id,
+          referenceName: methodName,
+          referenceKind: 'references',
+          line, column: 0, filePath, language: 'python',
+        });
+      }
+    }
+
+    return { nodes, references };
+  },
+};
+
+function findRootTypeBlocks(content: string): TypeBlock[] {
+  const blocks: TypeBlock[] = [];
+  const lines = content.split('\n');
+
+  const classRegex = /^class\s+(\w+)\s*(?:\([^)]*\))?\s*:/;
+  let currentClass: { name: string; startLine: number; indent: number } | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    const classMatch = line.match(classRegex);
+    if (classMatch) {
+      if (currentClass) {
+        finalizeBlock(content, lines, currentClass, i, blocks);
+      }
+      const hasStrawberryType = lookBackForDecorator(lines, i, /@strawberry\.type\b/);
+      if (hasStrawberryType) {
+        currentClass = {
+          name: classMatch[1]!,
+          startLine: i + 1,
+          indent: line.search(/\S/),
+        };
+      } else {
+        currentClass = null;
+      }
+    }
+  }
+  if (currentClass) {
+    finalizeBlock(content, lines, currentClass, lines.length, blocks);
+  }
+
+  return blocks;
+}
+
+function finalizeBlock(
+  _content: string,
+  lines: string[],
+  cls: { name: string; startLine: number; indent: number },
+  nextClassLine: number,
+  blocks: TypeBlock[]
+) {
+  let endLine = nextClassLine;
+  for (let j = nextClassLine - 1; j > cls.startLine; j--) {
+    if (lines[j]!.trim().length > 0) {
+      endLine = j + 1;
+      break;
+    }
+  }
+  const kind = classifyRootType(cls.name);
+  if (kind) {
+    blocks.push({ kind, className: cls.name, startLine: cls.startLine, endLine });
+  }
+}
+
+function classifyRootType(name: string): RootKind | null {
+  const lower = name.toLowerCase();
+  if (lower === 'query' || lower.endsWith('query') || lower.endsWith('queries')) return 'QUERY';
+  if (lower === 'mutation' || lower.endsWith('mutation') || lower.endsWith('mutations')) return 'MUTATION';
+  if (lower === 'subscription' || lower.endsWith('subscription') || lower.endsWith('subscriptions')) return 'SUBSCRIPTION';
+  return null;
+}
+
+function lookBackForDecorator(lines: string[], classLine: number, pattern: RegExp): boolean {
+  for (let i = classLine - 1; i >= Math.max(0, classLine - 5); i--) {
+    const line = lines[i]!.trim();
+    if (line.length === 0) continue;
+    if (pattern.test(line)) return true;
+    if (line.startsWith('@')) continue;
+    break;
+  }
+  return false;
+}
+
+function extractDecoratedMethods(
+  filePath: string,
+  content: string,
+  block: TypeBlock,
+  nodes: Node[],
+  references: UnresolvedRef[],
+  now: number,
+) {
+  const lines = content.split('\n');
+  const blockLines = lines.slice(block.startLine - 1, block.endLine);
+  const blockText = blockLines.join('\n');
+
+  const decoratorRegex = /@strawberry\.field\b[^\n]*/g;
+  let dm: RegExpExecArray | null;
+  while ((dm = decoratorRegex.exec(blockText)) !== null) {
+    const decoratorOffset = dm.index;
+    const tail = blockText.slice(decoratorOffset + dm[0].length);
+    const defMatch = tail.match(/\n\s*(?:async\s+)?def\s+(\w+)/);
+    if (!defMatch) continue;
+
+    const fieldName = defMatch[1]!;
+    if (fieldName === '__init__' || fieldName.startsWith('_')) continue;
+
+    const lineInBlock = blockText.slice(0, decoratorOffset).split('\n').length;
+    const line = block.startLine + lineInBlock - 1;
+
+    const routeNode = makeRouteNode(filePath, line, block.kind, fieldName, now);
+    nodes.push(routeNode);
+    references.push({
+      fromNodeId: routeNode.id,
+      referenceName: fieldName,
+      referenceKind: 'references',
+      line, column: 0, filePath, language: 'python',
+    });
+  }
+}
+
+function extractFieldAssignments(
+  filePath: string,
+  content: string,
+  block: TypeBlock,
+  nodes: Node[],
+  references: UnresolvedRef[],
+  now: number,
+) {
+  const lines = content.split('\n');
+  const blockLines = lines.slice(block.startLine - 1, block.endLine);
+  const blockText = blockLines.join('\n');
+
+  const assignRegex = /(\w+)\s*:[^=\n]*=\s*strawberry\.field\s*\(\s*[^)]*resolver\s*=\s*([\w.]+)/g;
+  let am: RegExpExecArray | null;
+  while ((am = assignRegex.exec(blockText)) !== null) {
+    const fieldName = am[1]!;
+    const resolverRef = am[2]!;
+
+    const lineInBlock = blockText.slice(0, am.index).split('\n').length;
+    const line = block.startLine + lineInBlock - 1;
+
+    const routeNode = makeRouteNode(filePath, line, block.kind, fieldName, now);
+    nodes.push(routeNode);
+
+    const resolverName = resolverRef.split('.').pop()!;
+    references.push({
+      fromNodeId: routeNode.id,
+      referenceName: resolverName,
+      referenceKind: 'references',
+      line, column: 0, filePath, language: 'python',
+      metadata: { graphqlResolver: resolverRef },
+    });
+  }
+}
+
+function makeRouteNode(filePath: string, line: number, kind: RootKind, fieldName: string, now: number): Node {
+  return {
+    id: `route:${filePath}:${line}:${kind}:${fieldName}`,
+    kind: 'route',
+    name: `${kind} ${fieldName}`,
+    qualifiedName: `${filePath}::${kind}:${fieldName}`,
+    filePath,
+    startLine: line,
+    endLine: line,
+    startColumn: 0,
+    endColumn: 0,
+    language: 'python',
+    updatedAt: now,
+  };
+}
+
+function findClassEnd(content: string, classStart: number): number {
+  const lines = content.split('\n');
+  const startLine = content.slice(0, classStart).split('\n').length;
+  const classIndent = lines[startLine - 1]!.search(/\S/);
+  for (let i = startLine; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.trim().length === 0) continue;
+    if (line.search(/\S/) <= classIndent && !/^\s*@/.test(line)) {
+      return i;
+    }
+  }
+  return lines.length;
+}
+
+function endLineOffset(content: string, lineNumber: number): number {
+  let pos = 0;
+  let count = 1;
+  while (count < lineNumber && pos < content.length) {
+    if (content[pos] === '\n') count++;
+    pos++;
+  }
+  const nextNewline = content.indexOf('\n', pos);
+  return nextNewline === -1 ? content.length : nextNewline;
+}

--- a/src/resolution/frameworks/index.ts
+++ b/src/resolution/frameworks/index.ts
@@ -27,6 +27,7 @@ import { swiftObjcBridgeResolver } from './swift-objc';
 import { reactNativeBridgeResolver } from './react-native';
 import { expoModulesResolver } from './expo-modules';
 import { fabricViewResolver } from './fabric';
+import { strawberryResolver, grapheneResolver } from './graphql';
 
 /**
  * All registered framework resolvers
@@ -46,6 +47,8 @@ const FRAMEWORK_RESOLVERS: FrameworkResolver[] = [
   djangoResolver,
   flaskResolver,
   fastapiResolver,
+  strawberryResolver,
+  grapheneResolver,
   // Ruby
   railsResolver,
   // Java
@@ -146,3 +149,4 @@ export { swiftObjcBridgeResolver } from './swift-objc';
 export { reactNativeBridgeResolver } from './react-native';
 export { expoModulesResolver } from './expo-modules';
 export { fabricViewResolver } from './fabric';
+export { strawberryResolver, grapheneResolver } from './graphql';

--- a/src/resolution/index.ts
+++ b/src/resolution/index.ts
@@ -537,6 +537,7 @@ export class ReferenceResolver {
       column: ref.column,
       filePath: ref.filePath || this.getFilePathFromNodeId(ref.fromNodeId),
       language: ref.language || this.getLanguageFromNodeId(ref.fromNodeId),
+      metadata: ref.metadata,
     }));
 
     const total = refs.length;
@@ -818,12 +819,9 @@ export class ReferenceResolver {
         line: ref.original.line,
         column: ref.original.column,
         metadata: {
+          ...(ref.original.metadata ?? {}),
           confidence: ref.confidence,
           resolvedBy: ref.resolvedBy,
-          // Uniform marker for function-as-value edges (#756), regardless of
-          // which strategy resolved them (import vs matchFunctionRef) — lets
-          // tooling label "callback registration" and lets validation diff
-          // exactly the edges this feature added.
           ...(ref.original.referenceKind === 'function_ref' ? { fnRef: true } : {}),
         },
       };

--- a/src/resolution/types.ts
+++ b/src/resolution/types.ts
@@ -26,6 +26,8 @@ export interface UnresolvedRef {
   language: Language;
   /** Possible qualified names it might resolve to */
   candidates?: string[];
+  /** Call-site metadata from extraction */
+  metadata?: Record<string, unknown>;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -313,6 +313,9 @@ export interface UnresolvedReference {
 
   /** Possible qualified names it might resolve to */
   candidates?: string[];
+
+  /** Call-site metadata (receiver, method, literal args) for calls edges */
+  metadata?: Record<string, unknown>;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- **In-memory indexing API** (`indexInMemoryOpen()`) — index a repo and return an `InMemoryGraph` handle for direct SQLite queries without persisting `.codegraph/`
- **Call-site metadata on edges** — `extractCall()` captures receiver text and string-literal arguments, stored in `Edge.metadata`
- **GraphQL framework resolver** — Strawberry (`@strawberry.field`, `field(resolver=...)`) and Graphene (`resolve_*` on ObjectType) detected as `kind: 'route'` nodes; verified on PDA: 2-step chains → 9-step (20 QUERY routes, edges through DataLoaders to DependencyRegistry)

## Test plan
- [x] 119 framework tests pass (9 new GraphQL tests)
- [x] Full test suite: 1614 passed, 3 skipped, 0 failures
- [x] Real-world verification on product-detail-api (Strawberry GraphQL)
- [x] Forge integration: `forge discover --deep` produces full route-flow chains for GraphQL operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpoV4HFP2ggEsvTPVzsdbd