### PR TITLE
fix(login): avoid cmd.exe when opening the login URL on Windows (#1114)

### DIFF
--- a/__tests__/open-browser-security.test.ts
+++ b/__tests__/open-browser-security.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// openBrowser() launches a URL that originates from the device-login server
+// response (verification_uri_complete). On Windows the URL must never be handed
+// to cmd.exe, which re-parses shell metacharacters (& | ^ ") and would allow a
+// malicious/compromised login server to inject commands. See issue #1114.
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+vi.mock('child_process', () => ({ spawn: spawnMock }));
+
+import { openBrowser } from '../src/reasoning/login';
+
+describe('openBrowser — Windows shell-injection hardening (#1114)', () => {
+  const realPlatform = process.platform;
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+    spawnMock.mockReturnValue({ on: vi.fn(), unref: vi.fn() });
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
+  });
+
+  it('does not launch the URL through cmd.exe on Windows', async () => {
+    const url = 'https://app.getcodegraph.com/device?user_code=ABCD-1234&calc';
+
+    await openBrowser(url);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [command, args] = spawnMock.mock.calls[0] as [string, string[]];
+
+    // cmd.exe (and its `start` builtin) re-parse metacharacters, so the launcher
+    // must not be cmd and must not carry cmd's `/c` switch.
+    expect(command.toLowerCase()).not.toContain('cmd');
+    expect(args).not.toContain('/c');
+
+    // The server-supplied URL is passed to the launcher as one intact argument,
+    // never concatenated into a shell command string.
+    expect(args).toContain(url);
+  });
+});

--- a/__tests__/open-browser-security.test.ts
+++ b/__tests__/open-browser-security.test.ts
@@ -38,5 +38,29 @@ describe('openBrowser — Windows shell-injection hardening (#1114)', () => {
     // The server-supplied URL is passed to the launcher as one intact argument,
     // never concatenated into a shell command string.
     expect(args).toContain(url);
+
+    // And never through a shell at all.
+    const options = spawnMock.mock.calls[0][2] as { shell?: boolean } | undefined;
+    expect(options?.shell).toBeFalsy();
+  });
+
+  it.each([
+    ['file:///C:/Windows/System32/calc.exe'],
+    ['\\\\evil.example\\share\\payload.exe'],
+    ['C:\\Windows\\System32\\calc.exe'],
+    ['javascript:alert(1)'],
+  ])('refuses to launch a non-http(s) target: %s', async (target) => {
+    // rundll32 url.dll,FileProtocolHandler (like `open` / `xdg-open`) hands the
+    // string to the OS handler, which happily executes file/UNC paths — so the
+    // server-supplied string must be scheme-checked before launching anything.
+    await openBrowser(target);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('still launches plain http:// URLs', async () => {
+    await openBrowser('http://localhost:8080/device?user_code=ABCD-1234');
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/reasoning/login.ts
+++ b/src/reasoning/login.ts
@@ -77,7 +77,9 @@ export async function pollForToken(deviceCode: string, intervalSec: number, expi
 export async function openBrowser(url: string): Promise<void> {
   const [cmd, args] =
     process.platform === 'darwin' ? ['open', [url]]
-    : process.platform === 'win32' ? ['cmd', ['/c', 'start', '', url]]
+    // Avoid `cmd /c start`: cmd.exe re-parses shell metacharacters (& | ^ ") in the
+    // server-supplied URL. rundll32 receives the URL as a single, opaque argument.
+    : process.platform === 'win32' ? ['rundll32', ['url.dll,FileProtocolHandler', url]]
     : ['xdg-open', [url]];
   try {
     const child = spawn(cmd as string, args as string[], { stdio: 'ignore', detached: true, windowsHide: true });

--- a/src/reasoning/login.ts
+++ b/src/reasoning/login.ts
@@ -75,6 +75,9 @@ export async function pollForToken(deviceCode: string, intervalSec: number, expi
 
 /** Best-effort: open a URL in the default browser. Never throws — the URL is also printed. */
 export async function openBrowser(url: string): Promise<void> {
+  // The OS handlers below (open / rundll32 / xdg-open) execute file and UNC
+  // paths as readily as they open URLs — never hand them a non-http(s) string.
+  if (!/^https?:\/\//i.test(url)) return;
   const [cmd, args] =
     process.platform === 'darwin' ? ['open', [url]]
     // Avoid `cmd /c start`: cmd.exe re-parses shell metacharacters (& | ^ ") in the


### PR DESCRIPTION
Closes #1114.

## Problem

`openBrowser()` (`src/reasoning/login.ts`) launches the device-login verification URL that comes from the login server response (`verification_uri_complete`, where the server base is `CODEGRAPH_LOGIN_URL` / default `app.getcodegraph.com`). On Windows it ran:

```ts
: process.platform === "win32" ? ["cmd", ["/c", "start", "", url]]
```

`cmd.exe` (and its `start` builtin) re-parse shell metacharacters (`&  |  ^  "`). A malicious or compromised login server — or a user tricked into pointing `CODEGRAPH_LOGIN_URL` at an attacker — could return a `verification_uri_complete` such as `https://app.getcodegraph.com/device?...&calc` and get arbitrary commands executed. (`spawn` without `shell: true` does not help here: libuv only quotes args containing whitespace/quotes, so a space-free URL reaches cmd.exe unescaped.) Defense-in-depth (`low`): it needs a hostile server/env, but the browser-open path should never route a server-supplied string through a shell.

## Fix

Two layers:

1. **Launch via `rundll32 url.dll,FileProtocolHandler <url>`** instead of `cmd /c start`. `rundll32` receives the URL as a single opaque `argv` element (Node `spawn` without `shell`), so there is no shell re-parsing. The macOS (`open`) and Linux (`xdg-open`) branches already pass the URL as a lone argument and are unchanged.
2. **`https?://` scheme allowlist** before launching anything. All three OS handlers (`open` / `rundll32,FileProtocolHandler` / `xdg-open`) will happily execute a `file:///...exe`, bare, or UNC (`\\host\share\payload.exe`) path handed to them — swapping the launcher alone doesn't close that, the allowlist does, on every platform.

## Tests

`__tests__/open-browser-security.test.ts`: stubs `process.platform = "win32"`, mocks `child_process.spawn`, and asserts (a) a URL containing `&` is not launched through `cmd`/`/c`, arrives at the launcher as one intact argument, and never with `shell: true`; (b) `file:`/UNC/bare-path/`javascript:` targets are refused (no spawn at all); (c) plain `http://` still launches. Written test-first (fails on the old `cmd` path, passes after the fix). `vitest run` + `tsc --noEmit` green.

## Reachability note (please weigh in)

As of current `main`, `openBrowser` — and all of `src/reasoning/login.ts` — has **no callers**: e5897d0 removed the `codegraph login` / `logout` / `usage` command wiring and left the module orphaned. So on `main` this is hardening dead code (the vulnerable path does ship in already-released versions that had the command). If you'd rather delete `login.ts` outright than patch it, happy to rework this PR into the removal instead.

> I develop on macOS, so I could not exercise the `rundll32` path on a real Windows host. `openBrowser` is best-effort (errors are swallowed), so a Windows regression degrades gracefully rather than breaking login.
