### PR TITLE
fix(scripts): make add-lang bench scripts work on Windows

### DIFF
--- a/scripts/add-lang/bench.sh
+++ b/scripts/add-lang/bench.sh
@@ -9,7 +9,10 @@
 # broken extractor); set FORCE_AB=1 to run it anyway.
 #
 # Usage: bench.sh <lang> <repo-name> <repo-url> "<question>" [headless|tmux|all]
-# Env:   CORPUS   corpus dir (default /tmp/codegraph-corpus, shared with agent-eval)
+# Env:   CORPUS         corpus dir (default /tmp/codegraph-corpus, shared with agent-eval)
+#        CODEGRAPH_BIN  path to the codegraph binary or dist/bin/codegraph.js —
+#                       bypasses the PATH lookup (needed on Windows, where the
+#                       npm shim isn't directly exec-able from Node children)
 set -uo pipefail
 
 LANG_TOKEN="${1:?usage: bench.sh <lang> <repo-name> <repo-url> \"<question>\" [mode]}"
@@ -23,10 +26,23 @@ AGENT_EVAL="$(cd "$HARNESS/../agent-eval" && pwd)"
 CORPUS="${CORPUS:-/tmp/codegraph-corpus}"
 REPO="$CORPUS/$NAME"
 
-command -v codegraph >/dev/null || { echo "no codegraph on PATH (build + ./scripts/local-install.sh first)"; exit 1; }
+# CODEGRAPH_BIN overrides the PATH lookup; the function shadows the `codegraph`
+# command for the rest of the script, and the export lets verify-extraction.mjs
+# (a Node child) resolve the same binary.
+if [ -n "${CODEGRAPH_BIN:-}" ]; then
+  export CODEGRAPH_BIN
+  case "$CODEGRAPH_BIN" in
+    *.js|*.mjs|*.cjs) codegraph() { node "$CODEGRAPH_BIN" "$@"; } ;;
+    *)                codegraph() { "$CODEGRAPH_BIN" "$@"; } ;;
+  esac
+  CODEGRAPH_DESC="$CODEGRAPH_BIN"
+else
+  command -v codegraph >/dev/null || { echo "no codegraph on PATH (build + ./scripts/local-install.sh first, or set CODEGRAPH_BIN)"; exit 1; }
+  CODEGRAPH_DESC="$(command -v codegraph)"
+fi
 
 echo "==================== add-lang bench: $NAME ($LANG_TOKEN) ===================="
-echo "codegraph: $(command -v codegraph) -> $(codegraph --version 2>/dev/null || echo '?')"
+echo "codegraph: $CODEGRAPH_DESC -> $(codegraph --version 2>/dev/null || echo '?')"
 
 # 1. Ensure the repo (shallow clone, reuse if present).
 mkdir -p "$CORPUS"

--- a/scripts/add-lang/verify-extraction.mjs
+++ b/scripts/add-lang/verify-extraction.mjs
@@ -5,11 +5,16 @@
 //
 // Usage: node scripts/add-lang/verify-extraction.mjs <repo-path> <lang>
 // Reads `codegraph status <repo> --json` using whatever codegraph is on PATH,
-// so it reflects the binary that built the index.
+// so it reflects the binary that built the index. Set CODEGRAPH_BIN to a
+// specific binary (or to dist/bin/codegraph.js) to bypass the PATH lookup —
+// on Windows, npm installs codegraph as a .cmd shim that execFileSync can't
+// launch by bare name, so the lookup below resolves the shim itself.
 //
 // Exit codes: 0 = pass or soft-warn, 1 = critical fail, 2 = could not run.
 
 import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
 
 const [repo, lang] = process.argv.slice(2);
 if (!repo || !lang) {
@@ -17,12 +22,43 @@ if (!repo || !lang) {
   process.exit(2);
 }
 
+function resolveCodegraphBin() {
+  if (process.env.CODEGRAPH_BIN) return process.env.CODEGRAPH_BIN;
+  if (process.platform !== 'win32') return 'codegraph';
+  // Windows: find the npm shim on PATH ourselves. The extensionless shim is a
+  // sh script (Git Bash only); .cmd/.exe are what a Node child can run.
+  for (const dir of (process.env.PATH || '').split(path.delimiter)) {
+    if (!dir) continue;
+    for (const ext of ['.cmd', '.exe', '.bat']) {
+      const candidate = path.join(dir, `codegraph${ext}`);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return 'codegraph';
+}
+
+function runCodegraph(args) {
+  const bin = resolveCodegraphBin();
+  const ext = path.extname(bin).toLowerCase();
+  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') {
+    return execFileSync(process.execPath, [bin, ...args], { encoding: 'utf8' });
+  }
+  if (ext === '.cmd' || ext === '.bat') {
+    // Batch shims only run through cmd.exe (shell:true). Node doesn't escape
+    // when shell is enabled, so quote every token ourselves.
+    const q = (s) => (/[\s"^&|<>()]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s);
+    return execFileSync(q(bin), args.map(q), { encoding: 'utf8', shell: true });
+  }
+  return execFileSync(bin, args, { encoding: 'utf8' });
+}
+
 let status;
 try {
-  const out = execFileSync('codegraph', ['status', repo, '--json'], { encoding: 'utf8' });
+  const out = runCodegraph(['status', repo, '--json']);
   status = JSON.parse(out);
 } catch (e) {
   console.error(`[verify] could not read codegraph status for ${repo}: ${e.message}`);
+  console.error('[verify] hint: set CODEGRAPH_BIN to the codegraph binary or dist/bin/codegraph.js');
   process.exit(2);
 }
 


### PR DESCRIPTION
## Problem

`scripts/add-lang/verify-extraction.mjs` hard-codes `execFileSync('codegraph', ...)`, which always fails with `ENOENT` on Windows: `CreateProcess` does no PATHEXT resolution, and npm exposes CLIs on Windows only as `.cmd` / extensionless-sh / `.ps1` shims — none of which Node can spawn without a shell (spawning a `.cmd` without `shell: true` is even a hard `EINVAL` since the CVE-2024-27980 fix). The phantom "could not read codegraph status" failure then forces `FORCE_AB=1` workarounds in `bench.sh` to get past a perfectly healthy extraction.

This bites anyone running the `/add-lang` bench flow on Windows, regardless of how Node is installed.

## Fix

**`verify-extraction.mjs`** — resolve the binary instead of assuming a bare name works:
- `CODEGRAPH_BIN` env var takes priority everywhere; a `.js`/`.mjs`/`.cjs` path runs via `process.execPath`.
- On win32 with no env var, scan `PATH` for the `codegraph.cmd`/`.exe`/`.bat` shim; batch shims run through the shell with self-quoted args (Node doesn't escape when `shell` is enabled), so paths with spaces survive.
- On macOS/Linux with no env var, the call is byte-for-byte the old behavior.
- The could-not-run path now exits 2 with a `CODEGRAPH_BIN` hint instead of a raw ENOENT.

**`bench.sh`** — honor `CODEGRAPH_BIN` via a `codegraph()` function that shadows the PATH lookup (routing `.js` paths through `node`), exported so the `verify-extraction.mjs` child resolves the same binary. Behavior with the env var unset is unchanged.

## Validation (Windows 11, Git Bash + PowerShell, real runs)

- `CODEGRAPH_BIN=dist/bin/codegraph.js` → verify reads status, `RESULT: PASS`, exit 0.
- `.cmd` shim on PATH, no env var → resolved and passed, including a shim dir **and** repo path containing spaces (the exact case that previously died with ENOENT).
- No codegraph resolvable → graceful exit 2 with the hint.
- Full `bench.sh` run under Git Bash (env-var and shim-pair variants): clone → wipe+index → verify → correctly skips the paid A/B on a deliberate critical failure, exit code propagated.
- `bash -n` clean; POSIX default paths are unchanged by inspection (only error-message text gained a hint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)