### PR TITLE
ci(release): publish npm packages with provenance and attest release bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write   # create the GitHub Release + tag, push the CHANGELOG promote
+  contents: write      # create the GitHub Release + tag, push the CHANGELOG promote
+  id-token: write      # OIDC token for npm --provenance and Sigstore signing
+  attestations: write  # store the GitHub artifact attestations for the bundles
 
 jobs:
   release:
@@ -127,6 +129,18 @@ jobs:
           ( cd release && sha256sum codegraph-* > SHA256SUMS )
           cat release/SHA256SUMS
 
+      - name: Attest build provenance for release bundles
+        # Signed, publicly-verifiable proof that each bundle (and SHA256SUMS)
+        # was built by this workflow from this repo — SHA256SUMS alone only
+        # proves integrity, not origin, since it ships next to the bundles.
+        # Verify any downloaded artifact with:
+        #   gh attestation verify <file> -R colbymchenry/codegraph
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: |
+            release/codegraph-*
+            release/SHA256SUMS
+
       - name: Release notes from CHANGELOG.md
         # The [<version>] block was guaranteed-populated by the
         # "Promote" step above, so the [Unreleased] fallback should
@@ -167,7 +181,10 @@ jobs:
               echo "skip $name@$V (already published)"
             else
               echo "publishing $name@$V"
-              ( cd "$dir" && npm publish --access public )
+              # --provenance: publish with an npm provenance attestation
+              # (needs the id-token: write permission above and the
+              # repository field pack-npm.sh writes into each package.json).
+              ( cd "$dir" && npm publish --access public --provenance )
             fi
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### New Features
+
+- Every release is now cryptographically verifiable: npm packages publish with npm provenance (the "Provenance" badge on npmjs.com, proving each version was built by this repository's release workflow from a specific commit), and the GitHub Release bundles carry signed build attestations you can check with `gh attestation verify <file> -R colbymchenry/codegraph`.
+
 ### Fixes
 
 - Callers and impact analysis no longer silently under-count a function that calls the same callee many times. When one caller contained several call sites to the same callee and an internal resolution batch boundary happened to split them, cleanup after the first batch removed the later sites' pending rows before they were ever attempted — their edges were never created, deterministically, and which edges went missing shifted with unrelated changes to the project's total reference count. Post-pass cleanup now targets the exact database row each processed reference came from. Found while validating the operator-call fix on nlohmann/json, where `write_cbor`'s 11 calls to `to_char_type` indexed as 10. (#1269)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@colbymchenry/codegraph",
   "version": "1.4.1",
   "description": "Supercharge AI coding agents with semantic code intelligence — surgical context, fewer tool calls, faster answers. 100% local.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/colbymchenry/codegraph.git"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/scripts/pack-npm.sh
+++ b/scripts/pack-npm.sh
@@ -64,7 +64,10 @@ for archive in "${archives[@]}"; do
         description: `CodeGraph self-contained bundle for ${process.env.TARGET}`,
         os: [process.env.OSV], cpu: [process.env.ARCHV],
         files: [process.env.NODEFILE, "lib", "bin"],
-        license: "MIT"
+        license: "MIT",
+        // npm --provenance refuses to publish unless this matches the repo
+        // the release workflow runs in.
+        repository: { type: "git", url: "git+https://github.com/colbymchenry/codegraph.git" }
       }, null, 2) + "\n");
     ' "$pkgdir/package.json"
   targets+=("$target")
@@ -111,7 +114,8 @@ VERSION="$VERSION" SCOPE="$SCOPE" TARGETS="${targets[*]}" \
       },
       optionalDependencies: opt,
       files: ["npm-shim.js","npm-sdk.js","dist","README.md"],
-      license: "MIT"
+      license: "MIT",
+      repository: { type: "git", url: "git+https://github.com/colbymchenry/codegraph.git" }
     }, null, 2) + "\n");
   ' "$NPM/main/package.json"
 


### PR DESCRIPTION
Makes every published artifact cryptographically verifiable as built by this repo's Release workflow — no approval process or external service signup involved; verification is done by downstream users/scanners.

- **npm provenance**: `npm publish --provenance` on the shim + per-platform packages, using the workflow's OIDC token (`id-token: write`). Shows the Provenance badge on npmjs.com tying each version to the commit and workflow that built it, and makes a stolen-`NPM_TOKEN` publish detectable.
- **GitHub Release attestations**: `actions/attest-build-provenance@v4` signs every platform bundle and `SHA256SUMS` (which previously only proved integrity, not origin, since it ships next to the bundles). Verify with `gh attestation verify <file> -R colbymchenry/codegraph`.
- `pack-npm.sh` now writes a `repository` field into the generated package.jsons — `--provenance` hard-fails without one matching the publishing repo. Root `package.json` gets the same field (also fixes the missing GitHub link on the npm page).

Validated: generated package.json snippet produces valid JSON with the field, workflow parses as YAML, `bash -n` clean. The first release run after this merge is the end-to-end test; it degrades loudly (publish fails) rather than silently if anything is misconfigured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)