### PR TITLE
fix(upgrade): stop npm installs self-shadowing on upgrade; verify the resolved version after every upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
+- `codegraph upgrade` on an npm install now upgrades through npm again instead of quietly creating a second copy that never wins the PATH race — previously `codegraph --version` kept reporting the old version forever, no matter how many times you upgraded. (#1238)
+- After every upgrade, CodeGraph now checks that the `codegraph` command your terminal resolves actually serves the freshly installed version — confirming you don't need a new terminal, or telling you exactly which stale install is shadowing the new one. (#1071)
 - The safety watchdog no longer kills a healthy index on severely degraded storage. It used to judge liveness purely by the event loop, so one long database write on a struggling disk looked identical to a hung process and could get a valid, in-progress index terminated. During `codegraph index`/`codegraph init` the watchdog now also checks whether the index files on disk are advancing before it acts: slow-but-progressing work is left alone (bounded by a hard cap), while a genuinely hung process is still killed exactly as fast as before. (#1231)
 
 ## [1.4.0] - 2026-07-10

--- a/__tests__/upgrade.test.ts
+++ b/__tests__/upgrade.test.ts
@@ -13,6 +13,7 @@ import {
   parseLatestTagFromLocation,
   reindexAdvisory,
   runUpgrade,
+  verifyResolvedVersion,
   buildWindowsUpgradeScript,
   NPM_PACKAGE,
   type InstallMethod,
@@ -86,6 +87,41 @@ describe('detectInstallMethod', () => {
   it('detects an npx run from the _npx cache', () => {
     const filename = '/home/u/.npm/_npx/abc123/node_modules/@colbymchenry/codegraph/dist/bin/codegraph.js';
     const m = detectInstallMethod({ filename, platform: 'linux', cwd: '/home/u', exists: () => false });
+    expect(m).toEqual({ kind: 'npx' });
+  });
+
+  // The npm thin-installer's per-platform package IS a complete bundle
+  // (vendored node + bin/ launcher) sitting inside node_modules. The layout
+  // sniff must not win over the node_modules path check, or `upgrade` curls
+  // install.sh into ~/.codegraph — a second install that loses the PATH race
+  // to npm's shim, so `codegraph -v` stays on the old version forever.
+  it('detects the npm thin-installer platform package as npm, not bundle', () => {
+    const root = '/usr/local/lib/node_modules/@colbymchenry/codegraph/node_modules/@colbymchenry/codegraph-linux-x64';
+    const filename = `${root}/lib/dist/bin/codegraph.js`;
+    const present = new Set([`${root}/node`, `${root}/bin/codegraph`]);
+    const m = detectInstallMethod({
+      filename,
+      platform: 'linux',
+      cwd: '/home/u/project',
+      exists: bundleExists(present),
+    });
+    expect(m).toEqual({ kind: 'npm', scope: 'global' });
+  });
+
+  it('detects a project-local thin-installer platform package as npm local', () => {
+    const cwd = '/home/u/project';
+    const root = `${cwd}/node_modules/@colbymchenry/codegraph/node_modules/@colbymchenry/codegraph-darwin-arm64`;
+    const filename = `${root}/lib/dist/bin/codegraph.js`;
+    const present = new Set([`${root}/node`, `${root}/bin/codegraph`]);
+    const m = detectInstallMethod({ filename, platform: 'darwin', cwd, exists: bundleExists(present) });
+    expect(m).toEqual({ kind: 'npm', scope: 'local' });
+  });
+
+  it('still detects an npx run when the cached platform package has the bundle layout', () => {
+    const root = '/home/u/.npm/_npx/abc123/node_modules/@colbymchenry/codegraph/node_modules/@colbymchenry/codegraph-linux-x64';
+    const filename = `${root}/lib/dist/bin/codegraph.js`;
+    const present = new Set([`${root}/node`, `${root}/bin/codegraph`]);
+    const m = detectInstallMethod({ filename, platform: 'linux', cwd: '/home/u', exists: bundleExists(present) });
     expect(m).toEqual({ kind: 'npx' });
   });
 
@@ -191,6 +227,7 @@ describe('version helpers', () => {
 
 interface Calls {
   runs: Array<{ cmd: string; args: string[]; env?: NodeJS.ProcessEnv }>;
+  captures: Array<{ cmd: string; args: string[] }>;
   logs: string[];
   errors: string[];
 }
@@ -199,7 +236,7 @@ function makeDeps(
   overrides: Partial<UpgradeDeps> & { method: InstallMethod; currentVersion: string },
   runExit = 0
 ): { deps: UpgradeDeps; calls: Calls } {
-  const calls: Calls = { runs: [], logs: [], errors: [] };
+  const calls: Calls = { runs: [], captures: [], logs: [], errors: [] };
   const deps: UpgradeDeps = {
     currentVersion: overrides.currentVersion,
     method: overrides.method,
@@ -207,6 +244,12 @@ function makeDeps(
     run: (cmd, args, env) => {
       calls.runs.push({ cmd, args, env });
       return runExit;
+    },
+    // Default probe: spawn fails → 'inconclusive'. Tests that exercise the
+    // post-upgrade version check override this.
+    capture: (cmd, args) => {
+      calls.captures.push({ cmd, args });
+      return overrides.capture ? overrides.capture(cmd, args) : null;
     },
     hasCommand: overrides.hasCommand ?? ((c) => c === 'curl'),
     log: (m) => calls.logs.push(m),
@@ -362,6 +405,109 @@ describe('runUpgrade', () => {
     expect(code).toBe(0);
     expect(calls.runs).toHaveLength(0);
     expect(calls.logs.join('\n')).toMatch(/git pull/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Post-upgrade version probe — does the PATH-resolved `codegraph` serve the
+// version we just installed, in THIS terminal?
+// ---------------------------------------------------------------------------
+
+describe('post-upgrade version probe', () => {
+  const npmGlobal = { method: { kind: 'npm', scope: 'global' } as InstallMethod, currentVersion: '0.9.8' };
+
+  it('match: confirms the same terminal already serves the new version', async () => {
+    const { deps, calls } = makeDeps({
+      ...npmGlobal,
+      hasCommand: (c) => c === 'codegraph',
+      capture: () => ({ code: 0, stdout: '0.9.9\n' }),
+    });
+    const code = await runUpgrade({}, deps);
+    expect(code).toBe(0);
+    expect(calls.captures).toEqual([{ cmd: 'codegraph', args: ['--version'] }]);
+    const out = calls.logs.join('\n');
+    expect(out).toMatch(/now reports v0\.9\.9/);
+    expect(out).not.toMatch(/Open a new terminal/);
+  });
+
+  it('mismatch: warns that a shadowing install is still serving the old version', async () => {
+    const { deps, calls } = makeDeps({
+      ...npmGlobal,
+      hasCommand: (c) => c === 'codegraph',
+      capture: () => ({ code: 0, stdout: '0.9.8\n' }),
+    });
+    const code = await runUpgrade({}, deps);
+    expect(code).toBe(0); // the upgrade itself succeeded — warn, don't fail
+    const out = calls.logs.join('\n');
+    expect(out).toMatch(/still reports an older version/);
+    expect(out).toMatch(/shadowing/);
+    expect(out).toMatch(/which -a codegraph/);
+  });
+
+  it('inconclusive: falls back to the soft new-terminal hint when codegraph is not on PATH', async () => {
+    const { deps, calls } = makeDeps(npmGlobal); // hasCommand resolves only curl
+    const code = await runUpgrade({}, deps);
+    expect(code).toBe(0);
+    expect(calls.captures).toHaveLength(0);
+    expect(calls.logs.join('\n')).toMatch(/Open a new terminal/);
+  });
+
+  it('inconclusive: a failing or unparsable probe never warns about shadowing', async () => {
+    const { deps, calls } = makeDeps({
+      ...npmGlobal,
+      hasCommand: (c) => c === 'codegraph',
+      capture: () => ({ code: 0, stdout: 'something went wrong\n' }),
+    });
+    const code = await runUpgrade({}, deps);
+    expect(code).toBe(0);
+    const out = calls.logs.join('\n');
+    expect(out).not.toMatch(/shadowing/);
+    expect(out).toMatch(/Open a new terminal/);
+  });
+
+  it('parses the last non-empty line, so a runtime warning above the version is harmless', () => {
+    const { deps } = makeDeps({
+      ...npmGlobal,
+      hasCommand: (c) => c === 'codegraph',
+      capture: () => ({ code: 0, stdout: '(node:1) ExperimentalWarning: blah\nv0.9.9\n\n' }),
+    });
+    expect(verifyResolvedVersion('v0.9.9', deps)).toBe('match');
+  });
+
+  it('routes the probe through cmd.exe on Windows (.cmd launcher)', async () => {
+    const { deps, calls } = makeDeps({
+      ...npmGlobal,
+      platform: 'win32',
+      hasCommand: (c) => c === 'codegraph' || c === 'npm.cmd',
+      capture: () => ({ code: 0, stdout: '0.9.9\r\n' }),
+    });
+    const code = await runUpgrade({}, deps);
+    expect(code).toBe(0);
+    expect(calls.captures).toEqual([{ cmd: 'cmd.exe', args: ['/d', '/s', '/c', 'codegraph --version'] }]);
+    expect(calls.logs.join('\n')).toMatch(/now reports v0\.9\.9/);
+  });
+
+  it('skips the probe for npm-local installs — PATH serves a different copy', async () => {
+    const { deps, calls } = makeDeps({
+      method: { kind: 'npm', scope: 'local' },
+      currentVersion: '0.9.8',
+      hasCommand: (c) => c === 'codegraph',
+      capture: () => ({ code: 0, stdout: '0.9.7\n' }),
+    });
+    const code = await runUpgrade({}, deps);
+    expect(code).toBe(0);
+    expect(calls.captures).toHaveLength(0);
+    expect(calls.logs.join('\n')).not.toMatch(/shadowing/);
+  });
+
+  it('does not probe after a failed upgrade', async () => {
+    const { deps, calls } = makeDeps(
+      { ...npmGlobal, hasCommand: (c) => c === 'codegraph', capture: () => ({ code: 0, stdout: '0.9.9\n' }) },
+      1
+    );
+    const code = await runUpgrade({}, deps);
+    expect(code).toBe(1);
+    expect(calls.captures).toHaveLength(0);
   });
 });
 

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -2351,6 +2351,7 @@ program
         method,
         resolveLatest: () => up.resolveLatestVersion(),
         run: up.defaultRun,
+        capture: up.defaultCapture,
         hasCommand: up.hasCommand,
         log: (m: string) => console.log(m),
         warn: (m: string) => warn(m),

--- a/src/upgrade/index.ts
+++ b/src/upgrade/index.ts
@@ -99,19 +99,20 @@ export function detectInstallMethod(input: DetectInput): InstallMethod {
   const P = isWin ? path.win32 : path.posix;
   const binDir = P.dirname(input.filename); // <…>/bin
 
-  // Bundle: <root>/lib/dist/bin/codegraph.js → <root> is up 3 from bin/.
-  // A bundle has a vendored node + a launcher script as siblings of lib/.
-  const bundleRoot = P.resolve(binDir, '..', '..', '..');
-  const vendoredNode = P.join(bundleRoot, isWin ? 'node.exe' : 'node');
-  const launcher = P.join(bundleRoot, 'bin', isWin ? 'codegraph.cmd' : 'codegraph');
-  if (exists(vendoredNode) && exists(launcher)) {
-    const os = isWin ? 'windows' : 'unix';
-    return { kind: 'bundle', os, bundleRoot, installDir: deriveInstallDir(bundleRoot, os, exists) };
-  }
-
   const norm = toPosix(input.filename);
 
+  // Path-based checks come FIRST. The npm thin-installer's per-platform
+  // package (@colbymchenry/codegraph-<platform>-<arch>) is itself a complete
+  // bundle — vendored node + bin/ launcher — living inside node_modules, so
+  // the layout sniff below would misread every npm install as a standalone
+  // bundle. `upgrade` would then curl install.sh into ~/.codegraph: a SECOND
+  // install that never wins the PATH race against npm's shim, leaving
+  // `codegraph -v` permanently on the old version (the #1071 shadow,
+  // self-inflicted). A path under node_modules is authoritative about HOW the
+  // user installed, whatever the artifact inside looks like.
+
   // npx cache: <…>/_npx/<hash>/node_modules/@colbymchenry/codegraph/…
+  // (checked before npm — the npx cache path also contains /node_modules/).
   if (norm.includes('/_npx/')) {
     return { kind: 'npx' };
   }
@@ -120,6 +121,16 @@ export function detectInstallMethod(input: DetectInput): InstallMethod {
   if (norm.includes('/node_modules/')) {
     const underCwd = norm.startsWith(toPosix(P.resolve(input.cwd)) + '/');
     return { kind: 'npm', scope: underCwd ? 'local' : 'global' };
+  }
+
+  // Bundle: <root>/lib/dist/bin/codegraph.js → <root> is up 3 from bin/.
+  // A bundle has a vendored node + a launcher script as siblings of lib/.
+  const bundleRoot = P.resolve(binDir, '..', '..', '..');
+  const vendoredNode = P.join(bundleRoot, isWin ? 'node.exe' : 'node');
+  const launcher = P.join(bundleRoot, 'bin', isWin ? 'codegraph.cmd' : 'codegraph');
+  if (exists(vendoredNode) && exists(launcher)) {
+    const os = isWin ? 'windows' : 'unix';
+    return { kind: 'bundle', os, bundleRoot, installDir: deriveInstallDir(bundleRoot, os, exists) };
   }
 
   // Source checkout: running <repo>/dist/bin/codegraph.js with a sibling .git.
@@ -278,6 +289,8 @@ export interface UpgradeDeps {
   resolveLatest: (pin?: string) => Promise<string>;
   /** Run a command inheriting stdio; returns its exit code (-1 = spawn failed). */
   run: (cmd: string, args: string[], env?: NodeJS.ProcessEnv) => number;
+  /** Run a command capturing stdout (nothing reaches the terminal); null = spawn failed. */
+  capture: (cmd: string, args: string[]) => { code: number; stdout: string } | null;
   hasCommand: (cmd: string) => boolean;
   log: (msg: string) => void;
   warn: (msg: string) => void;
@@ -377,12 +390,70 @@ export async function runUpgrade(opts: UpgradeOptions, deps: UpgradeDeps): Promi
   // fatal to the upgrade.
   if (code === 0) {
     try {
+      reportResolvedVersion(latest, deps);
+    } catch {
+      /* an inconclusive probe must not fail the upgrade */
+    }
+    try {
       await selfHealPromptHook(deps);
     } catch {
       /* a hook-wiring hiccup must not fail the upgrade */
     }
   }
   return code;
+}
+
+type VersionProbe = 'match' | 'mismatch' | 'inconclusive';
+
+/**
+ * Prove the upgrade actually took: spawn the `codegraph` this terminal's PATH
+ * resolves and compare its reported version to the target. Catches the silent
+ * failure mode where ANOTHER install shadows the one we just upgraded (issue
+ * #1071 — e.g. a stale `npm i -g` copy earlier on PATH than the bundle
+ * launcher): the upgrade "succeeds" but `codegraph -v` — in this terminal and
+ * every future one — keeps serving the old version. Exported for unit tests.
+ */
+export function verifyResolvedVersion(latest: string, deps: UpgradeDeps): VersionProbe {
+  if (!deps.hasCommand('codegraph')) return 'inconclusive';
+  // Windows installs expose codegraph through a .cmd launcher; Node can't
+  // spawn .cmd files without a shell, so route through cmd.exe there.
+  const probe = deps.platform === 'win32'
+    ? deps.capture('cmd.exe', ['/d', '/s', '/c', 'codegraph --version'])
+    : deps.capture('codegraph', ['--version']);
+  if (!probe || probe.code !== 0) return 'inconclusive';
+  // `codegraph --version` prints the bare version; take the last non-empty
+  // line so a stray runtime warning above it can't spoil the parse.
+  const reported = probe.stdout.trim().split(/\r?\n/).pop()?.trim() ?? '';
+  if (!parseSemver(reported)) return 'inconclusive';
+  return compareVersions(reported, latest) === 0 ? 'match' : 'mismatch';
+}
+
+/**
+ * Log the outcome of the post-upgrade version probe. On a match the user
+ * knows the current terminal is already serving the new version; on a
+ * mismatch they get told exactly which stale install is hijacking their PATH
+ * instead of discovering it via a mysteriously unchanged `codegraph -v`.
+ * Inconclusive probes fall back to the old soft hint — never a scare on
+ * setups we can't inspect (no `codegraph` on PATH yet, exotic wrappers).
+ */
+function reportResolvedVersion(latest: string, deps: UpgradeDeps): void {
+  const { method } = deps;
+  // A project-local npm install isn't served by PATH's `codegraph` (that
+  // would be some other install) — a probe could only false-alarm.
+  if (method.kind === 'npm' && method.scope === 'local') return;
+  switch (verifyResolvedVersion(latest, deps)) {
+    case 'match':
+      deps.log(c.green(`✓ \`codegraph\` on your PATH now reports ${latest} — this terminal is already using it.`));
+      break;
+    case 'mismatch':
+      deps.warn(`Installed ${latest}, but the \`codegraph\` this terminal resolves still reports an older version.`);
+      deps.log(c.dim('Another CodeGraph install earlier on your PATH is shadowing the one just upgraded.'));
+      deps.log(c.dim('Find every copy with `which -a codegraph` (Windows: `where codegraph`) and remove or upgrade the stale one.'));
+      break;
+    case 'inconclusive':
+      deps.log(c.dim('Open a new terminal if `codegraph --version` looks unchanged (PATH cache).'));
+      break;
+  }
 }
 
 /**
@@ -429,7 +500,9 @@ function upgradeUnixBundle(
     return 1;
   }
   deps.log('');
-  deps.log(c.green('✓ Upgrade complete.') + c.dim(' Open a new terminal if the version looks unchanged (PATH cache).'));
+  // No "open a new terminal" hedge here — after the swap, runUpgrade probes
+  // the PATH-resolved `codegraph --version` and reports the real outcome.
+  deps.log(c.green('✓ Upgrade complete.'));
   deps.log(reindexAdvisory());
   return 0;
 }
@@ -484,7 +557,9 @@ function upgradeWindowsBundle(
     return 1;
   }
   deps.log('');
-  deps.log(c.green('✓ Upgrade complete.') + c.dim(' Open a new terminal to be safe (PATH/version cache).'));
+  // The running node.exe was renamed aside, so the version probe in
+  // runUpgrade already exercises the NEW binary — no terminal hedge needed.
+  deps.log(c.green('✓ Upgrade complete.'));
   deps.log(reindexAdvisory());
   return 0;
 }
@@ -549,4 +624,13 @@ export function defaultRun(cmd: string, args: string[], env?: NodeJS.ProcessEnv)
   const r = spawnSync(cmd, args, { stdio: 'inherit', env: env ?? process.env, windowsHide: true });
   if (r.error) return -1;
   return r.status ?? -1;
+}
+
+export function defaultCapture(cmd: string, args: string[]): { code: number; stdout: string } | null {
+  // stdio is piped (the default with `encoding`), so nothing the probed
+  // command prints reaches the user's terminal. The timeout keeps a wedged
+  // probe from hanging the upgrade's last step.
+  const r = spawnSync(cmd, args, { encoding: 'utf-8', windowsHide: true, timeout: 30_000 });
+  if (r.error) return null;
+  return { code: r.status ?? -1, stdout: r.stdout ?? '' };
 }


### PR DESCRIPTION
Companion to #1239 / #1238. Together they make three guarantees hold after `codegraph upgrade`: hooks refreshed, agent instruction files refreshed (#1239), and — this PR — `codegraph -v` in the **same terminal** provably serving the new version.

## Problem 1 — npm installs self-shadow on upgrade (found while validating #1239)

Reproduced live in a sandboxed `$HOME`: install 1.3.1 via `npm i -g`, run `codegraph upgrade` — and `codegraph --version` reports **1.3.1 forever**, in that terminal and every future one.

Root cause: the npm thin-installer's per-platform package (`@colbymchenry/codegraph-<platform>-<arch>`) is itself a complete bundle — vendored `node` + `bin/` launcher — living inside `node_modules`. `detectInstallMethod` checked the bundle *layout* before the `node_modules` *path*, so every npm install misdetected as a standalone bundle and `upgrade` curled install.sh into `~/.codegraph`: a **second install** that never wins the PATH race against npm's shim. The #1071 shadow pile-up, manufactured by `upgrade` itself.

This also silently broke #1239 for npm users (the issue author's own environment): its post-upgrade `codegraph install --refresh` spawn resolves the stale npm shim, which doesn't know `--refresh`.

**Fix:** path-based checks (`/_npx/`, `/node_modules/`) now run before the layout sniff — where the file lives is authoritative about *how* the user installed, whatever the artifact inside looks like. npm installs upgrade through `npm install -g …@latest` again: same shim path, so the same terminal picks up the new version immediately. The shim's GitHub-download self-heal cache (`~/.codegraph`, issue #303) is outside `node_modules` and still detects as a bundle.

## Problem 2 — nothing ever verified the upgrade took

The unix-bundle path ended with "✓ Upgrade complete. *Open a new terminal if the version looks unchanged (PATH cache)*" — an unconditional hedge for a failure mode we can detect. After a successful swap, `runUpgrade` now probes the PATH-resolved `codegraph --version` (through `cmd.exe` on Windows for the `.cmd` launcher) and reports the real outcome:

- **match** → `✓ codegraph on your PATH now reports v1.4.0 — this terminal is already using it.`
- **mismatch** → a loud warning that a stale install is shadowing the upgraded one, with `which -a codegraph` / `where codegraph` to find it. Warn-only; the upgrade itself still exits 0.
- **inconclusive** (no `codegraph` on PATH, probe fails or output unparsable) → the old soft new-terminal hint, never a scare.

Skipped for npm-local installs, whose binary PATH never serves. New `capture` dep on `UpgradeDeps` (piped stdio, 30s timeout) keeps it unit-testable; probe parsing takes the last non-empty stdout line so a stray runtime warning can't spoil it.

## Validation

- **3 detection regression tests** (thin-installer platform package → npm global / npm local / npx-cached) — verified to **fail against the pre-fix code** and pass now.
- **8 probe orchestration tests**: match / mismatch / both inconclusive shapes / last-line parsing / Windows `cmd.exe` routing / npm-local skip / no probe after a failed upgrade.
- Full suite: 2290 passed, 4 skipped (platform-gated).
- Live e2e against real binaries in a sandboxed `$HOME`: bundle 1.3.1 → upgrade → same-shell `-v` = 1.4.0 with the green confirmation; simulated shadow prints the warning. (The npm misdetection itself was reproduced live pre-fix: upgrade curled install.sh and left the shim at 1.3.1.)

## Interaction with #1239

Independent — either can merge first; whichever lands second has a trivial conflict in `runUpgrade`'s post-success block and the CHANGELOG. Ordering note for the rebase: the version probe should run (and ideally gate) *before* the `install --refresh` spawn, so the refresh never executes through a shadowed stale binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)