### PR TITLE
fix(resolution): gate the Lua/Luau annotation pattern against method-call self-match (#1124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixes
+
+- Lua and Luau method calls with capitalized names (`obj:Method()` — the standard Roblox convention) now link to the right method. Because Lua's method-call syntax looks identical to a Luau type annotation, a capitalized call like `lg:Log()` was misread as declaring the variable's type, so whenever two or more classes shared a method name (`Init`, `Update`, `Destroy`, …) the call was silently dropped from callers, impact/blast-radius, and flow traces. Lowercase method names were unaffected. Thanks @inth3shadows for the precise root-cause analysis and repro. (#1124)
 
 ## [1.2.0] - 2026-07-02
 

--- a/__tests__/resolution.test.ts
+++ b/__tests__/resolution.test.ts
@@ -1820,6 +1820,47 @@ func main() {
         expect(otherCallers, `${c.lang}: Other callers`).not.toContain(c.callerA);
       });
     }
+
+    // Lua/Luau: a PascalCase method call (`lg:Log()`, the Roblox convention)
+    // is the identical `receiver:Name` shape as a Luau type annotation, so it
+    // self-matched the annotation pattern on the call's own line and inferred
+    // "type = Log" (#1124). Two things are load-bearing in these fixtures:
+    // the declaration sits on an EARLIER line than the call (on one line,
+    // pattern order resolves it — the `.new` pattern wins first), and TWO
+    // classes share the method name (a single class resolves via the
+    // same-name fallback even when inference misfires). Luau's `useLogger`
+    // takes a typed param instead of calling `.new()`, pinning that the
+    // gated pattern still matches a genuine annotation.
+    const pascalMethodCases: Array<{ lang: string; file: string; src: string }> = [
+      { lang: 'Lua', file: 'svc.lua',
+        src: `local Logger = {}\nLogger.__index = Logger\nfunction Logger.new() return setmetatable({}, Logger) end\nfunction Logger:Log() return 1 end\n\nlocal Other = {}\nOther.__index = Other\nfunction Other.new() return setmetatable({}, Other) end\nfunction Other:Log() return 2 end\n\nlocal function useLogger()\n\tlocal lg = Logger.new()\n\treturn lg:Log()\nend\n\nlocal function useOther()\n\tlocal o = Other.new()\n\treturn o:Log()\nend\n\nreturn useLogger, useOther\n` },
+      { lang: 'Luau', file: 'svc.luau',
+        src: `local Logger = {}\nLogger.__index = Logger\nfunction Logger.new() return setmetatable({}, Logger) end\nfunction Logger:Log(): number return 1 end\n\nlocal Other = {}\nOther.__index = Other\nfunction Other.new() return setmetatable({}, Other) end\nfunction Other:Log(): number return 2 end\n\nlocal function useLogger(lg: Logger): number\n\treturn lg:Log()\nend\n\nlocal function useOther(): number\n\tlocal o = Other.new()\n\treturn o:Log()\nend\n\nreturn useLogger, useOther\n` },
+    ];
+
+    for (const c of pascalMethodCases) {
+      it(`resolves a PascalCase method call without self-matching the annotation pattern — ${c.lang} (#1124)`, async () => {
+        fs.writeFileSync(path.join(tempDir, c.file), c.src);
+        cg = await CodeGraph.init(tempDir, { index: true });
+        cg.resolveReferences();
+
+        const methods = cg.getNodesByKind('method').filter((n) => n.name === 'Log');
+        expect(methods.length, `${c.lang}: both Log methods indexed`).toBe(2);
+
+        const loggerLog = methods.find((m) => /Logger/.test(m.qualifiedName ?? ''));
+        const otherLog = methods.find((m) => /Other/.test(m.qualifiedName ?? ''));
+        expect(loggerLog, `${c.lang}: Logger's Log`).toBeDefined();
+        expect(otherLog, `${c.lang}: Other's Log`).toBeDefined();
+
+        const loggerCallers = cg.getCallers(loggerLog!.id).map((x) => x.node.name);
+        const otherCallers = cg.getCallers(otherLog!.id).map((x) => x.node.name);
+
+        expect(loggerCallers, `${c.lang}: Logger callers`).toContain('useLogger');
+        expect(loggerCallers, `${c.lang}: Logger callers`).not.toContain('useOther');
+        expect(otherCallers, `${c.lang}: Other callers`).toContain('useOther');
+        expect(otherCallers, `${c.lang}: Other callers`).not.toContain('useLogger');
+      });
+    }
   });
 
   describe('Name Matcher: kind bias for new ref kinds', () => {

--- a/src/resolution/name-matcher.ts
+++ b/src/resolution/name-matcher.ts
@@ -1148,7 +1148,17 @@ function localReceiverTypePatterns(language: Language, r: string): RegExp[] {
       return [
         new RegExp(`\\b${r}\\b\\s*=\\s*([A-Z][\\w]*)\\.new\\b`), // local lg = Logger.new()
         new RegExp(`\\b${r}\\b\\s*=\\s*([A-Z][\\w]*)\\s*\\(`), // local lg = Logger(...)  (callable table)
-        new RegExp(`\\b${r}\\b\\s*:\\s*([A-Z][\\w.]*)`), // Luau: local lg: Logger  / typed param
+        // Luau annotation (`local lg: Logger`) / typed param — but Lua's
+        // method-call syntax is the IDENTICAL `receiver:Name` shape, and the
+        // backward scan starts on the call's own line, so without a gate any
+        // PascalCase method call (`lg:Log()`, the Roblox convention)
+        // self-matches as "type = Log" before the scan reaches the real
+        // declaration (#1124). The lookahead rejects a capture followed by
+        // any of Lua's three call forms — `(args)`, `"s"`/`'s'`/`[[s]]`,
+        // `{t}` — and its leading `[\w.]` alternative stops backtracking from
+        // shrinking the capture to dodge the gate (`lg:Log()` would otherwise
+        // still match, as `Lo`).
+        new RegExp(`\\b${r}\\b\\s*:\\s*([A-Z][\\w.]*)(?![\\w.]|\\s*[({"'\\[])`), // local lg: Logger  / typed param
       ];
     case 'r':
       return [


### PR DESCRIPTION
Fixes #1124

In Lua/Luau, method-call syntax (`lg:Log()`) is byte-identical to the Luau type-annotation shape (`lg: Logger`), and `inferLocalReceiverType` scans backward starting on the call's **own line** — so any PascalCase method call (the Roblox convention) self-matched the annotation pattern and inferred "type = `Log`" before the scan ever reached the real declaration. `resolveMethodOnType` then failed on the bogus type, and with 2+ same-named methods the fallback was ambiguous: the `calls` edge silently vanished. `Init`/`Update`/`Destroy` collisions are near-universal in real Luau code, so this hit essentially any real Roblox-convention codebase.

## Fix

Gate the annotation pattern with a lookahead that rejects a capture followed by any of Lua's three call forms — `(args)`, `"s"`/`'s'`/`[[s]]`, `{t}`:

```ts
new RegExp(`\\b${r}\\b\\s*:\\s*([A-Z][\\w.]*)(?![\\w.]|\\s*[({"'\\[])`)
```

Two deliberate choices:

- **The leading `[\w.]` lookahead alternative is load-bearing.** A naive `(?!\s*\()` gate is silently defeated by regex backtracking — the capture shrinks from `Log` to `Lo` and the lookahead passes (verified by probe). The `[\w.]` alternative forbids the capture from ending mid-identifier, so no shrunken match exists.
- **Gated, not dropped, and the `lua|luau` case stays shared.** The annotation pattern is the only type source for Luau typed params (`function use(lg: Logger)`) and annotated locals whose initializer isn't `T.new()` — dropping it would regress the #1125 typed-param coverage for the family. Keeping the case shared preserves inference in `.lua` files that carry Luau annotations (older rojo setups).

## Why the existing #1112 tests missed it

They use lowercase `lg:log()` (never trips the `[A-Z]` capture) with a single class (which resolves via the same-name fallback even when inference misfires). The new regression tests pin the two-ambiguous-classes PascalCase case for both `.lua` and `.luau`, with the declaration on an earlier line than the call (a same-line declaration is saved by pattern order, so multi-line is the shape that breaks), plus a Luau typed-param caller proving the gated pattern still matches a genuine annotation.

## Validation

- Issue's exact repro against the built dist: pre-fix both `Logger::Log` and `Other::Log` had **0 callers**; post-fix `useLogger` → `Logger::Log`, `useOther` → `Other::Log` (2/2), lowercase control unchanged.
- 10-shape pattern probe: all Lua call sugars rejected (incl. `lg:Log ()`, `lg:Log"msg"`, `lg:Log{x}`, `lg:Log[[s]]`); annotations with initializers, typed params, and dotted module types (`Types.Logger`) still captured.
- Full suite: 119 files, 1932 passed, 4 skipped, 0 failures.
- R and Pascal (added alongside in #1112) don't share the collision — their patterns require `<-`/`=`/`:=` shapes a call site never has (confirmed, matching the reporter's analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)