### PR TITLE
feat(installer): add Grok Build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Already installed? Run `codegraph upgrade`
 
 Follow [@getcodegraph](https://x.com/getcodegraph) on X for updates.
 
-### Supercharge Claude Code, Cursor, Codex, OpenCode, Hermes Agent, Gemini, Antigravity, Kiro, and GitHub Copilot with Semantic Code Intelligence
+### Supercharge Claude Code, Cursor, Codex, OpenCode, Hermes Agent, Gemini, Antigravity, Kiro, GitHub Copilot, and Grok Build with Semantic Code Intelligence
 
 **The fastest complete code graph · surgical context · built for how agents actually work · 100% local**
 
@@ -36,6 +36,7 @@ Follow [@getcodegraph](https://x.com/getcodegraph) on X for updates.
 [![Antigravity](https://img.shields.io/badge/Antigravity-supported-blueviolet.svg)](#supported-agents)
 [![Kiro](https://img.shields.io/badge/Kiro-supported-blueviolet.svg)](#supported-agents)
 [![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-supported-blueviolet.svg)](#supported-agents)
+[![Grok Build](https://img.shields.io/badge/Grok_Build-supported-blueviolet.svg)](#supported-agents)
 
 <br>
 
@@ -105,7 +106,7 @@ In a **new terminal**, run the installer to connect CodeGraph to the agents you 
 codegraph install
 ```
 
-<sub>Detects and auto-configures Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro, and GitHub Copilot (VS Code, Copilot CLI, JetBrains IDEs) — wiring the CodeGraph MCP server into each. **This is the step that connects CodeGraph to your agent;** installing the CLI in step 1 does not do it on its own. It only wires up your agent — it does **not** index any code; building each project's graph is the separate `codegraph init` in step 3. (Shortcut: `npx @colbymchenry/codegraph` downloads and runs this in one go.)</sub>
+<sub>Detects and auto-configures Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro, GitHub Copilot (VS Code, Copilot CLI, JetBrains IDEs), and Grok Build — wiring the CodeGraph MCP server into each. **This is the step that connects CodeGraph to your agent;** installing the CLI in step 1 does not do it on its own. It only wires up your agent — it does **not** index any code; building each project's graph is the separate `codegraph init` in step 3. (Shortcut: `npx @colbymchenry/codegraph` downloads and runs this in one go.)</sub>
 
 ### 3. Initialize each project
 
@@ -376,7 +377,7 @@ npx @colbymchenry/codegraph
 ```
 
 The installer will:
-- Ask which agent(s) to configure — auto-detects installed ones from: **Claude Code**, **Cursor**, **Codex CLI**, **opencode**, **Hermes Agent**, **Gemini CLI**, **Antigravity IDE**, **Kiro**, **GitHub Copilot** (VS Code, Copilot CLI, JetBrains IDEs)
+- Ask which agent(s) to configure — auto-detects installed ones from: **Claude Code**, **Cursor**, **Codex CLI**, **opencode**, **Hermes Agent**, **Gemini CLI**, **Antigravity IDE**, **Kiro**, **GitHub Copilot** (VS Code, Copilot CLI, JetBrains IDEs), **Grok Build**
 - Prompt to install `codegraph` on your PATH (so agents can launch the MCP server)
 - Ask whether configs apply to all your projects or just this one
 - Write each chosen agent's MCP server config, plus a small marker-fenced CodeGraph section in the agent's instructions file (`CLAUDE.md` / `AGENTS.md` / `GEMINI.md`) — that's how subagents and non-MCP agents learn the `codegraph explore` command, since the MCP server's own guidance only reaches the main agent. Removed cleanly by `codegraph uninstall`.
@@ -405,7 +406,7 @@ codegraph install --print-config copilot-vscode      # same, for Copilot in VS C
 
 ### 2. Restart Your Agent
 
-Restart your agent (Claude Code / Cursor / Codex CLI / opencode / Hermes Agent / Gemini CLI / Antigravity IDE / Kiro / VS Code, the Copilot CLI, or your JetBrains IDE for GitHub Copilot) for the MCP server to load.
+Restart your agent (Claude Code / Cursor / Codex CLI / opencode / Hermes Agent / Gemini CLI / Antigravity IDE / Kiro / VS Code, the Copilot CLI, or your JetBrains IDE for GitHub Copilot / Grok Build) for the MCP server to load.
 
 ### 3. Initialize Projects
 
@@ -764,6 +765,7 @@ is written):
 - **Antigravity IDE**
 - **Kiro**
 - **GitHub Copilot** — Copilot Chat in VS Code (`copilot-vscode`), the Copilot CLI (`copilot-cli`), and the Copilot plugin in JetBrains IDEs (`copilot-jetbrains`)
+- **Grok Build**
 
 ## Supported Languages
 
@@ -862,7 +864,7 @@ MIT
 
 <div align="center">
 
-**Made for AI coding agents — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro, and GitHub Copilot**
+**Made for AI coding agents — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro, GitHub Copilot, and Grok Build**
 
 [Report Bug](https://github.com/colbymchenry/codegraph/issues) · [Request Feature](https://github.com/colbymchenry/codegraph/issues)
 

--- a/__tests__/installer-targets.test.ts
+++ b/__tests__/installer-targets.test.ts
@@ -1284,6 +1284,7 @@ describe('Installer targets — registry', () => {
     expect(getTarget('copilot-vscode')?.id).toBe('copilot-vscode');
     expect(getTarget('copilot-cli')?.id).toBe('copilot-cli');
     expect(getTarget('copilot-jetbrains')?.id).toBe('copilot-jetbrains');
+    expect(getTarget('grok')?.id).toBe('grok');
     expect(getTarget('not-a-real-target')).toBeUndefined();
   });
 
@@ -1787,6 +1788,214 @@ function listAllFiles(dir: string): string[] {
 // SAME directory (which is exactly how this bug stayed invisible), so these
 // tests deliberately split them.
 // ---------------------------------------------------------------------------
+describe('Installer targets — Grok Build', () => {
+  let tmpHome: string;
+  let tmpCwd: string;
+  let origCwd: string;
+  let homeRestore: { restore: () => void };
+
+  beforeEach(() => {
+    tmpHome = mkTmpDir('home');
+    tmpCwd = mkTmpDir('cwd');
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+    homeRestore = setHome(tmpHome);
+  });
+
+  afterEach(() => {
+    homeRestore.restore();
+    process.chdir(origCwd);
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    fs.rmSync(tmpCwd, { recursive: true, force: true });
+  });
+
+  it('grok: install writes [mcp_servers.codegraph] to ~/.grok/config.toml AND the AGENTS.md codegraph block', () => {
+    const grok = getTarget('grok')!;
+    const first = grok.install('global', { autoAllow: false });
+    const tomlPath = path.join(tmpHome, '.grok', 'config.toml');
+    const agentsMd = path.join(tmpHome, '.grok', 'AGENTS.md');
+    expect(first.files.some((f) => f.path.endsWith('config.toml'))).toBe(true);
+    expect(fs.existsSync(tomlPath)).toBe(true);
+    const toml = fs.readFileSync(tomlPath, 'utf-8');
+    expect(toml).toContain('[mcp_servers.codegraph]');
+    expect(toml).toContain('command = "codegraph"');
+    expect(toml).toContain('args = ["serve", "--mcp"]');
+    // The short instructions block IS written (subagents / non-MCP
+    // harnesses read AGENTS.md but never the MCP initialize instructions).
+    expect(fs.existsSync(agentsMd)).toBe(true);
+    const body = fs.readFileSync(agentsMd, 'utf-8');
+    expect(body).toContain('## CodeGraph');
+    expect(body).toContain('codegraph explore');
+    // Re-install is fully unchanged (byte-equal block → idempotent).
+    const second = grok.install('global', { autoAllow: false });
+    for (const f of second.files) expect(f.action).toBe('unchanged');
+  });
+
+  it('grok: install preserves a pre-existing sibling MCP server in config.toml', () => {
+    const grok = getTarget('grok')!;
+    const dir = path.join(tmpHome, '.grok');
+    fs.mkdirSync(dir, { recursive: true });
+    const tomlPath = path.join(dir, 'config.toml');
+    fs.writeFileSync(tomlPath, [
+      '[mcp_servers.github]',
+      'command = "npx"',
+      'args = ["-y", "@modelcontextprotocol/server-github"]',
+      '',
+    ].join('\n'));
+
+    grok.install('global', { autoAllow: false });
+
+    const after = fs.readFileSync(tomlPath, 'utf-8');
+    expect(after).toContain('[mcp_servers.github]');
+    expect(after).toContain('server-github');
+    expect(after).toContain('[mcp_servers.codegraph]');
+  });
+
+  it('grok: install preserves other top-level TOML sections (cli, models, features)', () => {
+    const grok = getTarget('grok')!;
+    const dir = path.join(tmpHome, '.grok');
+    fs.mkdirSync(dir, { recursive: true });
+    const tomlPath = path.join(dir, 'config.toml');
+    fs.writeFileSync(tomlPath, [
+      '[cli]',
+      'auto_update = true',
+      '',
+      '[models]',
+      'default = "grok-build"',
+      '',
+    ].join('\n'));
+
+    grok.install('global', { autoAllow: false });
+
+    const after = fs.readFileSync(tomlPath, 'utf-8');
+    expect(after).toContain('auto_update = true');
+    expect(after).toContain('default = "grok-build"');
+    expect(after).toContain('[mcp_servers.codegraph]');
+  });
+
+  it('grok: install replaces a legacy AGENTS.md codegraph block with the current one, keeping user content', () => {
+    const grok = getTarget('grok')!;
+    const dir = path.join(tmpHome, '.grok');
+    fs.mkdirSync(dir, { recursive: true });
+    const agentsMd = path.join(dir, 'AGENTS.md');
+    fs.writeFileSync(agentsMd, `# My grok notes\n\nBe terse.\n\n${LEGACY_BLOCK}\n`);
+
+    const result = grok.install('global', { autoAllow: false });
+
+    const body = fs.readFileSync(agentsMd, 'utf-8');
+    expect(body).toContain('# My grok notes');
+    expect(body).toContain('Be terse.');
+    // Self-heal: the stale pre-#529 body is gone, the current block is in.
+    expect(body).not.toContain('Prefer `codegraph_search`');
+    expect(body).toContain('codegraph explore');
+    const mdEntry = result.files.find((f) => f.path.endsWith('AGENTS.md'));
+    expect(mdEntry?.action).toBe('updated');
+  });
+
+  it('grok: uninstall strips [mcp_servers.codegraph] but leaves siblings intact', () => {
+    const grok = getTarget('grok')!;
+    const dir = path.join(tmpHome, '.grok');
+    fs.mkdirSync(dir, { recursive: true });
+    const tomlPath = path.join(dir, 'config.toml');
+    // Pre-seed with a sibling MCP server.
+    fs.writeFileSync(tomlPath, [
+      '[mcp_servers.github]',
+      'command = "npx"',
+      'args = ["-y", "@modelcontextprotocol/server-github"]',
+      '',
+      '[mcp_servers.codegraph]',
+      'command = "codegraph"',
+      'args = ["serve", "--mcp"]',
+      '',
+    ].join('\n'));
+
+    grok.uninstall('global');
+
+    const after = fs.readFileSync(tomlPath, 'utf-8');
+    expect(after).not.toContain('[mcp_servers.codegraph]');
+    expect(after).toContain('[mcp_servers.github]');
+  });
+
+  it('grok: local install writes ./.grok/config.toml (project scope)', () => {
+    const grok = getTarget('grok')!;
+    const result = grok.install('local', { autoAllow: false });
+    const tomlPath = path.join(tmpCwd, '.grok', 'config.toml');
+    // macOS symlinks /var → /private/var; fs.realpathSync normalizes both.
+    expect(result.files.some((f) => fs.realpathSync(f.path) === fs.realpathSync(tomlPath))).toBe(true);
+    expect(fs.existsSync(tomlPath)).toBe(true);
+    const toml = fs.readFileSync(tomlPath, 'utf-8');
+    expect(toml).toContain('[mcp_servers.codegraph]');
+    // Local install does NOT write AGENTS.md (that's global only).
+    expect(result.files.some((f) => f.path.endsWith('AGENTS.md'))).toBe(false);
+  });
+
+  it('grok: local uninstall removes config.toml when it becomes empty', () => {
+    const grok = getTarget('grok')!;
+    grok.install('local', { autoAllow: false });
+    const tomlPath = path.join(tmpCwd, '.grok', 'config.toml');
+    expect(fs.existsSync(tomlPath)).toBe(true);
+
+    grok.uninstall('local');
+
+    // The only entry was codegraph, so the file is removed entirely.
+    expect(fs.existsSync(tomlPath)).toBe(false);
+    // The .grok/ dir should also be cleaned up.
+    expect(fs.existsSync(path.join(tmpCwd, '.grok'))).toBe(false);
+  });
+
+  it('grok: local uninstall keeps config.toml when sibling servers exist', () => {
+    const grok = getTarget('grok')!;
+    grok.install('local', { autoAllow: false });
+    const tomlPath = path.join(tmpCwd, '.grok', 'config.toml');
+    // Add a sibling server.
+    const content = fs.readFileSync(tomlPath, 'utf-8');
+    const withSibling = content.replace(
+      /\n*$/,
+      '\n\n[mcp_servers.github]\ncommand = "npx"\nargs = ["-y", "@modelcontextprotocol/server-github"]\n',
+    );
+    fs.writeFileSync(tomlPath, withSibling);
+
+    grok.uninstall('local');
+
+    expect(fs.existsSync(tomlPath)).toBe(true);
+    const after = fs.readFileSync(tomlPath, 'utf-8');
+    expect(after).not.toContain('[mcp_servers.codegraph]');
+    expect(after).toContain('[mcp_servers.github]');
+  });
+
+  it('grok: detect before install shows alreadyConfigured=false', () => {
+    const grok = getTarget('grok')!;
+    expect(grok.detect('global').alreadyConfigured).toBe(false);
+    expect(grok.detect('local').alreadyConfigured).toBe(false);
+  });
+
+  it('grok: detect after install shows alreadyConfigured=true', () => {
+    const grok = getTarget('grok')!;
+    grok.install('global', { autoAllow: false });
+    expect(grok.detect('global').alreadyConfigured).toBe(true);
+    // Local was not installed, so it should still be false.
+    expect(grok.detect('local').alreadyConfigured).toBe(false);
+  });
+
+  it('grok: GROK_HOME env var overrides default config dir', () => {
+    const grok = getTarget('grok')!;
+    const customHome = mkTmpDir('grok-home');
+    process.env.GROK_HOME = customHome;
+    try {
+      grok.install('global', { autoAllow: false });
+      const tomlPath = path.join(customHome, 'config.toml');
+      expect(fs.existsSync(tomlPath)).toBe(true);
+      const toml = fs.readFileSync(tomlPath, 'utf-8');
+      expect(toml).toContain('[mcp_servers.codegraph]');
+      // Default location should NOT have been written.
+      expect(fs.existsSync(path.join(tmpHome, '.grok', 'config.toml'))).toBe(false);
+    } finally {
+      delete process.env.GROK_HOME;
+      fs.rmSync(customHome, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('Installer targets — opencode XDG config path (#535)', () => {
   let tmpHome: string;
   let tmpCwd: string;

--- a/src/installer/targets/grok.ts
+++ b/src/installer/targets/grok.ts
@@ -1,0 +1,199 @@
+/**
+ * Grok Build (xAI) target. Writes:
+ *
+ *   - MCP server entry to `~/.grok/config.toml` (global) or
+ *     `./.grok/config.toml` (local) as the dotted-key table
+ *     `[mcp_servers.codegraph]`. TOML — not JSON — handled by
+ *     the narrow serializer in `./toml.ts` (same as Codex).
+ *
+ * Grok reads project rules from `AGENTS.md` files natively, so no
+ * separate instructions file is needed — the MCP `initialize`
+ * response is the single source of truth for agent-facing guidance
+ * (issue #529). A prior install that wrote a `<!-- CODEGRAPH_START -->`
+ * block into an AGENTS.md is self-healed on upgrade (stripped by
+ * install, same as other targets).
+ *
+ * No permissions concept — Grok gates tool invocations through its
+ * own UI prompts rather than an external allowlist. `autoAllow` is
+ * silently ignored.
+ *
+ * Config dir resolution: `~/.grok/` (preferred) or `$GROK_HOME`
+ * (env override). Project-scoped config lives at `.grok/config.toml`
+ * relative to the project root.
+ *
+ * Docs: https://docs.x.ai/docs/mcp
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  AgentTarget,
+  DetectionResult,
+  InstallOptions,
+  Location,
+  WriteResult,
+} from './types';
+import {
+  atomicWriteFileSync,
+  getMcpServerConfig,
+  removeMarkedSection,
+  upsertInstructionsEntry,
+} from './shared';
+import {
+  CODEGRAPH_SECTION_END,
+  CODEGRAPH_SECTION_START,
+} from '../instructions-template';
+import { buildTomlTable, removeTomlTable, upsertTomlTable } from './toml';
+
+const TOML_HEADER = 'mcp_servers.codegraph';
+
+function globalConfigDir(): string {
+  const grokHome = process.env.GROK_HOME;
+  return grokHome || path.join(os.homedir(), '.grok');
+}
+function tomlConfigPath(loc: Location): string {
+  return loc === 'global'
+    ? path.join(globalConfigDir(), 'config.toml')
+    : path.join(process.cwd(), '.grok', 'config.toml');
+}
+/**
+ * Grok reads AGENTS.md natively from the project root and from
+ * `~/.grok/`. We write the marker-fenced block to the global
+ * AGENTS.md so subagents and non-MCP harnesses see it (#704).
+ * Project-local AGENTS.md at the cwd is left to the user.
+ */
+function instructionsPath(): string {
+  return path.join(globalConfigDir(), 'AGENTS.md');
+}
+
+class GrokTarget implements AgentTarget {
+  readonly id = 'grok' as const;
+  readonly displayName = 'Grok Build';
+  readonly docsUrl = 'https://docs.x.ai/docs/mcp';
+
+  supportsLocation(_loc: Location): boolean {
+    return true;
+  }
+
+  detect(loc: Location): DetectionResult {
+    const tomlPath = tomlConfigPath(loc);
+    let alreadyConfigured = false;
+    if (fs.existsSync(tomlPath)) {
+      try {
+        const content = fs.readFileSync(tomlPath, 'utf-8');
+        alreadyConfigured = content.includes(`[${TOML_HEADER}]`);
+      } catch { /* ignore */ }
+    }
+    const configDir = loc === 'global' ? globalConfigDir() : path.join(process.cwd(), '.grok');
+    const installed = fs.existsSync(configDir) || fs.existsSync(tomlPath);
+    return { installed, alreadyConfigured, configPath: tomlPath };
+  }
+
+  install(loc: Location, _opts: InstallOptions): WriteResult {
+    const files: WriteResult['files'] = [];
+
+    files.push(writeMcpEntry(loc));
+
+    // Global AGENTS.md gets the short marker-fenced CodeGraph block (#704):
+    // subagents and non-MCP harnesses read AGENTS.md but never the MCP
+    // initialize instructions. Upsert self-heals a stale pre-#529 block.
+    // Only write for global — project-local AGENTS.md is the user's domain.
+    if (loc === 'global') {
+      files.push(upsertInstructionsEntry(instructionsPath()));
+    }
+
+    return {
+      files,
+      notes: ['Restart Grok for MCP changes to take effect.'],
+    };
+  }
+
+  uninstall(loc: Location): WriteResult {
+    const files: WriteResult['files'] = [];
+
+    const tomlPath = tomlConfigPath(loc);
+    if (fs.existsSync(tomlPath)) {
+      const content = fs.readFileSync(tomlPath, 'utf-8');
+      const { content: nextContent, action } = removeTomlTable(content, TOML_HEADER);
+      if (action === 'removed') {
+        if (nextContent.trim() === '') {
+          try { fs.unlinkSync(tomlPath); } catch { /* ignore */ }
+          // Also remove the .grok/ dir if it's now empty (project-local only;
+          // never remove the global ~/.grok/ — it has other files).
+          if (loc === 'local') {
+            const dir = path.dirname(tomlPath);
+            try {
+              if (fs.readdirSync(dir).length === 0) fs.rmdirSync(dir);
+            } catch { /* ignore */ }
+          }
+        } else {
+          atomicWriteFileSync(tomlPath, nextContent.trimEnd() + '\n');
+        }
+        files.push({ path: tomlPath, action: 'removed' });
+      } else {
+        files.push({ path: tomlPath, action: 'not-found' });
+      }
+    } else {
+      files.push({ path: tomlPath, action: 'not-found' });
+    }
+
+    // Strip the marker-delimited block from global AGENTS.md if a prior
+    // install wrote one. Only for global — local AGENTS.md is the user's.
+    if (loc === 'global') {
+      files.push(removeInstructionsEntry());
+    }
+
+    return { files };
+  }
+
+  printConfig(loc: Location): string {
+    const block = buildCodegraphBlock();
+    const target = tomlConfigPath(loc);
+    return `# Add to ${target}\n\n${block}\n`;
+  }
+
+  describePaths(loc: Location): string[] {
+    const paths = [tomlConfigPath(loc)];
+    if (loc === 'global') paths.push(instructionsPath());
+    return paths;
+  }
+}
+
+function buildCodegraphBlock(): string {
+  const mcp = getMcpServerConfig();
+  return buildTomlTable(TOML_HEADER, {
+    command: mcp.command,
+    args: mcp.args,
+  });
+}
+
+function writeMcpEntry(loc: Location): WriteResult['files'][number] {
+  const file = tomlConfigPath(loc);
+  const dir = path.dirname(file);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  const block = buildCodegraphBlock();
+  const existing = fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : '';
+  const created = existing.length === 0;
+  const { content: nextContent, action } = upsertTomlTable(existing, TOML_HEADER, block);
+
+  if (action === 'unchanged') {
+    return { path: file, action: 'unchanged' };
+  }
+  atomicWriteFileSync(file, nextContent);
+  return { path: file, action: created ? 'created' : 'updated' };
+}
+
+/**
+ * Strip the marker-delimited CodeGraph block from `~/.grok/AGENTS.md`
+ * if a prior install wrote one. Used by both install (self-heal on
+ * upgrade) and uninstall — see issue #529.
+ */
+function removeInstructionsEntry(): WriteResult['files'][number] {
+  const file = instructionsPath();
+  const action = removeMarkedSection(file, CODEGRAPH_SECTION_START, CODEGRAPH_SECTION_END);
+  return { path: file, action };
+}
+
+export const grokTarget: AgentTarget = new GrokTarget();

--- a/src/installer/targets/registry.ts
+++ b/src/installer/targets/registry.ts
@@ -19,6 +19,7 @@ import { kiroTarget } from './kiro';
 import { copilotVscodeTarget } from './copilot-vscode';
 import { copilotCliTarget } from './copilot-cli';
 import { copilotJetbrainsTarget } from './copilot-jetbrains';
+import { grokTarget } from './grok';
 
 export const ALL_TARGETS: readonly AgentTarget[] = Object.freeze([
   claudeTarget,
@@ -32,6 +33,7 @@ export const ALL_TARGETS: readonly AgentTarget[] = Object.freeze([
   copilotVscodeTarget,
   copilotCliTarget,
   copilotJetbrainsTarget,
+  grokTarget,
 ]);
 
 export function getTarget(id: string): AgentTarget | undefined {

--- a/src/installer/targets/types.ts
+++ b/src/installer/targets/types.ts
@@ -19,7 +19,7 @@ export type Location = 'global' | 'local';
  * lookup. New targets add a value here when they're added to the
  * registry. Keep these short and lowercase.
  */
-export type TargetId = 'claude' | 'cursor' | 'codex' | 'opencode' | 'hermes' | 'gemini' | 'antigravity' | 'kiro' | 'copilot-vscode' | 'copilot-cli' | 'copilot-jetbrains';
+export type TargetId = 'claude' | 'cursor' | 'codex' | 'opencode' | 'hermes' | 'gemini' | 'antigravity' | 'kiro' | 'copilot-vscode' | 'copilot-cli' | 'copilot-jetbrains' | 'grok';
 
 /**
  * Result of `target.detect(location)`.


### PR DESCRIPTION
Adds a Grok Build installer target so `codegraph install` auto-wires the CodeGraph MCP server into Grok Build. 

Closes #1347 

**What is in this PR:**

- **`src/installer/targets/grok.ts`** (new) — implements `AgentTarget` for Grok Build:
  - Detects `~/.grok/config.toml` (falls back to `$GROK_HOME/config.toml`)
  - Writes `[mcp_servers.codegraph]` TOML table with `command = "codegraph"` and `args = ["serve", "--mcp"]`
  - Supports both global (`~/.grok/config.toml`) and project-scoped (`.grok/config.toml`) installs
  - Respects `GROK_HOME` env var override for config directory
  - **Surgical** `[mcp_servers.codegraph]` write — preserves all sibling MCP servers and other top-level TOML sections (`[cli]`, `[models]`, `[ui]`, `[plugins]`, `[marketplace]`, etc.)
  - **Idempotent**: byte-identical re-runs return `action: "unchanged"`
  - **Uninstall** drops only `[mcp_servers.codegraph]`; siblings and other sections intact
  - For local uninstall, removes `.grok/config.toml` and the empty `.grok/` dir if only codegraph was present
  - Writes marker-fenced CodeGraph block to `~/.grok/AGENTS.md` (global only) — subagents and non-MCP harnesses read AGENTS.md but never the MCP initialize instructions
  - No permissions concept — Grok gates tool invocations through its own UI
- **`src/installer/targets/registry.ts`** — registers `grokTarget`
- **`src/installer/targets/types.ts`** — extends `TargetId` union with `"grok"`
- **`__tests__/installer-targets.test.ts`** — 13 new grok-specific tests (sibling preservation, top-level section preservation, idempotency, uninstall, local install, local uninstall cleanup, detect transitions, GROK_HOME override)
- **`README.md`** — adds Grok Build to supported-agents badges and prose

**Why Grok Build:** Grok Build is xAI's CLI agent (https://x.ai) with a TOML-based config at `~/.grok/config.toml`. It uses `[mcp_servers.<name>]` sections for MCP server entries — the same TOML format as Codex, so it reuses the existing `toml.ts` serializer. It also supports project-scoped config at `.grok/config.toml`, making it a natural fit for both install locations.

**Test Results:**

| Suite | Result |
|-------|--------|
| `installer-targets` (176 tests) | all pass |
| Full suite (2084 tests) | all pass |
| `npm run build` (tsc) | clean |
| Live CLI smoke test (install → verify → idempotent re-run → uninstall → byte-equal round-trip) | all pass |

**Notes:**
- Follows the same single-file-per-target + registry-entry + `TargetId` union pattern as the existing targets. Mirrors the Codex test scaffolding (TOML format, global-only instructions).
- Reuses the existing TOML serializer (`toml.ts`) — no new dependency.
- Docs reference: Grok MCP server config format is documented at `~/.grok/docs/user-guide/07-mcp-servers.md` and `~/.grok/docs/user-guide/05-configuration.md`.