### PR TITLE
fix(db): WAL truncate at parked barriers only

### DIFF
--- a/src/db/wal-valve.ts
+++ b/src/db/wal-valve.ts
@@ -263,16 +263,14 @@ export class WalCheckpointValve {
         // SQLite reports log = checkpointed = -1, which is harmless here.
         if (res && res.busy === 0 && res.log === res.checkpointed) {
           this.sizeAtLastFullBackfill = this.db.getWalSizeBytes();
-          // Opportunistic file chop while everything is folded: best-effort —
-          // an active writer/reader turns it into a busy no-op, and the
-          // barrier-path truncate (backpressure file cap) remains the
-          // deterministic bound.
-          if (this.db.getWalSizeBytes() > this.softBytes * 2) {
-            return this.db.checkpointWalTruncate().then((t) => {
-              if (t) this.log(`timer truncate: busy=${t.busy} wal=${this.mb(this.db.getWalSizeBytes())}`);
-              this.sizeAtLastFullBackfill = this.db.getWalSizeBytes();
-            });
-          }
+          // NO truncate here. A truncate checkpoint that starts against an
+          // ACTIVE writer wins the lock race and then blocks that writer for
+          // its entire backfill — after a multi-GB single-transaction burst
+          // (edge-index recreate) that exceeds the writer's 5s busy_timeout
+          // and fails the index with "database is locked" (§7a.2 record run).
+          // The file chop happens exclusively at parked barriers
+          // (backpressure/foldNow), where the writer is awaiting us by
+          // construction and cannot collide.
         }
       })
       .catch(() => { /* best-effort */ })


### PR DESCRIPTION
The §7a.2 record run failed with `database is locked` (EXIT=1) right after edge-index-recreate: the timer-path opportunistic truncate — added in #1335 on the assumption a racing writer degrades it to a busy no-op — actually WINS the lock race and then blocks the writer for its whole backfill. Small mid-resolution folds (18–41MB, sub-100ms) masked the hazard; the recreate's multi-GB burst turned it into a >5s writer stall and a fatal.

Truncation now happens exclusively at parked barriers (`backpressure`/`foldNow`), where the writer is awaiting the valve by construction. Between barriers the file may transiently exceed the cap by one write burst, folded at the next barrier (the post-recreate hook exists for exactly the biggest one).

Dubbo gate: exit 0, WAL peak 81MB, dump byte-identical. Suites 27/27. Kernel-scale record re-run follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)