### PR TITLE
fix(prompt-hook): record high-tier gate telemetry only when context was actually injected (#1143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### New Features
 
 - The Claude Code context hook now recognizes prompts that describe code in plain words — in any language — by checking the prompt's words against the symbol names actually in your project's index. Asking about "the state machine des commandes" finds `OrderStateMachine` with no keyword involved. Confidence decides how much gets injected: structural questions and prompts naming a real symbol still get full context up front; a plain-words match gets a short pointer to the matching symbols so the agent queries them itself; everything else stays silent, exactly as before.
-- Anonymous usage telemetry now counts how often the context hook injected context, offered a hint, or stayed silent — fixed counter names only; the prompt's content is never stored or sent. This makes the hook's accuracy measurable instead of guessed.
+- Anonymous usage telemetry now counts how often the context hook injected context, offered a hint, or stayed silent — fixed counter names only; the prompt's content is never stored or sent. This makes the hook's accuracy measurable instead of guessed. The counters record what actually happened, not what was attempted: a lookup that errors or comes back empty counts as a distinct silent outcome, never as delivered context (#1143, thanks @inth3shadows).
 
 ### Fixes
 

--- a/docs/design/telemetry.md
+++ b/docs/design/telemetry.md
@@ -75,10 +75,16 @@ Event types:
   The prompt hook additionally rolls up its gate DECISION as `cli_command`
   counters named `prompt-hook-gate-<outcome>`, outcome ∈ `high-keyword` /
   `high-token` / `medium-segment` / `nudge-projects` / `noop-shape` /
-  `noop-no-index` / `noop-unverified` — decision names only, never prompt
-  content. This is the gate's measured recall/precision funnel: a rising
-  `noop-*` share against the `high`/`medium` tiers is the signal that the
-  gate (keyword table or segment matching) is missing real questions.
+  `noop-no-index` / `noop-unverified` / `noop-explore-keyword` /
+  `noop-explore-token` / `noop-vocab-empty` — decision names only, never
+  prompt content. This is the gate's measured recall/precision funnel: a
+  rising `noop-*` share against the `high`/`medium` tiers is the signal that
+  the gate (keyword table or segment matching) is missing real questions.
+  A `high-*` outcome means context was actually injected — a gate decision
+  whose `codegraph_explore` errored or returned nothing records
+  `noop-explore-<trigger>` instead (#1143), and a MEDIUM-eligible prompt
+  hitting a not-yet-backfilled segment vocabulary records `noop-vocab-empty`
+  rather than polluting `noop-unverified` (#1142).
 - **`uninstall`** — one per `uninstall`/`uninit` run (churn signal). Props: `targets`.
 
 Volume math: rollups mean monthly events ≈ active machines × active days × distinct

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -1141,8 +1141,14 @@ program
               process.stdout.write(
                 `<codegraph_context note="Structural context from CodeGraph for this prompt — treat returned source as already read; ${more}.">\n${body}${others}\n</codegraph_context>\n`,
               );
+              gate(keyworded ? 'high-keyword' : 'high-token');
+            } else {
+              // A high-* outcome must mean context was actually delivered —
+              // the funnel's noop-vs-high split is how gate recall is
+              // measured (#1143). An explore error or empty result is a
+              // delivery failure, not a gate success.
+              gate(keyworded ? 'noop-explore-keyword' : 'noop-explore-token');
             }
-            gate(keyworded ? 'high-keyword' : 'high-token');
             return;
           }
 


### PR DESCRIPTION
## Summary

Fixes #1143. The `gate('high-keyword'/'high-token')` call sat one level outside the `if (!result.isError && text.trim())` injection guard, so a silent `codegraph_explore` failure (error or empty result) was recorded as a successful HIGH-tier fire. Per `docs/design/telemetry.md`, the gate counters are the measured recall/precision funnel — the data that decides whether the #1136 gate design survives — so a delivery failure inflating the high tiers corrupts exactly the signal the telemetry exists to produce.

## What changed

- The high-tier gate call moved inside the success branch; the failure branch records `noop-explore-keyword` / `noop-explore-token`, preserving the keyword-vs-token trigger split (an explore failing on keyword-gated prompts points at explore; on token-verified prompts it may point at verification looseness).
- `docs/design/telemetry.md`'s outcome enum updated. It also pre-documents `noop-vocab-empty`, which the #1142 fix (next PR) introduces — one coherent edit to the enum paragraph instead of two conflicting ones.

## Testing

Build clean; hook + telemetry suites green. The gate call is inside the commander action and its outcomes are try/catch-wrapped fire-and-forget counters, so this is pinned by review rather than a spawned-CLI telemetry harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)