### PR TITLE
fix(search): make explore find symbols named in CJK (Chinese/Japanese/Korean)

### DIFF
--- a/__tests__/extract-search-terms-cjk.test.ts
+++ b/__tests__/extract-search-terms-cjk.test.ts
@@ -1,0 +1,56 @@
+/**
+ * `extractSearchTerms` must surface terms from ideographic-script queries.
+ *
+ * Regression for: the ASCII-only `[^a-zA-Z0-9]` word split erased every
+ * character of a Chinese/Japanese/Korean query, so it returned `[]` and
+ * `explore` reported "No relevant code found" for symbols named in those
+ * scripts — even though the FTS index (default unicode61 tokenizer) stores
+ * them and `query`/`node` find them. The ASCII path is intentionally left
+ * unchanged; these cases are recovered additively.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractSearchTerms } from '../src/search/query-utils';
+
+describe('extractSearchTerms — ideographic (CJK) queries', () => {
+  it('surfaces a whole Chinese symbol name (was [] → explore found nothing)', () => {
+    expect(extractSearchTerms('寻路服务')).toContain('寻路服务');
+  });
+
+  it('keeps a two-character Chinese word (below the ASCII ≥3 floor)', () => {
+    expect(extractSearchTerms('寻路')).toContain('寻路');
+  });
+
+  it('splits whitespace-separated Chinese terms into separate terms', () => {
+    const terms = extractSearchTerms('寻路服务 自动寻路模块');
+    expect(terms).toContain('寻路服务');
+    expect(terms).toContain('自动寻路模块');
+  });
+
+  it('pulls the ideographic run out of a mixed Latin+Han identifier', () => {
+    const terms = extractSearchTerms('NavMeshAgent类型');
+    expect(terms).toContain('navmeshagent'); // ASCII compound — unchanged
+    expect(terms).toContain('类型');          // Han run — previously dropped
+  });
+
+  it('supports Japanese (Kanji) and Korean (Hangul) runs', () => {
+    expect(extractSearchTerms('経路探索')).toContain('経路探索');
+    expect(extractSearchTerms('길찾기')).toContain('길찾기');
+  });
+});
+
+describe('extractSearchTerms — ASCII behaviour is unchanged', () => {
+  it('splits camelCase into its parts', () => {
+    const terms = extractSearchTerms('getUserName');
+    expect(terms).toContain('user');
+    expect(terms).toContain('name');
+  });
+
+  it('still drops stop words and sub-3-char tokens', () => {
+    const terms = extractSearchTerms('the id of a UserService');
+    expect(terms).not.toContain('the');
+    expect(terms).not.toContain('of');
+    expect(terms).not.toContain('id');
+    expect(terms).toContain('service');
+  });
+});

--- a/src/search/query-utils.ts
+++ b/src/search/query-utils.ts
@@ -142,6 +142,13 @@ export function getStemVariants(term: string): string[] {
 }
 
 /**
+ * Ideographic scripts (Han, Hiragana, Katakana, Hangul) are not space-delimited,
+ * so a run of them is one "word" that the ASCII whitespace/underscore/camelCase
+ * tokenization below can't see. Matched as maximal runs and surfaced as terms.
+ */
+const IDEOGRAPHIC_RUN_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]+/gu;
+
+/**
  * Extract meaningful search terms from a natural language query.
  * Splits camelCase, PascalCase, snake_case, SCREAMING_SNAKE, and dot.notation
  * into individual tokens before filtering.
@@ -190,6 +197,21 @@ export function extractSearchTerms(query: string, options?: { stems?: boolean })
     const lower = word.toLowerCase();
     if (lower.length < 3) continue;
     if (STOP_WORDS.has(lower)) continue;
+    tokens.add(lower);
+  }
+
+  // The split above is ASCII-only ([^a-zA-Z0-9]), so a query written in an
+  // ideographic script — Chinese, Japanese, Korean — treats EVERY character as a
+  // separator and yields zero terms. That made `explore` return "No relevant code
+  // found" for symbols named in those scripts, even though they ARE indexed and
+  // `query`/`node` (which pass the raw string to FTS) find them. Recover each
+  // ideographic run as its own term: FTS5's default unicode61 tokenizer keeps
+  // such a run as a single token, so a whole-run term matches exactly the way
+  // query/node already do. Floor of 2 rather than the ≥3 used to strip short
+  // ASCII noise — an ideographic word is 1–2 characters (e.g. "寻路" = pathfinding).
+  for (const run of query.match(IDEOGRAPHIC_RUN_RE) ?? []) {
+    const lower = run.toLowerCase();
+    if (lower.length < 2) continue;
     tokens.add(lower);
   }
 


### PR DESCRIPTION
## Problem

`codegraph_explore` / `codegraph explore` returns **"No relevant code found"** for a query written in a CJK script (Chinese, Japanese, Korean) — even when the symbol is indexed and `codegraph query` / `codegraph node` find it with the *same* string.

Repro on a Chinese-named codebase:

```
$ codegraph query   "寻路服务"              # ✅ finds class 寻路服务
$ codegraph node    "寻路服务"              # ✅ full source
$ codegraph explore "寻路服务"              # ❌ No relevant code found
$ codegraph explore "NavMeshAgent 寻路服务" # ✅ works — an ASCII token rescues it
```

## Root cause

`explore` derives its search terms via `extractSearchTerms()` (`src/search/query-utils.ts`), whose final tokenization is ASCII-only:

```ts
const words = normalised.split(/[^a-zA-Z0-9]+/).filter(Boolean);
```

For an all-ideographic query **every** character matches `[^a-zA-Z0-9]`, so the split yields only empty strings and the function returns `[]`. `context/index.ts` then guards the text search with `if (searchTerms.length > 0)`, so nothing is searched. `query` / `node` are unaffected because they pass the raw string straight to FTS.

## Fix

After the existing ASCII pass (**left completely untouched** — no change to Latin/accent behaviour), additively recover each ideographic run (`\p{Script=Han|Hiragana|Katakana|Hangul}`) as its own term. FTS5's default `unicode61` tokenizer already stores such a run as a single token (which is exactly why `query` works), so a whole-run term matches the same way. The floor is 2 chars rather than the ≥3 used to strip short ASCII noise, because an ideographic word is 1–2 characters (`寻路` = "pathfinding").

```
extractSearchTerms("寻路服务")             → ["寻路服务"]              (was [])
extractSearchTerms("寻路服务 自动寻路模块") → ["寻路服务", "自动寻路模块"]
extractSearchTerms("NavMeshAgent类型")      → ["navmeshagent", "类型"]   (Latin part unchanged)
```

## Tests

- New `__tests__/extract-search-terms-cjk.test.ts` — 7 cases (Han / Kana / Hangul, 2-char words, mixed Latin+Han, plus ASCII-unchanged guards).
- Full `npm test` is green apart from a few **pre-existing, unrelated** failures on my Windows box (`arkts-resolution`, `frameworks-integration`, `mcp-roots`, `mcp-initialize`, plus tinypool "Worker exited unexpectedly"). I verified those fail **identically with this change stashed**, so they are environmental, not from this PR.

## Scope / possible follow-up

This fixes **symbol-name / identifier** queries (the common case — "find `寻路服务`"). A CJK **natural-language** question has no word spacing, so it still tokenizes as one long run; proper CJK word segmentation would be a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
