### PR TITLE
fix(cli): require full rebuild for stale extraction indexes

### DIFF
--- a/__tests__/status-json.test.ts
+++ b/__tests__/status-json.test.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { CodeGraph } from '../src';
+import { EXTRACTION_VERSION } from '../src/extraction/extraction-version';
 
 const BIN = path.resolve(__dirname, '../dist/bin/codegraph.js');
 const PKG_VERSION = JSON.parse(
@@ -30,6 +31,15 @@ function runStatusJson(cwd: string): Record<string, unknown> {
   // leading output by parsing the last non-empty line.
   const line = stdout.trim().split('\n').filter(Boolean).pop()!;
   return JSON.parse(line);
+}
+
+function runStatusText(cwd: string): string {
+  return execFileSync(process.execPath, [BIN, 'status'], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, CODEGRAPH_NO_DAEMON: '1', NO_COLOR: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
 }
 
 describe('codegraph status --json — CI fields (#329)', () => {
@@ -85,6 +95,29 @@ describe('codegraph status --json — CI fields (#329)', () => {
     const ms = Date.parse(out.lastIndexed as string);
     expect(ms).toBeGreaterThanOrEqual(before - 1000);
     expect(ms).toBeLessThanOrEqual(after + 1000);
+  });
+
+  it('status requires a full rebuild when the extraction version is stale', async () => {
+    fs.writeFileSync(path.join(tempDir, 'a.ts'), 'export const x = 1;\n');
+    const cg = CodeGraph.initSync(tempDir);
+    await cg.indexAll();
+    cg.close();
+
+    // Simulate an index built by an older extraction engine. Incremental sync
+    // cannot revisit every unchanged file, so it must not be offered here.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { DatabaseSync } = require('node:sqlite');
+    const db = new DatabaseSync(path.join(tempDir, '.codegraph', 'codegraph.db'));
+    db.prepare(
+      "INSERT INTO project_metadata (key, value, updated_at) VALUES ('indexed_with_extraction_version', ?, 0) " +
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+    ).run(String(EXTRACTION_VERSION - 1));
+    db.close();
+
+    const out = runStatusText(tempDir);
+    expect(out).toContain('Run "codegraph index"');
+    expect(out).toMatch(/full rebuild/i);
+    expect(out).not.toContain('codegraph sync');
   });
 });
 

--- a/__tests__/upgrade.test.ts
+++ b/__tests__/upgrade.test.ts
@@ -204,10 +204,12 @@ describe('version helpers', () => {
     expect(parseLatestTagFromLocation('https://github.com/o/r/releases')).toBeNull();
   });
 
-  it('reindexAdvisory mentions the refresh commands', () => {
+  it('reindexAdvisory requires a full rebuild for extraction improvements', () => {
     const a = reindexAdvisory();
-    expect(a).toContain('codegraph sync');
-    expect(a).toContain('codegraph index -f');
+    expect(a).toContain('codegraph index');
+    expect(a).toMatch(/full rebuild/i);
+    expect(a).not.toContain('codegraph sync');
+    expect(a).not.toContain('codegraph index -f');
   });
 
   it('buildWindowsUpgradeScript targets the right asset per arch and renames-not-deletes the exe', () => {
@@ -300,7 +302,8 @@ describe('runUpgrade', () => {
     expect(calls.runs[0].args[1]).toContain('curl -fsSL');
     expect(calls.runs[0].args[1]).toContain('| sh');
     expect(calls.runs[0].env?.CODEGRAPH_INSTALL_DIR).toBe('/h/.codegraph');
-    expect(calls.logs.join('\n')).toMatch(/codegraph sync/); // re-index advisory printed
+    expect(calls.logs.join('\n')).toMatch(/codegraph index/); // re-index advisory printed
+    expect(calls.logs.join('\n')).not.toMatch(/codegraph sync/);
   });
 
   it('unix bundle: falls back to wget, and errors when neither downloader exists', async () => {

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -1037,7 +1037,7 @@ program
       if (reindexRecommended) {
         const builtWith = buildInfo.version ? `v${buildInfo.version.replace(/^v/, '')}` : 'an earlier version';
         warn(`Index was built by ${builtWith}; re-index to pick up this engine's improvements.`);
-        info('Run "codegraph index" (full rebuild) or "codegraph sync"');
+        info('Run "codegraph index" (full rebuild required)');
         console.log();
       }
 

--- a/src/upgrade/index.ts
+++ b/src/upgrade/index.ts
@@ -310,9 +310,8 @@ const c = {
 export function reindexAdvisory(): string {
   return [
     c.dim('Your existing project indexes keep working, but were built by the previous version.'),
-    c.dim('To pick up this version’s extraction improvements, refresh each project:'),
-    `  ${c.cyan('codegraph sync')}        ${c.dim('# incremental, fast')}`,
-    `  ${c.cyan('codegraph index -f')}    ${c.dim('# full rebuild')}`,
+    c.dim('To pick up this version’s extraction improvements, fully rebuild each project index:'),
+    `  ${c.cyan('codegraph index')}    ${c.dim('# full rebuild required')}`,
     c.dim('(`codegraph status` flags any index that predates the engine you’re running.)'),
   ].join('\n');
 }


### PR DESCRIPTION
## Summary

- require a full `codegraph index` rebuild when an index predates the current extraction version
- stop suggesting incremental `codegraph sync` for extraction-version staleness
- avoid the unnecessary `-f` safety override in the post-upgrade advisory
- cover both the upgrade advisory and the built CLI `status` output

## Reproduction and root cause

A full index stamps `indexed_with_extraction_version`, while `sync` deliberately does not advance that stamp because it only revisits changed files. When extraction behavior improves, unchanged files built by an older engine can therefore remain incomplete after `sync`.

Both `codegraph status` and the post-upgrade advisory previously offered `codegraph sync` as a recovery command, which could leave the index stale while implying the extraction improvements had been applied.

## Behavior boundary

This only changes public guidance. It does not automatically rebuild indexes during upgrade and does not change sync or indexing behavior.

`codegraph index` already recreates the database and performs the required full rebuild. Its `-f` flag only bypasses unsafe-root protection, so the general advisory should not recommend it.

## Verification

- `npm run build`
- `npx vitest run __tests__/upgrade.test.ts --reporter=dot --pool=threads --fileParallelism=false` (50 passed)
- focused red/green test for `status requires a full rebuild when the extraction version is stale`
- focused red/green test for `reindexAdvisory requires a full rebuild for extraction improvements`
- `git diff --check`
- GoLand inspections on all four changed files: no errors

On this Windows environment, the complete `status-json.test.ts` file has a pre-existing process-exit hang that reproduced before the change; the new CLI regression test passes independently after build.