### PR TITLE
Detect export-macro class/struct .h headers as C++, not C (#1159)

### DIFF
--- a/__tests__/extraction.test.ts
+++ b/__tests__/extraction.test.ts
@@ -102,6 +102,42 @@ describe('Language Detection', () => {
     expect(detectLanguage('stdio.h', '#ifndef STDIO_H\nvoid printf();\n#endif\n')).toBe('c');
   });
 
+  it('should detect a .h with an export-macro class/struct header as C++ (#1159)', () => {
+    // `class MODULE_API Foo : Base` — the ubiquitous Unreal Engine / library
+    // export-macro form. The macro between `class` and the name previously
+    // defeated the C++ signal, so the header fell back to C and the class was
+    // dropped. Case is stripped of any other C++ tell (no `public:`) so only the
+    // class/struct signal itself is under test.
+    expect(detectLanguage('Foo.h', 'class ENGINE_API Foo : public Bar\n{\n    void Tick();\n};\n')).toBe('cpp');
+    expect(detectLanguage('Foo.h', 'class CORE_API Widget\n{\n    void draw();\n};\n')).toBe('cpp');
+    expect(detectLanguage('Widget.h', 'struct MODULE_API Widget : Base\n{\n    int n;\n};\n')).toBe('cpp');
+    // Regressions guards: the plain forms must keep working, and a plain C
+    // `struct X { … }` (valid C, base-clause absent) must stay C.
+    expect(detectLanguage('Foo.h', 'class Foo : public Bar\n{\n};\n')).toBe('cpp');
+    expect(detectLanguage('Point.h', 'struct Point {\n    int x;\n    int y;\n};\n')).toBe('c');
+  });
+
+  it('recovers the class from an export-macro-only .h header end-to-end (#1159)', () => {
+    // The issue's impact: with detection fixed, the header now reaches the C++
+    // grammar + #1061 macro-blanking, so the class, its member, and its base
+    // edge are all recovered. The header carries NO other C++ tell (no `public:`,
+    // no `#define`) — the macro class is the sole signal, which is exactly the
+    // case that regressed to C before.
+    const header = `class ENGINE_API Foo : public Bar
+{
+    void Tick();
+};
+`;
+    expect(detectLanguage('Foo.h', header)).toBe('cpp');
+    const result = extractFromSource('Foo.h', header);
+    expect(result.nodes.find((n) => n.name === 'Foo')?.kind).toBe('class');
+    expect(
+      result.unresolvedReferences.find(
+        (r) => r.referenceKind === 'extends' && r.referenceName === 'Bar'
+      )
+    ).toBeTruthy();
+  });
+
   it('should detect Metal shader files as C++ (#1121)', () => {
     expect(detectLanguage('Shaders.metal')).toBe('cpp');
     expect(isSourceFile('Renderer/Shaders.metal')).toBe(true);

--- a/src/extraction/grammars.ts
+++ b/src/extraction/grammars.ts
@@ -373,10 +373,19 @@ export function detectLanguage(filePath: string, source?: string, overrides?: Re
 /**
  * Heuristic: does a .h file contain C++ constructs?
  * Checks the first ~8KB for patterns that are unique to C++ and never valid C.
+ *
+ * The `class`/`struct` signals tolerate an optional all-caps export/visibility
+ * macro between the keyword and the type name — the ubiquitous Unreal Engine /
+ * library form `class ENGINE_API Foo : Base` (#1159). Without this, such a
+ * header (when it carries no other C++ tell like `public:` in the first 8KB)
+ * falls back to the C grammar and its whole class definition is dropped.
+ * `struct` is matched only in its base-clause form (`struct X : Base`) — that
+ * `:` is C++-exclusive, whereas a plain `struct X { … }` is valid C and must
+ * stay `c`.
  */
 function looksLikeCpp(source: string): boolean {
   const sample = source.substring(0, 8192);
-  return /\bnamespace\b|\bclass\s+\w+\s*[:{]|\btemplate\s*<|\b(?:public|private|protected)\s*:|\bvirtual\b|\busing\s+(?:namespace\b|\w+\s*=)/.test(sample);
+  return /\bnamespace\b|\bclass\s+(?:[A-Z_][A-Z0-9_]*\s+)?\w+\s*[:{]|\bstruct\s+(?:[A-Z_][A-Z0-9_]*\s+)?\w+\s*:|\btemplate\s*<|\b(?:public|private|protected)\s*:|\bvirtual\b|\busing\s+(?:namespace\b|\w+\s*=)/.test(sample);
 }
 
 /**


### PR DESCRIPTION
Fixes #1159.

## Problem

A `.h` whose only C++ tell is an all-caps export/visibility macro between the keyword and the type name — the ubiquitous Unreal Engine / library form `class ENGINE_API Foo : public Bar` — was classified as **C** by `looksLikeCpp`. Parsed with the C grammar, the whole class definition (node, members, base clause) never materialized in the graph, breaking type-hierarchy, callers, and blast-radius queries through that type.

This sits one step *upstream* of the existing #1061 export-macro blanking: that recovery never runs, because detection has already routed the header to C.

Note the issue's minimal repro also has `public:`, which `looksLikeCpp` already catches via another branch — so the truly-failing case is a macro class carrying no other C++ tell in the first 8 KB. Confirmed empirically before/after:

```
class ENGINE_API Foo : public Bar { void Tick(); };   // before: c   after: cpp
struct CORE_API Widget : Base { int n; };             // before: c   after: cpp
struct Point { int x; int y; };                        // before: c   after: c  (guard)
```

## Fix

`looksLikeCpp`'s `class`/`struct` signal now tolerates an optional all-caps macro between the keyword and the name. `struct` is matched only in its base-clause form (`struct X : Base`) — that `:` is C++-exclusive, whereas a plain `struct X { … }` is valid C and must stay `c`.

## Tests

Added to `extraction.test.ts`: detection for macro class (with/without base) and macro struct; regression guards (plain `class:base` stays cpp, plain C `struct{}` stays c); and an **end-to-end** case proving a macro-only header now recovers the class node and its `extends` edge (detection + #1061 blanking together).

Full suite green (124 files, 2121 passed).
