### PR TITLE
feat(installer): add Grok Build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Already installed? Run `codegraph upgrade`
 
 Follow [@getcodegraph](https://x.com/getcodegraph) on X for updates.
 
-### Supercharge Claude Code, Cursor, Codex, OpenCode, Hermes Agent, Gemini, Antigravity, and Kiro with Semantic Code Intelligence
+### Supercharge Claude Code, Cursor, Codex, OpenCode, Hermes Agent, Gemini, Antigravity, Kiro, and Grok Build with Semantic Code Intelligence
 
 **Surgical context · fewer tool calls · faster answers · 100% local**
 
@@ -32,6 +32,7 @@ Follow [@getcodegraph](https://x.com/getcodegraph) on X for updates.
 [![Gemini](https://img.shields.io/badge/Gemini-supported-blueviolet.svg)](#supported-agents)
 [![Antigravity](https://img.shields.io/badge/Antigravity-supported-blueviolet.svg)](#supported-agents)
 [![Kiro](https://img.shields.io/badge/Kiro-supported-blueviolet.svg)](#supported-agents)
+[![Grok Build](https://img.shields.io/badge/Grok_Build-supported-blueviolet.svg)](#supported-agents)
 
 <br>
 
@@ -102,7 +103,7 @@ In a **new terminal**, run the installer to connect CodeGraph to the agents you 
 codegraph install
 ```
 
-<sub>Detects and auto-configures Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, and Kiro — wiring the CodeGraph MCP server into each. **This is the step that connects CodeGraph to your agent;** installing the CLI in step 1 does not do it on its own. It only wires up your agent — it does **not** index any code; building each project's graph is the separate `codegraph init` in step 3. (Shortcut: `npx @colbymchenry/codegraph` downloads and runs this in one go.)</sub>
+<sub>Detects and auto-configures Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro, and Grok Build — wiring the CodeGraph MCP server into each. **This is the step that connects CodeGraph to your agent;** installing the CLI in step 1 does not do it on its own. It only wires up your agent — it does **not** index any code; building each project's graph is the separate `codegraph init` in step 3. (Shortcut: `npx @colbymchenry/codegraph` downloads and runs this in one go.)</sub>
 
 ### 3. Initialize each project
 
@@ -415,7 +416,7 @@ npx @colbymchenry/codegraph
 ```
 
 The installer will:
-- Ask which agent(s) to configure — auto-detects installed ones from: **Claude Code**, **Cursor**, **Codex CLI**, **opencode**, **Hermes Agent**, **Gemini CLI**, **Antigravity IDE**, **Kiro**
+- Ask which agent(s) to configure — auto-detects installed ones from: **Claude Code**, **Cursor**, **Codex CLI**, **opencode**, **Hermes Agent**, **Gemini CLI**, **Antigravity IDE**, **Kiro**, **Grok Build**
 - Prompt to install `codegraph` on your PATH (so agents can launch the MCP server)
 - Ask whether configs apply to all your projects or just this one
 - Write each chosen agent's MCP server config, plus a small marker-fenced CodeGraph section in the agent's instructions file (`CLAUDE.md` / `AGENTS.md` / `GEMINI.md`) — that's how subagents and non-MCP agents learn the `codegraph explore` command, since the MCP server's own guidance only reaches the main agent. Removed cleanly by `codegraph uninstall`.
@@ -442,7 +443,7 @@ codegraph install --print-config codex               # print snippet, no file wr
 
 ### 2. Restart Your Agent
 
-Restart your agent (Claude Code / Cursor / Codex CLI / opencode / Hermes Agent / Gemini CLI / Antigravity IDE / Kiro) for the MCP server to load.
+Restart your agent (Claude Code / Cursor / Codex CLI / opencode / Hermes Agent / Gemini CLI / Antigravity IDE / Kiro / Grok Build) for the MCP server to load.
 
 ### 3. Initialize Projects
 
@@ -800,6 +801,7 @@ is written):
 - **Gemini CLI**
 - **Antigravity IDE**
 - **Kiro**
+- **Grok Build**
 
 ## Supported Languages
 
@@ -908,7 +910,7 @@ MIT
 
 <div align="center">
 
-**Made for AI coding agents — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, and Kiro**
+**Made for AI coding agents — Claude Code, Cursor, Codex CLI, opencode, Hermes Agent, Gemini CLI, Antigravity IDE, Kiro, and Grok Build**
 
 [Report Bug](https://github.com/colbymchenry/codegraph/issues) · [Request Feature](https://github.com/colbymchenry/codegraph/issues)
 

--- a/__tests__/installer-targets.test.ts
+++ b/__tests__/installer-targets.test.ts
@@ -227,6 +227,36 @@ describe('Installer targets — partial-state idempotency', () => {
     expect(mdEntry?.action).toBe('updated');
   });
 
+  it('grok: writes and removes only its MCP table while preserving sibling tables', () => {
+    const grok = getTarget('grok')!;
+    const config = path.join(tmpHome, '.grok', 'config.toml');
+    fs.mkdirSync(path.dirname(config), { recursive: true });
+    fs.writeFileSync(config, [
+      '[mcp_servers.other]',
+      'command = "other-server"',
+      '',
+      '[ui]',
+      'theme = "dark"',
+      '',
+    ].join('\n'));
+
+    grok.install('global', { autoAllow: false });
+
+    const installed = fs.readFileSync(config, 'utf-8');
+    expect(installed).toContain('[mcp_servers.other]');
+    expect(installed).toContain('[ui]');
+    expect(installed).toContain('[mcp_servers.codegraph]');
+    expect(installed).toContain('command = "codegraph"');
+    expect(installed).toContain('args = ["serve", "--mcp"]');
+
+    grok.uninstall('global');
+
+    const removed = fs.readFileSync(config, 'utf-8');
+    expect(removed).toContain('[mcp_servers.other]');
+    expect(removed).toContain('[ui]');
+    expect(removed).not.toContain('[mcp_servers.codegraph]');
+  });
+
   it('opencode: prefers .jsonc when both .json and .jsonc exist', () => {
     const opencode = getTarget('opencode')!;
     const dir = path.join(tmpHome, '.config', 'opencode');

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -3,7 +3,7 @@
  *
  * Multi-target: writes MCP server config + instructions for the
  * agents the user picks (Claude Code, Cursor, Codex CLI, opencode,
- * Hermes Agent, Gemini CLI, Antigravity IDE).
+ * Hermes Agent, Gemini CLI, Antigravity IDE, Kiro, Grok Build).
  * Defaults to the Claude-only behavior for backwards compatibility
  * when no targets are explicitly chosen and nothing else is detected.
  *

--- a/src/installer/targets/grok.ts
+++ b/src/installer/targets/grok.ts
@@ -1,0 +1,143 @@
+/**
+ * Grok Build target.
+ *
+ * Grok Build reads MCP server definitions from
+ * `~/.grok/config.toml` (or `$GROK_HOME/config.toml`) and supports a
+ * project-local `.grok/config.toml`. Its MCP table format matches the
+ * Codex CLI format, so this target shares the narrow TOML helpers.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  AgentTarget,
+  DetectionResult,
+  InstallOptions,
+  Location,
+  WriteResult,
+} from './types';
+import {
+  atomicWriteFileSync,
+  getMcpServerConfig,
+  removeMarkedSection,
+  upsertInstructionsEntry,
+} from './shared';
+import {
+  CODEGRAPH_SECTION_END,
+  CODEGRAPH_SECTION_START,
+} from '../instructions-template';
+import { buildTomlTable, removeTomlTable, upsertTomlTable } from './toml';
+
+const TOML_HEADER = 'mcp_servers.codegraph';
+
+function configDir(loc: Location): string {
+  if (loc === 'local') return path.join(process.cwd(), '.grok');
+  return process.env.GROK_HOME || path.join(os.homedir(), '.grok');
+}
+
+function tomlConfigPath(loc: Location): string {
+  return path.join(configDir(loc), 'config.toml');
+}
+
+function instructionsPath(): string {
+  return path.join(configDir('global'), 'AGENTS.md');
+}
+
+class GrokTarget implements AgentTarget {
+  readonly id = 'grok' as const;
+  readonly displayName = 'Grok Build';
+  readonly docsUrl = 'https://x.ai';
+
+  supportsLocation(_loc: Location): boolean {
+    return true;
+  }
+
+  detect(loc: Location): DetectionResult {
+    const file = tomlConfigPath(loc);
+    let alreadyConfigured = false;
+    if (fs.existsSync(file)) {
+      try {
+        alreadyConfigured = fs.readFileSync(file, 'utf-8').includes(`[${TOML_HEADER}]`);
+      } catch { /* best-effort detection */ }
+    }
+    return {
+      installed: fs.existsSync(configDir(loc)),
+      alreadyConfigured,
+      configPath: file,
+    };
+  }
+
+  install(loc: Location, _opts: InstallOptions): WriteResult {
+    const files: WriteResult['files'] = [writeMcpEntry(loc)];
+    // Grok Build loads user-wide AGENTS.md for its non-MCP contexts.
+    if (loc === 'global') files.push(upsertInstructionsEntry(instructionsPath()));
+    return { files };
+  }
+
+  uninstall(loc: Location): WriteResult {
+    const files: WriteResult['files'] = [removeMcpEntry(loc)];
+    if (loc === 'global') {
+      files.push(removeInstructionsEntry());
+    } else {
+      removeEmptyLocalConfigDir();
+    }
+    return { files };
+  }
+
+  printConfig(loc: Location): string {
+    return `# Add to ${tomlConfigPath(loc)}\n\n${buildCodegraphBlock()}\n`;
+  }
+
+  describePaths(loc: Location): string[] {
+    return loc === 'global'
+      ? [tomlConfigPath(loc), instructionsPath()]
+      : [tomlConfigPath(loc)];
+  }
+}
+
+function buildCodegraphBlock(): string {
+  const mcp = getMcpServerConfig();
+  return buildTomlTable(TOML_HEADER, { command: mcp.command, args: mcp.args });
+}
+
+function writeMcpEntry(loc: Location): WriteResult['files'][number] {
+  const file = tomlConfigPath(loc);
+  const dir = path.dirname(file);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  const existing = fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : '';
+  const created = existing.length === 0;
+  const { content, action } = upsertTomlTable(existing, TOML_HEADER, buildCodegraphBlock());
+  if (action === 'unchanged') return { path: file, action };
+  atomicWriteFileSync(file, content);
+  return { path: file, action: created ? 'created' : 'updated' };
+}
+
+function removeMcpEntry(loc: Location): WriteResult['files'][number] {
+  const file = tomlConfigPath(loc);
+  if (!fs.existsSync(file)) return { path: file, action: 'not-found' };
+
+  const { content, action } = removeTomlTable(fs.readFileSync(file, 'utf-8'), TOML_HEADER);
+  if (action === 'not-found') return { path: file, action };
+  if (content.trim() === '') {
+    fs.unlinkSync(file);
+  } else {
+    atomicWriteFileSync(file, content.trimEnd() + '\n');
+  }
+  return { path: file, action };
+}
+
+function removeInstructionsEntry(): WriteResult['files'][number] {
+  const file = instructionsPath();
+  return { path: file, action: removeMarkedSection(file, CODEGRAPH_SECTION_START, CODEGRAPH_SECTION_END) };
+}
+
+function removeEmptyLocalConfigDir(): void {
+  const dir = configDir('local');
+  try {
+    if (fs.readdirSync(dir).length === 0) fs.rmdirSync(dir);
+  } catch { /* another Grok file or concurrent change: leave it alone */ }
+}
+
+export const grokTarget: AgentTarget = new GrokTarget();

--- a/src/installer/targets/registry.ts
+++ b/src/installer/targets/registry.ts
@@ -16,6 +16,7 @@ import { hermesTarget } from './hermes';
 import { geminiTarget } from './gemini';
 import { antigravityTarget } from './antigravity';
 import { kiroTarget } from './kiro';
+import { grokTarget } from './grok';
 
 export const ALL_TARGETS: readonly AgentTarget[] = Object.freeze([
   claudeTarget,
@@ -26,6 +27,7 @@ export const ALL_TARGETS: readonly AgentTarget[] = Object.freeze([
   geminiTarget,
   antigravityTarget,
   kiroTarget,
+  grokTarget,
 ]);
 
 export function getTarget(id: string): AgentTarget | undefined {

--- a/src/installer/targets/types.ts
+++ b/src/installer/targets/types.ts
@@ -19,7 +19,7 @@ export type Location = 'global' | 'local';
  * lookup. New targets add a value here when they're added to the
  * registry. Keep these short and lowercase.
  */
-export type TargetId = 'claude' | 'cursor' | 'codex' | 'opencode' | 'hermes' | 'gemini' | 'antigravity' | 'kiro';
+export type TargetId = 'claude' | 'cursor' | 'codex' | 'opencode' | 'hermes' | 'gemini' | 'antigravity' | 'kiro' | 'grok';
 
 /**
  * Result of `target.detect(location)`.


### PR DESCRIPTION
## Summary
- add a Grok Build installer target for global and project-local TOML MCP configuration
- preserve sibling MCP and top-level Grok settings on install and uninstall
- register `--target=grok`, document support, and cover preservation behavior

## Validation
- `npm run build`
- `npm test` (2527 passed, 175 skipped)

Fixes #1347