### PR TITLE
feat: Add basic Dockerfile and docs (#1261)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:24-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d
+
+ENV CODEGRAPH_TELEMETRY=0
+ENV DO_NOT_TRACK=1
+
+WORKDIR /workspace
+
+ARG CODEGRAPH_VERSION=1.4.1
+RUN npm install -g @colbymchenry/codegraph@${CODEGRAPH_VERSION} && npm cache clean --force
+
+ENTRYPOINT ["codegraph"]
+CMD ["serve", "--mcp"]

--- a/site/src/content/docs/getting-started/quickstart.md
+++ b/site/src/content/docs/getting-started/quickstart.md
@@ -37,3 +37,23 @@ codegraph init
 `codegraph init` creates the local `.codegraph/` directory and builds the full graph in the same step — one command, done. Your agent will use CodeGraph tools automatically when a `.codegraph/` directory exists.
 
 Next: build [Your First Graph](/codegraph/getting-started/your-first-graph/), or see the full [Installation](/codegraph/getting-started/installation/) options.
+
+
+## 4. Running in Docker
+
+You can also build a CodeGraph Docker image:
+
+```bash
+VERSION="1.4.1" # pick the latest version
+docker build --build-arg CODEGRAPH_VERSION="$VERSION" -f Dockerfile -t colbymchenry/codegraph .
+```
+
+To run a CodeGraph CLI command, add it at the end, e.g. for `codegraph init` run:
+```bash
+docker run --rm -i --init -v "$(pwd)":/workspace:rw colbymchenry/codegraph init
+```
+
+Run the CodeGraph MCP server:
+```bash
+docker run --rm -i --init -v "$(pwd)":/workspace:rw colbymchenry/codegraph
+```


### PR DESCRIPTION
- #1261: Add basic Dockerfile and instructions how to run it

Similar docker image was published here:
https://hub.docker.com/repository/docker/kernoio/codegraph