### PR TITLE
fix(index): stop verified daemon before recreating database

### DIFF
--- a/__tests__/daemon-registry.test.ts
+++ b/__tests__/daemon-registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { spawn } from 'child_process';
+import { execFileSync, spawn } from 'child_process';
 import * as fs from 'fs';
+import * as net from 'net';
 import * as os from 'os';
 import * as path from 'path';
 import {
@@ -9,8 +10,10 @@ import {
   registerDaemon,
   deregisterDaemon,
   listDaemons,
+  stopDaemonAt,
   type DaemonRecord,
 } from '../src/mcp/daemon-registry';
+import { encodeLockInfo, getDaemonPidPath, getDaemonSocketPath } from '../src/mcp/daemon-paths';
 
 /** A pid that's guaranteed dead: spawn a trivial process, let it exit, reap it. */
 async function deadPid(): Promise<number> {
@@ -23,6 +26,24 @@ async function deadPid(): Promise<number> {
 
 function rec(root: string, pid: number, startedAt = Date.now()): DaemonRecord {
   return { root, pid, version: '1.0.0', socketPath: `${root}/.codegraph/daemon.sock`, startedAt };
+}
+
+function waitForExit(child: ReturnType<typeof spawn>): Promise<void> {
+  return child.exitCode !== null
+    ? Promise.resolve()
+    : new Promise((resolve) => child.once('exit', () => resolve()));
+}
+
+function startDetachedProcess(): number {
+  const source = [
+    "const { spawn } = require('child_process');",
+    "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' });",
+    'child.unref();',
+    'console.log(child.pid);',
+  ].join(' ');
+  const pid = Number(execFileSync(process.execPath, ['-e', source], { encoding: 'utf8' }).trim());
+  if (!Number.isInteger(pid) || pid <= 0) throw new Error('could not start daemon fixture');
+  return pid;
 }
 
 describe('daemon-registry', () => {
@@ -55,6 +76,54 @@ describe('daemon-registry', () => {
       expect(isProcessAlive(NaN)).toBe(false);
       expect(isProcessAlive(await deadPid())).toBe(false);
     });
+  });
+
+  it('does not signal a live PID unless its socket identifies a CodeGraph daemon', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-foreign-daemon-'));
+    fs.mkdirSync(path.join(root, '.codegraph'));
+    const pid = startDetachedProcess();
+    fs.writeFileSync(
+      getDaemonPidPath(root),
+      encodeLockInfo({ pid, version: 'test', socketPath: path.join(root, '.codegraph', 'missing.sock'), startedAt: Date.now() }),
+    );
+
+    try {
+      const result = await stopDaemonAt(root);
+      expect(result.outcome).toBe('unverified');
+      expect(isProcessAlive(pid)).toBe(true);
+      expect(fs.existsSync(getDaemonPidPath(root))).toBe(true);
+    } finally {
+      if (isProcessAlive(pid)) process.kill(pid, 'SIGKILL');
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('stops a daemon whose socket hello matches its pidfile', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-daemon-identity-'));
+    fs.mkdirSync(path.join(root, '.codegraph'));
+    const socketPath = getDaemonSocketPath(root);
+    const pid = startDetachedProcess();
+    const server = net.createServer((socket) => {
+      socket.end(`${JSON.stringify({ codegraph: 'test', pid, socketPath })}\n`);
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(socketPath, resolve);
+    });
+    fs.writeFileSync(
+      getDaemonPidPath(root),
+      encodeLockInfo({ pid, version: 'test', socketPath, startedAt: Date.now() }),
+    );
+
+    try {
+      const result = await stopDaemonAt(root);
+      expect(result.outcome).toMatch(/term|kill/);
+      expect(isProcessAlive(pid)).toBe(false);
+    } finally {
+      if (isProcessAlive(pid)) process.kill(pid, 'SIGKILL');
+      server.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('listDaemons returns [] when nothing is registered (no dir yet)', () => {

--- a/__tests__/index-command.test.ts
+++ b/__tests__/index-command.test.ts
@@ -20,6 +20,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { CodeGraph } from '../src';
 import { DatabaseConnection } from '../src/db';
+import { encodeLockInfo, getDaemonPidPath } from '../src/mcp/daemon-paths';
 
 const BIN = path.resolve(__dirname, '../dist/bin/codegraph.js');
 
@@ -47,6 +48,27 @@ function graphCounts(dir: string): { nodes: number; edges: number } {
   } finally {
     cg.close();
   }
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function startDetachedProcess(): number {
+  const source = [
+    "const { spawn } = require('child_process');",
+    "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' });",
+    'child.unref();',
+    'console.log(child.pid);',
+  ].join(' ');
+  const pid = Number(execFileSync(process.execPath, ['-e', source], { encoding: 'utf8' }).trim());
+  if (!Number.isInteger(pid) || pid <= 0) throw new Error('could not start daemon fixture');
+  return pid;
 }
 
 describe('codegraph index — full re-index keeps the graph populated (#874)', () => {
@@ -111,6 +133,29 @@ describe('codegraph index — full re-index keeps the graph populated (#874)', (
 
     expect(afterIndex.nodes).toBe(afterInit.nodes);
     expect(afterIndex.edges).toBe(afterInit.edges);
+  });
+
+  it('refuses to recreate while a live daemon cannot be verified (#1325)', () => {
+    runCodegraph(['init'], tempDir);
+    const daemonPid = startDetachedProcess();
+    const lockPath = getDaemonPidPath(fs.realpathSync(tempDir));
+    fs.writeFileSync(
+      lockPath,
+      encodeLockInfo({
+        pid: daemonPid,
+        version: 'test',
+        socketPath: path.join(tempDir, '.codegraph', 'missing.sock'),
+        startedAt: Date.now(),
+      }),
+    );
+
+    try {
+      expect(() => runCodegraph(['index', '--quiet'], tempDir)).toThrow(/could not verify.*daemon/i);
+      expect(isAlive(daemonPid)).toBe(true);
+      expect(fs.existsSync(lockPath)).toBe(true);
+    } finally {
+      if (isAlive(daemonPid)) process.kill(daemonPid, 'SIGKILL');
+    }
   });
 });
 

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -768,6 +768,15 @@ program
         process.exit(1);
       }
 
+      // A live MCP daemon keeps SQLite handles open. Verify it by its socket
+      // before stopping it so a stale pidfile can never signal another process.
+      const { stopDaemonAt } = await import('../mcp/daemon-registry');
+      const daemonStop = await stopDaemonAt(fs.realpathSync(projectPath));
+      if (daemonStop.outcome === 'unverified' || daemonStop.outcome === 'still-running') {
+        error('Could not verify that the active CodeGraph daemon has stopped. Run `codegraph daemon` to stop it, then retry `codegraph index`.');
+        process.exit(1);
+      }
+
       const { default: CodeGraph, getDatabasePath } = await loadCodeGraph();
       // `index` is a FULL re-index — identical to a fresh `init`. RECREATE the
       // database from scratch (discard .codegraph/codegraph.db + its WAL) rather

--- a/src/mcp/daemon-registry.ts
+++ b/src/mcp/daemon-registry.ts
@@ -19,6 +19,7 @@
  * TerminateProcess). Validated live on all three.
  */
 import * as fs from 'fs';
+import * as net from 'net';
 import * as os from 'os';
 import * as path from 'path';
 import * as crypto from 'crypto';
@@ -142,35 +143,48 @@ async function waitForDeath(pid: number, timeoutMs: number): Promise<boolean> {
 export interface StopResult {
   root: string;
   pid: number | null;
-  /** 'term' graceful, 'kill' force, 'not-running' stale lock, 'no-daemon' none found. */
-  outcome: 'term' | 'kill' | 'not-running' | 'no-daemon';
+  /** 'term' graceful, 'kill' force, 'still-running' failed stop, 'not-running' stale lock, 'unverified' foreign PID, 'no-daemon' none found. */
+  outcome: 'term' | 'kill' | 'still-running' | 'not-running' | 'unverified' | 'no-daemon';
 }
 
-/**
- * Stop the daemon serving `root`: SIGTERM, wait, then SIGKILL if it won't go,
- * then sweep its artifacts. `root` must be realpath'd (match how the daemon
- * keys its socket/lockfile). Resolves the pid from the authoritative lockfile,
- * falling back to the registry.
- */
-export async function stopDaemonAt(root: string): Promise<StopResult> {
-  let pid: number | null = null;
-  try {
-    const info = decodeLockInfo(fs.readFileSync(getDaemonPidPath(root), 'utf8'));
-    pid = info?.pid ?? null;
-  } catch {
-    /* no lockfile */
-  }
-  if (pid == null) {
-    const rec = listDaemons({ prune: false }).find(
-      (r) => path.resolve(r.root) === path.resolve(root)
-    );
-    pid = rec?.pid ?? null;
-  }
+type DaemonIdentity = { pid: number; version: string; socketPath: string; startedAt: number };
 
-  if (pid == null) {
-    cleanupDaemonArtifacts(root);
-    return { root, pid: null, outcome: 'no-daemon' };
-  }
+/** Confirm the pidfile points at a live CodeGraph daemon before signalling its PID. */
+async function verifiesDaemonIdentity(info: DaemonIdentity): Promise<boolean> {
+  if (!info.socketPath || info.version === 'unknown') return false;
+  return new Promise((resolve) => {
+    const socket = net.createConnection(info.socketPath);
+    let buffer = '';
+    let settled = false;
+    const finish = (matches: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(matches);
+    };
+    const timer = setTimeout(() => finish(false), 500);
+    socket.on('error', () => finish(false));
+    socket.on('data', (chunk: Buffer | string) => {
+      buffer += chunk.toString();
+      if (buffer.length > 8192) return finish(false);
+      const newline = buffer.indexOf('\n');
+      if (newline < 0) return;
+      try {
+        const hello = JSON.parse(buffer.slice(0, newline));
+        finish(
+          hello?.codegraph === info.version &&
+          hello?.pid === info.pid &&
+          hello?.socketPath === info.socketPath,
+        );
+      } catch {
+        finish(false);
+      }
+    });
+  });
+}
+
+async function stopLiveDaemon(root: string, pid: number): Promise<StopResult> {
   if (!isProcessAlive(pid)) {
     cleanupDaemonArtifacts(root);
     return { root, pid, outcome: 'not-running' };
@@ -182,11 +196,47 @@ export async function stopDaemonAt(root: string): Promise<StopResult> {
   let outcome: StopResult['outcome'] = 'term';
   if (!(await waitForDeath(pid, 3000))) {
     try { process.kill(pid, 'SIGKILL'); } catch { /* raced to exit */ }
-    await waitForDeath(pid, 2000);
+    if (!(await waitForDeath(pid, 2000))) {
+      return { root, pid, outcome: 'still-running' };
+    }
     outcome = 'kill';
   }
   cleanupDaemonArtifacts(root);
   return { root, pid, outcome };
+}
+
+/**
+ * Stop the daemon serving `root`: SIGTERM, wait, then SIGKILL if it won't go,
+ * then sweep its artifacts. `root` must be realpath'd (match how the daemon
+ * keys its socket/lockfile). Resolves the pid from the authoritative lockfile,
+ * falling back to the registry.
+ */
+export async function stopDaemonAt(root: string): Promise<StopResult> {
+  let identity: DaemonIdentity | null = null;
+  try {
+    const info = decodeLockInfo(fs.readFileSync(getDaemonPidPath(root), 'utf8'));
+    if (info) identity = info;
+  } catch {
+    /* no lockfile */
+  }
+  if (identity == null) {
+    const rec = listDaemons({ prune: false }).find(
+      (r) => path.resolve(r.root) === path.resolve(root)
+    );
+    if (rec) identity = rec;
+  }
+
+  if (identity == null) {
+    cleanupDaemonArtifacts(root);
+    return { root, pid: null, outcome: 'no-daemon' };
+  }
+  if (!isProcessAlive(identity.pid)) {
+    return stopLiveDaemon(root, identity.pid);
+  }
+  if (!(await verifiesDaemonIdentity(identity))) {
+    return { root, pid: identity.pid, outcome: 'unverified' };
+  }
+  return stopLiveDaemon(root, identity.pid);
 }
 
 /** Stop every registered, live daemon. */


### PR DESCRIPTION
## Summary
- Stop a verified CodeGraph daemon before `codegraph index` recreates its SQLite database.
- Fail closed when daemon identity cannot be verified, so an unrelated PID is never signaled.
- Keep unverified daemon state intact and tell the user to stop it manually.

## Root cause
On Windows, a surviving MCP daemon can retain the database handle after the client exits. Recreating the database then fails with `EPERM: database file is in use`.

## Validation
- `npm run build`
- `npx vitest run __tests__/daemon-registry.test.ts __tests__/index-command.test.ts __tests__/query-pool.test.ts __tests__/mcp-daemon.test.ts` (35 passed)

## Scope
Automated tests ran on macOS. The fix uses Node IPC/PID behavior intended to be cross-platform, but Windows runtime verification is still welcome.

Fixes #1325