### PR TITLE
fix(extraction): tolerate whitespace in MyBatis close tags and fix qualified include refid

### DIFF
--- a/__tests__/mybatis-extractor-robustness.test.ts
+++ b/__tests__/mybatis-extractor-robustness.test.ts
@@ -216,3 +216,56 @@ describe('iBatis 2 <sqlMap> coverage (#1182 gap 3)', () => {
     expect(methodNodes(xml, 'SqlMapConfig.xml')).toHaveLength(0);
   });
 });
+
+describe('MyBatis extractor — whitespace in close tags', () => {
+  it('does not swallow the next statement when a close tag has trailing space', () => {
+    const xml =
+      '<mapper namespace="com.example.FooMapper">' +
+      '<select id="a">SELECT 1</select >' +
+      '<select id="b">SELECT 2</select>' +
+      '</mapper>';
+    expect(methodNames(xml).sort()).toEqual([
+      'com.example.FooMapper::a',
+      'com.example.FooMapper::b',
+    ]);
+  });
+
+  it('still resolves the include after a spaced close tag', () => {
+    const xml =
+      '<mapper namespace="com.example.FooMapper">' +
+      '<sql id="cols">id</sql>' +
+      '<select id="a">SELECT <include refid="cols"/> FROM t</select >' +
+      '</mapper>';
+    const refs = extractFromSource('FooMapper.xml', xml).unresolvedReferences.map(
+      (r) => r.referenceName
+    );
+    expect(refs).toContain('com.example.FooMapper::cols');
+  });
+});
+
+describe('MyBatis extractor — qualified include refid', () => {
+  it('resolves a cross-mapper refid whose namespace has multiple dots', () => {
+    const xml =
+      '<mapper namespace="com.example.M">' +
+      '<sql id="base">id, name</sql>' +
+      '<select id="getAll">SELECT <include refid="com.example.M.base"/> FROM t</select>' +
+      '</mapper>';
+    const res = extractFromSource('M.xml', xml);
+    const fragment = res.nodes.find((n) => n.qualifiedName.endsWith('::base'));
+    const refs = res.unresolvedReferences.map((r) => r.referenceName);
+    expect(fragment?.qualifiedName).toBe('com.example.M::base');
+    expect(refs).toContain('com.example.M::base');
+  });
+
+  it('still resolves a same-namespace bare refid (regression guard)', () => {
+    const xml =
+      '<mapper namespace="com.example.M">' +
+      '<sql id="base">id</sql>' +
+      '<select id="getAll">SELECT <include refid="base"/> FROM t</select>' +
+      '</mapper>';
+    const refs = extractFromSource('M.xml', xml).unresolvedReferences.map(
+      (r) => r.referenceName
+    );
+    expect(refs).toContain('com.example.M::base');
+  });
+});

--- a/src/extraction/mybatis-extractor.ts
+++ b/src/extraction/mybatis-extractor.ts
@@ -185,7 +185,7 @@ export class MyBatisExtractor {
       dialect === 'ibatis'
         ? 'select|insert|update|delete|sql|statement|procedure'
         : 'select|insert|update|delete|sql';
-    const stmtRegex = new RegExp(`<(${verbs})\\b([^>]*)>([\\s\\S]*?)</\\1>`, 'g');
+    const stmtRegex = new RegExp(`<(${verbs})\\b([^>]*)>([\\s\\S]*?)</\\1\\s*>`, 'g');
     let m: RegExpExecArray | null;
     while ((m = stmtRegex.exec(body)) !== null) {
       const elemType = m[1]!;
@@ -199,6 +199,7 @@ export class MyBatisExtractor {
       if (!idMatch) continue;
       const id = idMatch[2]!;
       const absoluteIndex = bodyStart + m.index;
+      const openTagLen = elemType.length + attrs.length + 2;
       const startLine = this.getLineNumber(absoluteIndex);
       const endLine = this.getLineNumber(absoluteIndex + m[0].length);
       const { qualifiedName: qualified, name } = this.qualifyStatement(namespace, id);
@@ -236,12 +237,14 @@ export class MyBatisExtractor {
       let inc: RegExpExecArray | null;
       while ((inc = includeRegex.exec(elemBody)) !== null) {
         const refid = inc[2]!;
-        const refQualified = refid.includes('.')
-          ? refid.replace(/\./g, '::')
-          : namespace
-            ? `${namespace}::${refid}`
-            : refid;
-        const includeOffset = absoluteIndex + (m[0].length - m[3]!.length - `</${elemType}>`.length) + inc.index;
+        const dot = refid.lastIndexOf('.');
+        const refQualified =
+          dot >= 0
+            ? `${refid.slice(0, dot)}::${refid.slice(dot + 1)}`
+            : namespace
+              ? `${namespace}::${refid}`
+              : refid;
+        const includeOffset = absoluteIndex + openTagLen + inc.index;
         const line = this.getLineNumber(includeOffset);
         this.unresolvedReferences.push({
           fromNodeId: nodeId,


### PR DESCRIPTION
## Summary

Fixes two bugs in the MyBatis/iBatis mapper extractor (`src/extraction/mybatis-extractor.ts`), both reported and diagnosed in #1209:

- **Whitespace in close tags** — a close tag with trailing whitespace (`</select >`, legal XML) was missed by the statement regex. The non-greedy body overshot to the next real close tag, silently swallowing the statement in between. Fixed by adding `\s*` before `>` in the close-tag pattern.
- **Qualified include refid** — a fully-qualified `<include refid="com.example.M.base">` had every dot replaced with `::`, producing `com::example::M::base` which never matched the fragment node's `qualifiedName` (`com.example.M::base`). Fixed by splitting on the last dot only, consistent with `qualifyStatement`'s own logic.

Also fixes the include-offset calculation to derive from the opening tag length rather than subtracting the close tag, so it stays correct when the close tag carries trailing whitespace.

Closes #1209

## Test plan

- [x] Added 4 new test cases in `mybatis-extractor-robustness.test.ts`:
  - Close tag with trailing space does not swallow the next statement
  - `<include>` still resolves after a spaced close tag
  - Cross-mapper refid with multi-dot namespace resolves correctly
  - Bare refid regression guard (same-namespace, no dots)
- [x] All 21 existing + new tests pass (`npx vitest run __tests__/mybatis-extractor-robustness.test.ts`)