### PR TITLE
chore: bump version to 1.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@colbymchenry/codegraph",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@colbymchenry/codegraph",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colbymchenry/codegraph",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Supercharge AI coding agents with semantic code intelligence — surgical context, fewer tool calls, faster answers. 100% local.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps `package.json` + `package-lock.json` to **1.1.6** to cut a patch release.

The `[Unreleased]` CHANGELOG block (promoted to `[1.1.6]` by the Release workflow) contains:
- Installer prunes old version bundles instead of piling them up (#1074)
- `codegraph index` rebuilds an oversized index without wedging the watchdog (#1067)

Both are bug fixes → patch bump. After this merges, the Release workflow runs against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)