### PR TITLE
Allow verified linked worktrees under ~/.config

### DIFF
--- a/__tests__/security.test.ts
+++ b/__tests__/security.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -312,6 +313,46 @@ describe('validateProjectPath — sensitive directory blocking', () => {
       expect(validateProjectPath(dir)).toBeNull();
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('allows a verified linked worktree under .config without allowing ordinary config directories', () => {
+    const mainRepo = createTempDir();
+    const configRoot = path.join(os.homedir(), '.config');
+    fs.mkdirSync(configRoot, { recursive: true });
+    const configSandbox = fs.mkdtempSync(path.join(configRoot, 'codegraph-worktree-test-'));
+    const worktree = path.join(configSandbox, 'superpowers', 'worktrees', 'project');
+    const ordinaryConfigDir = path.join(configSandbox, 'ordinary-project');
+    fs.mkdirSync(ordinaryConfigDir, { recursive: true });
+
+    try {
+      execFileSync('git', ['init', '-q'], { cwd: mainRepo, stdio: 'ignore' });
+      fs.writeFileSync(path.join(mainRepo, 'README.md'), '# main\n');
+      execFileSync('git', ['add', '.'], { cwd: mainRepo, stdio: 'ignore' });
+      execFileSync(
+        'git',
+        ['-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-qm', 'init'],
+        { cwd: mainRepo, stdio: 'ignore' },
+      );
+      fs.mkdirSync(path.dirname(worktree), { recursive: true });
+      execFileSync('git', ['worktree', 'add', '-q', '-b', 'feature', worktree], {
+        cwd: mainRepo,
+        stdio: 'ignore',
+      });
+
+      expect(validateProjectPath(worktree)).toBeNull();
+      expect(validateProjectPath(ordinaryConfigDir)).toMatch(/sensitive directory/i);
+    } finally {
+      try {
+        execFileSync('git', ['worktree', 'remove', '--force', worktree], {
+          cwd: mainRepo,
+          stdio: 'ignore',
+        });
+      } catch {
+        // best-effort cleanup
+      }
+      cleanupTempDir(mainRepo);
+      cleanupTempDir(configSandbox);
     }
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { gitCommonDir, gitWorktreeRoot } from './sync/worktree';
 
 // ============================================================
 // SECURITY UTILITIES
@@ -45,6 +46,8 @@ const SENSITIVE_PATHS = new Set([
   '/root', '/boot', '/lib', '/lib64', '/opt',
   'c:\\', 'c:\\windows', 'c:\\windows\\system32',
 ]);
+
+const SENSITIVE_HOME_DIRS = ['.ssh', '.gnupg', '.aws', '.config'];
 
 /**
  * Config "languages" whose nodes are pure key/value DATA lifted from a config
@@ -78,6 +81,38 @@ function isWithinDir(child: string, parent: string): boolean {
     p = p.toLowerCase();
   }
   return c === p || c.startsWith(p + path.sep);
+}
+
+/**
+ * Allow the narrow linked-worktree case used by agent harnesses that place
+ * task worktrees below ~/.config while keeping ordinary config directories
+ * blocked. The linked tree must point to a standard non-sensitive main
+ * checkout through Git's shared .git directory.
+ */
+function isVerifiedLinkedWorktreeUnderConfig(
+  resolved: string,
+  configPath: string,
+  homeDir: string,
+): boolean {
+  const worktreeRoot = gitWorktreeRoot(resolved);
+  const commonDir = gitCommonDir(resolved);
+  if (!worktreeRoot || !commonDir) return false;
+  if (!isWithinDir(resolved, worktreeRoot)) return false;
+  if (!isWithinDir(worktreeRoot, configPath)) return false;
+  if (path.basename(commonDir) !== '.git') return false;
+
+  try {
+    if (!fs.statSync(path.join(worktreeRoot, '.git')).isFile()) return false;
+  } catch {
+    return false;
+  }
+
+  const mainCheckout = path.dirname(commonDir);
+  if (mainCheckout === worktreeRoot) return false;
+  for (const dir of SENSITIVE_HOME_DIRS) {
+    if (isWithinDir(mainCheckout, path.join(homeDir, dir))) return false;
+  }
+  return true;
 }
 
 /**
@@ -165,10 +200,15 @@ export function validateProjectPath(dirPath: string): string | null {
 
   // Also block common sensitive home subdirectories
   const homeDir = require('os').homedir();
-  const sensitiveHomeDirs = ['.ssh', '.gnupg', '.aws', '.config'];
-  for (const dir of sensitiveHomeDirs) {
+  for (const dir of SENSITIVE_HOME_DIRS) {
     const sensitivePath = path.join(homeDir, dir);
     if (resolved === sensitivePath || resolved.startsWith(sensitivePath + path.sep)) {
+      if (
+        dir === '.config'
+        && isVerifiedLinkedWorktreeUnderConfig(resolved, sensitivePath, homeDir)
+      ) {
+        continue;
+      }
       return `Refusing to operate on sensitive directory: ${resolved}`;
     }
   }


### PR DESCRIPTION
## Summary

CodeGraph currently rejects every project path below `~/.config` as sensitive. Agent harnesses can legitimately place task-owned Git linked worktrees there, so those worktrees cannot be indexed even when their main checkout is outside every protected home directory.

This change permits only that verified linked-worktree case while retaining the existing denial for ordinary config directories and for `.ssh`, `.gnupg`, and `.aws`.

## Security boundary

The exception requires all of the following:

- Git resolves a distinct linked-worktree root
- the worktree has a `.git` file
- its shared common directory is a standard `.git` directory
- the main checkout is outside every sensitive home directory

An ordinary directory or standalone repository below `~/.config` remains blocked.

## Test plan

- `npm run build`
- `npx vitest run __tests__/security.test.ts __tests__/worktree-detection.test.ts` — 63 passed, 2 skipped
- manual built-output check: a real linked worktree below `~/.config` is accepted while an ordinary config directory is rejected
- `git diff --check`

## Full-suite note

The local full suite reached 2373 passed and 4 skipped. Two filesystem-watcher tests timed out after the host reported `EMFILE: too many open files`; rerunning those tests alone reproduced the same host-level watcher exhaustion.