### PR TITLE
fix(mcp): replace misleading 'Budget: make at most N' with 'NO call limit'

### DIFF
--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1008,7 +1008,7 @@ export class ToolHandler {
         if (tool.name === 'codegraph_explore') {
           return {
             ...tool,
-            description: `${tool.description} Budget: make at most ${budget} calls for this project (${stats.fileCount.toLocaleString()} files indexed).`,
+            description: `${tool.description} Tip: ~${budget} calls usually orient you on a project this size (${stats.fileCount.toLocaleString()} files indexed); there is NO call limit — call again whenever a result doesn't fully cover your question.`,
           };
         }
         return tool;
@@ -3673,7 +3673,7 @@ export class ToolHandler {
         const stats = cg.getStats();
         const callBudget = getExploreBudget(stats.fileCount);
         lines.push('');
-        lines.push(`> **Explore budget: ${callBudget} calls for this project (${stats.fileCount.toLocaleString()} files indexed).** Each call covers ~6 files; if your question spans more, spend your remaining calls on the uncovered area BEFORE falling back to Read — another explore is cheaper and more complete than reading those files. Synthesize once you've used ${callBudget}.`);
+        lines.push(`> **Orientation tip: ~${callBudget} calls typically cover a project this size (${stats.fileCount.toLocaleString()} files).** There is NO call limit — if this result didn't cover your question, call again targeting the uncovered area; another explore is cheaper and more complete than Read.`);
       } catch {
         // Stats unavailable — skip budget note
       }


### PR DESCRIPTION
## Problem

`codegraph_explore`'s tool description and result footer both use **'Budget: make at most N calls'` wording. Despite the existence of a `getExploreBudget()` helper, **there is no actual call limit enforced at runtime** — the wording creates a fictional constraint.

LLM agents reading these strings interpret them as a hard limit and abandon `codegraph_explore` mid-investigation, falling back to slower grep/Read chains. The 'budget' framing degrades real-world agent behavior: agents stop exploring the moment they hit the displayed number, even when their initial result didn't fully cover the question.

## Reproduction

In an MCP-integrated agent (tested with OpenCode + oh-my-openagent):

1. Open a project with ~500 files
2. Ask a question whose answer spans more files than the displayed `budget` (e.g. `budget=2`, question needs 4 files)
3. Observe the agent abandon `codegraph_explore` after 2 calls and switch to `grep`/`Read`, even though the tool would have returned richer results on the 3rd and 4th calls

Before (description shown to agent):
```
... verbatim source grouped by file. Budget: make at most 2 calls for this project (482 files indexed).
```

Before (footer of every explore result):
```
> **Explore budget: 2 calls for this project (482 files indexed).** Each call covers ~6 files; if your question spans more, spend your remaining calls on the uncovered area BEFORE falling back to Read — another explore is cheaper and more complete than reading those files. Synthesize once you've used 2.
```

Both wordings are read as "you have at most 2 calls; stop after that." The 'BEFORE falling back to Read' phrasing actually *encourages* the wrong behavior.

## Fix

Replace both strings with orientation-focused wording that:

- Clarifies the number is a **tip** (`~N calls usually orient`), not a limit
- **Explicitly states 'NO call limit — call again whenever a result doesn't fully cover your question'**
- Preserves the original intent (steer agents toward efficient explore usage) without the unintended 'stop after N calls' side-effect

After (description):
```
... verbatim source grouped by file. Tip: ~2 calls usually orient you on a project this size (482 files indexed); there is NO call limit — call again whenever a result doesn't fully cover your question.
```

After (footer):
```
> **Orientation tip: ~2 calls typically cover a project this size (482 files).** There is NO call limit — if this result didn't cover your question, call again targeting the uncovered area; another explore is cheaper and more complete than Read.
```

## Behavior impact

- **No runtime behavior change.** No limit was enforced before; none is enforced now. The change only affects the description string shown to agents and the footer appended to `codegraph_explore` results.
- **Real-world agent behavior improves measurably.** In local testing on v1.4.1, agents that previously stopped exploring after the displayed number now continue exploring when their initial result doesn't cover the question — matching the tool's actual (unlimited) design.

## Files changed

- `src/mcp/tools.ts` — 2 line changes (description, footer). No structural changes.

## Notes

- The function `getExploreBudget()` and its heuristic are preserved — the budget number itself is useful as an *orientation hint*. The PR only removes the misleading 'limit' framing around it.
- If there is intent to add a real soft limit in the future (e.g. rate limiting), it should be implemented as an explicit runtime check, not implied via description text.

## Verification

- `grep -c 'Budget: make at most\|Explore budget:' src/mcp/tools.ts` → 0 (was 2)
- `grep -c 'NO call limit' src/mcp/tools.ts` → 2 (was 0)
- TypeScript compiles cleanly (string-only change inside template literals)