### PR TITLE
feat(extraction): make MAX_FILE_SIZE configurable via CODEGRAPH_MAX_FILE_SIZE env var

### DIFF
--- a/__tests__/extraction.test.ts
+++ b/__tests__/extraction.test.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { CodeGraph } from '../src';
-import { extractFromSource, scanDirectory, buildDefaultIgnore, discoverEmbeddedRepoRoots, buildScopeIgnore } from '../src/extraction';
+import { extractFromSource, scanDirectory, buildDefaultIgnore, discoverEmbeddedRepoRoots, buildScopeIgnore, getMaxFileSize } from '../src/extraction';
 import { detectLanguage, isLanguageSupported, getSupportedLanguages, initGrammars, loadAllGrammars, isSourceFile } from '../src/extraction/grammars';
 import { stripCppTemplateArgs, blankCppExportMacros, blankCppInlineMacros, blankMetalAttributes, blankCudaConstructs, blankCppAnnotationMacroCalls, blankCppApiPrefixMacros, blankCppInlineAnnotationMacros, recoverMangledCppName } from '../src/extraction/languages/c-cpp';
 import { normalizePath } from '../src/utils';
@@ -10937,5 +10937,34 @@ import DataStore from '../data/DataStore';
       expect(imports).toContain('../model/TodoItem');
       expect(imports).toContain('../data/DataStore');
     });
+  });
+});
+
+describe('CODEGRAPH_MAX_FILE_SIZE env var (#1016)', () => {
+  const originalEnv = process.env.CODEGRAPH_MAX_FILE_SIZE;
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.CODEGRAPH_MAX_FILE_SIZE;
+    else process.env.CODEGRAPH_MAX_FILE_SIZE = originalEnv;
+  });
+
+  it('returns 1 MB default when env var is not set', () => {
+    delete process.env.CODEGRAPH_MAX_FILE_SIZE;
+    expect(getMaxFileSize()).toBe(1024 * 1024);
+  });
+
+  it('returns custom value when env var is a valid positive integer', () => {
+    process.env.CODEGRAPH_MAX_FILE_SIZE = '5242880';
+    expect(getMaxFileSize()).toBe(5242880);
+  });
+
+  it('falls back to default for invalid values', () => {
+    process.env.CODEGRAPH_MAX_FILE_SIZE = 'notanumber';
+    expect(getMaxFileSize()).toBe(1024 * 1024);
+
+    process.env.CODEGRAPH_MAX_FILE_SIZE = '-1';
+    expect(getMaxFileSize()).toBe(1024 * 1024);
+
+    process.env.CODEGRAPH_MAX_FILE_SIZE = '0';
+    expect(getMaxFileSize()).toBe(1024 * 1024);
   });
 });

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -120,9 +120,18 @@ export function hashContent(content: string): string {
 /**
  * Skip files larger than this (bytes). Generated bundles, minified JS, and
  * vendored blobs blow the WASM heap and the worker-recycle budget for no useful
- * symbols. 1 MB covers essentially all hand-written source.
+ * symbols. 1 MB covers essentially all hand-written source. Override via
+ * CODEGRAPH_MAX_FILE_SIZE (bytes) for projects with legitimate large source files.
  */
-const MAX_FILE_SIZE = 1024 * 1024;
+export function getMaxFileSize(): number {
+  const envVal = process.env.CODEGRAPH_MAX_FILE_SIZE;
+  if (envVal !== undefined) {
+    const parsed = parseInt(envVal, 10);
+    if (parsed > 0 && !isNaN(parsed)) return parsed;
+  }
+  return 1024 * 1024;
+}
+const MAX_FILE_SIZE = getMaxFileSize();
 
 /**
  * Directory names that are dependency, build, cache, or tooling output across the


### PR DESCRIPTION
## Summary

Projects with legitimate large source files (1–5 MB hand-written code, not minified bundles or vendored blobs) are silently skipped during indexing due to the hardcoded 1 MB file size limit. This leaves gaps in the function graph.

This PR makes the limit configurable via the `CODEGRAPH_MAX_FILE_SIZE` environment variable (value in bytes), following the existing pattern of `CODEGRAPH_*` env vars for runtime configuration:

```bash
CODEGRAPH_MAX_FILE_SIZE=5242880 codegraph index   # 5 MB limit
```

The 1 MB default is **unchanged** — zero behavior difference for users who don't set the variable.

- Invalid values (non-numeric, zero, negative) silently fall back to the 1 MB default
- The `size_exceeded` warning message already includes the effective limit, so users can see the configured value
- The exported `getMaxFileSize()` function enables testing and future use by `codegraph status`

Closes #1016

## Test plan

- [x] 3 new tests in `extraction.test.ts`:
  - Default 1 MB when env var is not set
  - Custom value when env var is a valid positive integer
  - Fallback to default for invalid values (non-numeric, negative, zero)
- [x] All existing extraction tests pass (zero regressions)