### PR TITLE
fix(extraction): strip template args from out-of-line C++ method qualifiers (#1286)

### DIFF
--- a/__tests__/extraction.test.ts
+++ b/__tests__/extraction.test.ts
@@ -4074,6 +4074,35 @@ class Both : public Base<char>, public Plain {};
     });
   });
 
+  describe('C++ out-of-line template method qualifier (#1286)', () => {
+    // An out-of-line template method definition
+    // (`template<typename T> T Box<T>::get()`) recorded its class qualifier as the
+    // full instantiation `Box<T>`, so the method's qualifiedName was `Box<T>::get`.
+    // That never name-matched the class node indexed as `Box`, and long/multi-line
+    // template params could push the qualifiedName past the 255-byte filename
+    // limit. The `<…>` args are stripped so the qualifier is the bare `Box`,
+    // exactly like #1043 did for templated base classes. Inline method bodies were
+    // already unaffected.
+    it('strips template args from an out-of-line template method qualifier', () => {
+      const code = `
+template <typename T>
+class Box { public: T get() const; void set(T v); private: T value; };
+
+template <typename T> T Box<T>::get() const { return value; }
+template <typename T> void Box<T>::set(T v) { value = v; }
+`;
+      const nodes = extractFromSource('box.cpp', code).nodes;
+      const get = nodes.find((n) => n.name === 'get');
+      const set = nodes.find((n) => n.name === 'set');
+
+      // Qualifier is the bare class, not the `Box<T>` instantiation.
+      expect(get?.qualifiedName).toBe('Box::get');
+      expect(set?.qualifiedName).toBe('Box::set');
+      // No node still carries angle brackets in its qualified name.
+      expect(nodes.find((n) => n.qualifiedName?.includes('<'))).toBeUndefined();
+    });
+  });
+
   describe('C++ stack-allocation construction (#1035)', () => {
     // `Calculator calc(0)` (direct-init) and `Widget w{1, 2}` (brace-init) carry
     // the constructor args directly on the declarator — no call/new node — so

--- a/src/extraction/languages/c-cpp.ts
+++ b/src/extraction/languages/c-cpp.ts
@@ -88,7 +88,14 @@ function extractCppReceiverType(node: SyntaxNode, source: string): string | unde
   if (!declarator) return undefined;
   const qid = findDeclaratorQualifiedId(declarator);
   if (!qid) return undefined;
-  const parts = getNodeText(qid, source).trim().split('::').filter(Boolean);
+  // Strip template arguments before splitting on `::` so an out-of-line template
+  // method definition (`template<typename T> T Box<T>::get()`) yields the bare
+  // class `Box`, not `Box<T>` — matching the class node indexed as `Box`, the
+  // same reason #1043 stripped them from templated base-class references. Doing it
+  // before the split also tolerates `::` inside the args (`Box<std::string>::get`).
+  const parts = stripCppTemplateArgs(getNodeText(qid, source).trim())
+    .split('::')
+    .filter(Boolean);
   return parts.length > 1 ? parts.slice(0, -1).join('::') : undefined;
 }
 


### PR DESCRIPTION
Fixes #1286.

## Problem
`stripCppTemplateArgs` (added in #1043 to drop `<…>` from templated base-class refs so `extends` resolves) isn't applied to method qualifiers. An out-of-line template method keeps the class template params in `qualified_name`:

```cpp
template <typename T> class Box { public: T get() const; };
template <typename T> T Box<T>::get() const { /* ... */ }
// → qualified_name = "Box<T>::get"   (expected "Box::get")
```

- `name` is already clean (`get`); only the qualifier leaks.
- Inline method bodies are unaffected (`Box::get`) — the same method got a different `qualified_name` depending on where it's defined.
- Long/multi-line template params (ICU `capi_helper.h` shape) push the `qualified_name` past NAME_MAX (255) → consumers deriving a filename hit "File name too long".
- Same failure mode #1043 fixed for `extends`: `name-matcher` compares the qualifier before the last `::`, and `Box<T>` ≠ the class node `Box`.

## Fix
Apply the existing `stripCppTemplateArgs` to the receiver in `extractCppReceiverType`, before the `::` split (also tolerates `::` inside template args like `Box<std::string>::get`). Reuses the #1043 helper.

## Tests
- `__tests__/extraction.test.ts`: out-of-line `Box<T>::get`/`set` now extract as `Box::get`/`Box::set`; no node carries `<` in its qualified name.
- All template-related tests (incl. #1043) pass.
