### PR TITLE
Add QML

### DIFF
--- a/__tests__/qml.test.ts
+++ b/__tests__/qml.test.ts
@@ -1,0 +1,557 @@
+/**
+ * QML Extractor Tests
+ *
+ * Tests for the QmlExtractor (QML declarative UI files) and
+ * the Qt framework resolver (C++ signal/slot extraction).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { QmlExtractor } from '../src/extraction/qml-extractor';
+import { qtResolver } from '../src/resolution/frameworks/qt';
+import { detectLanguage, isSourceFile } from '../src/extraction/grammars';
+import { blankQtMacros } from '../src/extraction/languages/c-cpp';
+
+// ---------------------------------------------------------------------------
+// Language detection
+// ---------------------------------------------------------------------------
+
+describe('QML language detection', () => {
+  it('detects .qml as qml', () => {
+    expect(detectLanguage('ui/Main.qml')).toBe('qml');
+    expect(detectLanguage('components/Button.qml')).toBe('qml');
+  });
+
+  it('treats .qml as a source file', () => {
+    expect(isSourceFile('ui/Main.qml')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QML Extractor
+// ---------------------------------------------------------------------------
+
+describe('QmlExtractor — imports', () => {
+  it('extracts a plain module import', () => {
+    const src = `
+import QtQuick
+Item {}
+`.trim();
+    const result = new QmlExtractor('ui/Main.qml', src).extract();
+    const imp = result.nodes.find((n) => n.kind === 'import');
+    expect(imp).toBeDefined();
+    expect(imp!.name).toBe('QtQuick');
+    expect(imp!.language).toBe('qml');
+  });
+
+  it('extracts a versioned import', () => {
+    const src = `
+import QtQuick 2.15
+Item {}
+`.trim();
+    const result = new QmlExtractor('ui/Main.qml', src).extract();
+    const imp = result.nodes.find((n) => n.kind === 'import');
+    expect(imp).toBeDefined();
+    expect(imp!.name).toBe('QtQuick');
+  });
+
+  it('extracts a qualified module import', () => {
+    const src = `
+import Qt.labs.platform
+Item {}
+`.trim();
+    const result = new QmlExtractor('ui/Main.qml', src).extract();
+    const imp = result.nodes.find((n) => n.kind === 'import');
+    expect(imp!.name).toBe('Qt.labs.platform');
+  });
+
+  it('extracts a directory import with quotes', () => {
+    const src = `
+import "components"
+Item {}
+`.trim();
+    const result = new QmlExtractor('ui/Main.qml', src).extract();
+    const imp = result.nodes.find((n) => n.kind === 'import');
+    expect(imp!.name).toBe('components');
+  });
+
+  it('extracts multiple imports', () => {
+    const src = `
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import "components"
+Item {}
+`.trim();
+    const result = new QmlExtractor('ui/Main.qml', src).extract();
+    const imports = result.nodes.filter((n) => n.kind === 'import');
+    expect(imports).toHaveLength(3);
+    expect(imports.map((i) => i.name)).toContain('QtQuick');
+    expect(imports.map((i) => i.name)).toContain('QtQuick.Controls');
+    expect(imports.map((i) => i.name)).toContain('components');
+  });
+});
+
+describe('QmlExtractor — root component', () => {
+  it('creates a component node named after the .qml file', () => {
+    const src = `
+import QtQuick
+Rectangle {
+  width: 200
+  height: 100
+}
+`.trim();
+    const result = new QmlExtractor('ui/MyButton.qml', src).extract();
+    const comp = result.nodes.find((n) => n.kind === 'component');
+    expect(comp).toBeDefined();
+    expect(comp!.name).toBe('MyButton');
+    expect(comp!.language).toBe('qml');
+    expect(comp!.isExported).toBe(true);
+  });
+
+  it('marks the root component as exported', () => {
+    const src = `import QtQuick\nItem {}`;
+    const result = new QmlExtractor('views/LoginView.qml', src).extract();
+    const comp = result.nodes.find((n) => n.kind === 'component');
+    expect(comp!.isExported).toBe(true);
+    expect(comp!.name).toBe('LoginView');
+  });
+});
+
+describe('QmlExtractor — property declarations', () => {
+  it('extracts a simple property', () => {
+    const src = `
+import QtQuick
+Item {
+    property int count: 0
+}
+`.trim();
+    const result = new QmlExtractor('ui/Counter.qml', src).extract();
+    const prop = result.nodes.find((n) => n.kind === 'property' && n.name === 'count');
+    expect(prop).toBeDefined();
+    expect(prop!.signature).toContain('property int count');
+  });
+
+  it('extracts a readonly property', () => {
+    const src = `
+import QtQuick
+Item {
+    readonly property string title: "Hello"
+}
+`.trim();
+    const result = new QmlExtractor('ui/Widget.qml', src).extract();
+    const prop = result.nodes.find((n) => n.kind === 'property' && n.name === 'title');
+    expect(prop).toBeDefined();
+  });
+
+  it('extracts a required property', () => {
+    const src = `
+import QtQuick
+Item {
+    required property var model
+}
+`.trim();
+    const result = new QmlExtractor('ui/Widget.qml', src).extract();
+    const prop = result.nodes.find((n) => n.kind === 'property' && n.name === 'model');
+    expect(prop).toBeDefined();
+  });
+});
+
+describe('QmlExtractor — signal declarations', () => {
+  it('extracts a no-arg signal', () => {
+    const src = `
+import QtQuick
+Item {
+    signal clicked()
+}
+`.trim();
+    const result = new QmlExtractor('ui/Button.qml', src).extract();
+    const sig = result.nodes.find((n) => n.kind === 'method' && n.name === 'clicked');
+    expect(sig).toBeDefined();
+    expect(sig!.signature).toContain('signal clicked');
+  });
+
+  it('extracts a parametrized signal', () => {
+    const src = `
+import QtQuick
+Item {
+    signal valueChanged(real newValue)
+}
+`.trim();
+    const result = new QmlExtractor('ui/Slider.qml', src).extract();
+    const sig = result.nodes.find((n) => n.kind === 'method' && n.name === 'valueChanged');
+    expect(sig).toBeDefined();
+  });
+
+  it('extracts multiple signals', () => {
+    const src = `
+import QtQuick
+Item {
+    signal pressed()
+    signal released()
+    signal clicked()
+}
+`.trim();
+    const result = new QmlExtractor('ui/Button.qml', src).extract();
+    const sigs = result.nodes.filter((n) => n.kind === 'method');
+    expect(sigs.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('QmlExtractor — signal handler bindings', () => {
+  it('extracts an onClicked handler', () => {
+    const src = `
+import QtQuick
+Item {
+    MouseArea {
+        onClicked: console.log("clicked")
+    }
+}
+`.trim();
+    const result = new QmlExtractor('ui/Main.qml', src).extract();
+    const handler = result.nodes.find((n) => n.kind === 'method' && n.name === 'onClicked');
+    expect(handler).toBeDefined();
+  });
+
+  it('emits an unresolved reference from handler to signal name', () => {
+    const src = `
+import QtQuick
+Item {
+    onFooChanged: doSomething()
+}
+`.trim();
+    const result = new QmlExtractor('ui/Main.qml', src).extract();
+    const ref = result.unresolvedReferences.find((r) => r.referenceName === 'fooChanged');
+    expect(ref).toBeDefined();
+    expect(ref!.referenceKind).toBe('calls');
+  });
+});
+
+describe('QmlExtractor — function declarations', () => {
+  it('extracts a function node', () => {
+    const src = `
+import QtQuick
+Item {
+    function greet(name) {
+        return "Hello " + name
+    }
+}
+`.trim();
+    const result = new QmlExtractor('ui/Greeter.qml', src).extract();
+    const fn = result.nodes.find((n) => n.kind === 'function' && n.name === 'greet');
+    expect(fn).toBeDefined();
+    expect(fn!.signature).toContain('function greet');
+  });
+});
+
+describe('QmlExtractor — nested components', () => {
+  it('extracts nested component instantiation', () => {
+    const src = `
+import QtQuick
+Item {
+    MyCustomWidget {
+        id: widget
+    }
+}
+`.trim();
+    const result = new QmlExtractor('ui/Main.qml', src).extract();
+    const comps = result.nodes.filter((n) => n.kind === 'component');
+    // root + nested
+    expect(comps.length).toBeGreaterThanOrEqual(2);
+    expect(comps.some((c) => c.name === 'MyCustomWidget')).toBe(true);
+  });
+
+  it('emits a contains edge between parent and nested component', () => {
+    const src = `
+import QtQuick
+Item {
+    MyWidget {}
+}
+`.trim();
+    const result = new QmlExtractor('ui/Root.qml', src).extract();
+    const containsEdges = result.edges.filter((e) => e.kind === 'contains');
+    expect(containsEdges.length).toBeGreaterThan(0);
+  });
+
+  it('emits an unresolved ref for user-defined nested types', () => {
+    const src = `
+import QtQuick
+Item {
+    MyBusinessWidget {}
+}
+`.trim();
+    const result = new QmlExtractor('ui/Root.qml', src).extract();
+    const typeRef = result.unresolvedReferences.find(
+      (r) => r.referenceName === 'MyBusinessWidget',
+    );
+    expect(typeRef).toBeDefined();
+  });
+});
+
+describe('QmlExtractor — error resilience', () => {
+  it('does not throw on empty source', () => {
+    const result = new QmlExtractor('ui/Empty.qml', '').extract();
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('does not throw on malformed QML', () => {
+    const src = 'import QtQuick\nItem { unclosed {';
+    expect(() => new QmlExtractor('ui/Bad.qml', src).extract()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Qt framework resolver — C++ extraction
+// ---------------------------------------------------------------------------
+
+describe('qtResolver — detection', () => {
+  it('detects project with .qml files', () => {
+    const ctx = {
+      getAllFiles: () => ['src/main.cpp', 'ui/Main.qml'],
+      readFile: () => null,
+      getNodesByName: () => [],
+      getNodesByQualifiedName: () => [],
+      getNodesByKind: () => [],
+      getNodesByLowerName: () => [],
+      fileExists: () => false,
+      getProjectRoot: () => '/tmp',
+      getImportMappings: () => [],
+    };
+    // @ts-expect-error — minimal mock
+    expect(qtResolver.detect(ctx)).toBe(true);
+  });
+
+  it('detects project with QObject includes', () => {
+    const ctx = {
+      getAllFiles: () => ['src/widget.h'],
+      readFile: (f: string) => (f === 'src/widget.h' ? '#include <QObject>\nclass Foo {};' : null),
+      getNodesByName: () => [],
+      getNodesByQualifiedName: () => [],
+      getNodesByKind: () => [],
+      getNodesByLowerName: () => [],
+      fileExists: () => false,
+      getProjectRoot: () => '/tmp',
+      getImportMappings: () => [],
+    };
+    // @ts-expect-error — minimal mock
+    expect(qtResolver.detect(ctx)).toBe(true);
+  });
+});
+
+describe('qtResolver — C++ signal extraction', () => {
+  const QT_CPP = `
+#include <QObject>
+
+class Counter : public QObject {
+    Q_OBJECT
+public:
+    explicit Counter(QObject *parent = nullptr);
+    int value() const;
+signals:
+    void valueChanged(int newValue);
+    void thresholdReached();
+public slots:
+    void setValue(int value);
+    void reset();
+};
+`.trim();
+
+  it('extracts signal methods from signals: section', () => {
+    const { nodes } = qtResolver.extract!('src/counter.h', QT_CPP);
+    const signals = nodes.filter((n) => n.signature?.includes('signal'));
+    expect(signals.length).toBeGreaterThanOrEqual(2);
+    expect(signals.some((n) => n.name === 'valueChanged')).toBe(true);
+    expect(signals.some((n) => n.name === 'thresholdReached')).toBe(true);
+  });
+
+  it('extracts slot methods from slots: section', () => {
+    const { nodes } = qtResolver.extract!('src/counter.h', QT_CPP);
+    const slots = nodes.filter((n) => n.signature?.includes('slot'));
+    expect(slots.length).toBeGreaterThanOrEqual(2);
+    expect(slots.some((n) => n.name === 'setValue')).toBe(true);
+    expect(slots.some((n) => n.name === 'reset')).toBe(true);
+  });
+
+  it('returns no nodes for non-Qt C++ files', () => {
+    const src = `
+#include <iostream>
+class Foo { void bar() {} };
+`.trim();
+    const { nodes } = qtResolver.extract!('src/foo.cpp', src);
+    expect(nodes).toHaveLength(0);
+  });
+});
+
+describe('qtResolver — Q_PROPERTY extraction', () => {
+  const QT_CPP = `
+#include <QObject>
+class Widget : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(int count READ count WRITE setCount NOTIFY countChanged)
+    Q_PROPERTY(QString title READ title NOTIFY titleChanged)
+};
+`.trim();
+
+  it('extracts Q_PROPERTY as property nodes', () => {
+    const { nodes } = qtResolver.extract!('src/widget.h', QT_CPP);
+    const props = nodes.filter((n) => n.kind === 'property');
+    expect(props.length).toBeGreaterThanOrEqual(2);
+    expect(props.some((n) => n.name === 'count')).toBe(true);
+    expect(props.some((n) => n.name === 'title')).toBe(true);
+  });
+
+  it('emits references to READ, WRITE, NOTIFY from Q_PROPERTY', () => {
+    const { references } = qtResolver.extract!('src/widget.h', QT_CPP);
+    const refNames = references.map((r) => r.referenceName);
+    expect(refNames).toContain('count');
+    expect(refNames).toContain('setCount');
+    expect(refNames).toContain('countChanged');
+  });
+});
+
+describe('qtResolver — connect() edge extraction', () => {
+  const SRC_MACRO = `
+#include <QObject>
+void setup(Counter *c, Display *d) {
+    QObject::connect(c, SIGNAL(valueChanged(int)), d, SLOT(displayValue(int)));
+}
+`.trim();
+
+  it('extracts SIGNAL/SLOT connect() references', () => {
+    const { references } = qtResolver.extract!('src/setup.cpp', SRC_MACRO);
+    const refNames = references.map((r) => r.referenceName);
+    expect(refNames).toContain('valueChanged');
+    expect(refNames).toContain('displayValue');
+  });
+
+  const SRC_PTR = `
+#include <QObject>
+void setup(Counter *c, Display *d) {
+    connect(c, &Counter::valueChanged, d, &Display::displayValue);
+}
+`.trim();
+
+  it('extracts pointer-style connect() references', () => {
+    const { references } = qtResolver.extract!('src/setup.cpp', SRC_PTR);
+    const refNames = references.map((r) => r.referenceName);
+    expect(refNames).toContain('valueChanged');
+    expect(refNames).toContain('displayValue');
+  });
+});
+
+describe('qtResolver — QML signal handler resolution', () => {
+  it('resolves onFooChanged to fooChanged signal in C++', () => {
+    const signalNode = {
+      id: 'sig-1',
+      kind: 'method' as const,
+      name: 'fooChanged',
+      qualifiedName: 'src/widget.h::Widget::fooChanged',
+      filePath: 'src/widget.h',
+      language: 'cpp' as const,
+      startLine: 10,
+      endLine: 10,
+      startColumn: 0,
+      endColumn: 40,
+      updatedAt: Date.now(),
+      signature: 'signal fooChanged()',
+    };
+
+    const ctx = {
+      getAllFiles: () => ['ui/Main.qml', 'src/widget.h'],
+      readFile: () => null,
+      getNodesByName: (name: string) => (name === 'fooChanged' ? [signalNode] : []),
+      getNodesByQualifiedName: () => [],
+      getNodesByKind: () => [],
+      getNodesByLowerName: () => [],
+      fileExists: () => false,
+      getProjectRoot: () => '/tmp',
+      getImportMappings: () => [],
+    };
+
+    const ref = {
+      fromNodeId: 'handler-1',
+      referenceName: 'onFooChanged',
+      referenceKind: 'calls' as const,
+      line: 5,
+      column: 4,
+      filePath: 'ui/Main.qml',
+      language: 'qml' as const,
+    };
+
+    // @ts-expect-error — minimal mock
+    const resolved = qtResolver.resolve(ref, ctx);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.targetNodeId).toBe('sig-1');
+    expect(resolved!.resolvedBy).toBe('framework');
+  });
+
+  it('does not resolve non-handler QML references', () => {
+    const ctx = {
+      getAllFiles: () => [],
+      readFile: () => null,
+      getNodesByName: () => [],
+      getNodesByQualifiedName: () => [],
+      getNodesByKind: () => [],
+      getNodesByLowerName: () => [],
+      fileExists: () => false,
+      getProjectRoot: () => '/tmp',
+      getImportMappings: () => [],
+    };
+
+    const ref = {
+      fromNodeId: 'node-1',
+      referenceName: 'someFunction',
+      referenceKind: 'calls' as const,
+      line: 3,
+      column: 0,
+      filePath: 'ui/Main.qml',
+      language: 'qml' as const,
+    };
+
+    // @ts-expect-error — minimal mock
+    const resolved = qtResolver.resolve(ref, ctx);
+    expect(resolved).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Qt C++ preParse — blankQtMacros
+// ---------------------------------------------------------------------------
+
+describe('blankQtMacros', () => {
+  it('blanks Q_OBJECT to same-length spaces', () => {
+    const src = 'class Foo : public QObject {\n    Q_OBJECT\npublic:\n};\n';
+    const result = blankQtMacros(src);
+    expect(result).not.toContain('Q_OBJECT');
+    // Byte offset preserved: Q_OBJECT is 8 chars → 8 spaces
+    expect(result.indexOf('        \n')).toBeGreaterThan(0);
+    expect(result.length).toBe(src.length);
+  });
+
+  it('blanks Q_INVOKABLE', () => {
+    const src = '    Q_INVOKABLE void doThing();\n';
+    const result = blankQtMacros(src);
+    expect(result).not.toContain('Q_INVOKABLE');
+    expect(result.length).toBe(src.length);
+  });
+
+  it('blanks signals: keyword but keeps colon', () => {
+    const src = 'signals:\n    void clicked();\n';
+    const result = blankQtMacros(src);
+    expect(result).not.toContain('signals');
+    expect(result).toContain(':');
+    expect(result.length).toBe(src.length);
+  });
+
+  it('blanks Q_SIGNALS: keyword but keeps colon', () => {
+    const src = 'Q_SIGNALS:\n    void pressed();\n';
+    const result = blankQtMacros(src);
+    expect(result).not.toContain('Q_SIGNALS');
+    expect(result).toContain(':');
+    expect(result.length).toBe(src.length);
+  });
+
+  it('passes through non-Qt source unchanged', () => {
+    const src = '#include <iostream>\nint main() { return 0; }\n';
+    const result = blankQtMacros(src);
+    expect(result).toBe(src);
+  });
+});

--- a/__tests__/qml.test.ts
+++ b/__tests__/qml.test.ts
@@ -555,3 +555,416 @@ describe('blankQtMacros', () => {
     expect(result).toBe(src);
   });
 });
+
+// ---------------------------------------------------------------------------
+// QmlExtractor — enum declarations
+// ---------------------------------------------------------------------------
+
+describe('QmlExtractor — enum declarations', () => {
+  it('extracts an enum node', () => {
+    const src = `
+import QtQuick
+Item {
+    enum Status {
+        Active,
+        Inactive,
+        Pending
+    }
+}
+`.trim();
+    const result = new QmlExtractor('ui/Widget.qml', src).extract();
+    const enumNode = result.nodes.find((n) => n.kind === 'enum' && n.name === 'Status');
+    expect(enumNode).toBeDefined();
+    expect(enumNode!.language).toBe('qml');
+  });
+
+  it('extracts enum_member nodes', () => {
+    const src = `
+import QtQuick
+Item {
+    enum Priority {
+        Low,
+        Medium,
+        High
+    }
+}
+`.trim();
+    const result = new QmlExtractor('ui/Task.qml', src).extract();
+    const members = result.nodes.filter((n) => n.kind === 'enum_member');
+    expect(members.length).toBeGreaterThanOrEqual(3);
+    expect(members.some((m) => m.name === 'Low')).toBe(true);
+    expect(members.some((m) => m.name === 'Medium')).toBe(true);
+    expect(members.some((m) => m.name === 'High')).toBe(true);
+  });
+
+  it('emits a contains edge from parent component to enum node', () => {
+    const src = `
+import QtQuick
+Item {
+    enum Mode { Read, Write }
+}
+`.trim();
+    const result = new QmlExtractor('ui/Doc.qml', src).extract();
+    const enumNode = result.nodes.find((n) => n.kind === 'enum');
+    const rootComp = result.nodes.find((n) => n.kind === 'component');
+    expect(enumNode).toBeDefined();
+    const containsEdge = result.edges.find(
+      (e) => e.kind === 'contains' && e.source === rootComp!.id && e.target === enumNode!.id,
+    );
+    expect(containsEdge).toBeDefined();
+  });
+
+  it('does not confuse enum members with nested component types', () => {
+    const src = `
+import QtQuick
+Item {
+    enum Color { Red, Green, Blue }
+    Rectangle { color: "red" }
+}
+`.trim();
+    const result = new QmlExtractor('ui/Palette.qml', src).extract();
+    // Rectangle is a built-in — not an unresolved ref
+    const typeRef = result.unresolvedReferences.find((r) => r.referenceName === 'Red');
+    expect(typeRef).toBeUndefined();
+    const enumNode = result.nodes.find((n) => n.kind === 'enum');
+    expect(enumNode).toBeDefined();
+  });
+
+  it('extracts qualified enum member names', () => {
+    const src = `
+import QtQuick
+Item {
+    enum Direction { Up, Down, Left, Right }
+}
+`.trim();
+    const result = new QmlExtractor('ui/Arrow.qml', src).extract();
+    const member = result.nodes.find((n) => n.kind === 'enum_member' && n.name === 'Up');
+    expect(member).toBeDefined();
+    expect(member!.qualifiedName).toContain('Direction');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QmlExtractor — inline components (QML 6)
+// ---------------------------------------------------------------------------
+
+describe('QmlExtractor — inline components', () => {
+  it('extracts an inline component declaration', () => {
+    const src = `
+import QtQuick
+ApplicationWindow {
+    component MyButton: Rectangle {
+        property string label: ""
+        signal clicked()
+    }
+}
+`.trim();
+    const result = new QmlExtractor('ui/Main.qml', src).extract();
+    const inlineComp = result.nodes.find((n) => n.kind === 'component' && n.name === 'MyButton');
+    expect(inlineComp).toBeDefined();
+    expect(inlineComp!.language).toBe('qml');
+  });
+
+  it('marks inline component as exported', () => {
+    const src = `
+import QtQuick
+Item {
+    component Header: Rectangle {}
+}
+`.trim();
+    const result = new QmlExtractor('ui/Layout.qml', src).extract();
+    const header = result.nodes.find((n) => n.name === 'Header' && n.kind === 'component');
+    expect(header).toBeDefined();
+    expect(header!.isExported).toBe(true);
+  });
+
+  it('emits a references edge to the base type', () => {
+    const src = `
+import QtQuick
+Item {
+    component Badge: Rectangle {}
+}
+`.trim();
+    const result = new QmlExtractor('ui/Badge.qml', src).extract();
+    // Rectangle is a built-in — but we still emit the extends reference for traceability
+    const ref = result.unresolvedReferences.find(
+      (r) => r.referenceName === 'Rectangle',
+    );
+    expect(ref).toBeDefined();
+    expect(ref!.referenceKind).toBe('references');
+  });
+
+  it('captures properties inside inline component', () => {
+    const src = `
+import QtQuick
+Item {
+    component MyLabel: Text {
+        property color textColor: "black"
+        signal tapped()
+    }
+}
+`.trim();
+    const result = new QmlExtractor('ui/Labels.qml', src).extract();
+    const prop = result.nodes.find((n) => n.kind === 'property' && n.name === 'textColor');
+    const sig = result.nodes.find((n) => n.kind === 'method' && n.name === 'tapped');
+    expect(prop).toBeDefined();
+    expect(sig).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QmlExtractor — attached type handlers
+// ---------------------------------------------------------------------------
+
+describe('QmlExtractor — attached type handlers', () => {
+  it('extracts Component.onCompleted handler', () => {
+    const src = `
+import QtQuick
+Item {
+    Component.onCompleted: console.log("ready")
+}
+`.trim();
+    const result = new QmlExtractor('ui/Main.qml', src).extract();
+    const handler = result.nodes.find(
+      (n) => n.kind === 'method' && n.name === 'Component.onCompleted',
+    );
+    expect(handler).toBeDefined();
+    expect(handler!.signature).toContain('Component.onCompleted');
+  });
+
+  it('extracts Keys.onPressed handler', () => {
+    const src = `
+import QtQuick
+Item {
+    Keys.onPressed: (event) => { event.accepted = true }
+}
+`.trim();
+    const result = new QmlExtractor('ui/Input.qml', src).extract();
+    const handler = result.nodes.find(
+      (n) => n.kind === 'method' && n.name === 'Keys.onPressed',
+    );
+    expect(handler).toBeDefined();
+  });
+
+  it('emits a calls reference from attached handler to the signal name', () => {
+    const src = `
+import QtQuick
+Item {
+    Component.onCompleted: doInit()
+}
+`.trim();
+    const result = new QmlExtractor('ui/Main.qml', src).extract();
+    const ref = result.unresolvedReferences.find((r) => r.referenceName === 'completed');
+    expect(ref).toBeDefined();
+    expect(ref!.referenceKind).toBe('calls');
+  });
+
+  it('emits a references edge to the attached type', () => {
+    const src = `
+import QtQuick
+Item {
+    Keys.onReturnPressed: submit()
+}
+`.trim();
+    const result = new QmlExtractor('ui/Form.qml', src).extract();
+    const ref = result.unresolvedReferences.find(
+      (r) => r.referenceName === 'Keys' && r.referenceKind === 'references',
+    );
+    expect(ref).toBeDefined();
+  });
+
+  it('emits a contains edge from parent component to attached handler', () => {
+    const src = `
+import QtQuick
+Item {
+    Component.onDestruction: cleanup()
+}
+`.trim();
+    const result = new QmlExtractor('ui/Widget.qml', src).extract();
+    const handler = result.nodes.find((n) => n.name === 'Component.onDestruction');
+    const comp = result.nodes.find((n) => n.kind === 'component');
+    expect(handler).toBeDefined();
+    const edge = result.edges.find(
+      (e) => e.kind === 'contains' && e.source === comp!.id && e.target === handler!.id,
+    );
+    expect(edge).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// qtResolver — QML_NAMED_ELEMENT extraction
+// ---------------------------------------------------------------------------
+
+describe('qtResolver — QML_NAMED_ELEMENT extraction', () => {
+  const QT_CPP_NAMED = `
+#include <QObject>
+#include <QtQml>
+
+class PrivateCounter : public QObject {
+    Q_OBJECT
+    QML_NAMED_ELEMENT(Counter)
+public:
+    explicit PrivateCounter(QObject *parent = nullptr);
+signals:
+    void countChanged();
+};
+`.trim();
+
+  it('extracts a component alias node with the QML name', () => {
+    const { nodes } = qtResolver.extract!('src/counter.h', QT_CPP_NAMED);
+    const alias = nodes.find((n) => n.kind === 'component' && n.name === 'Counter');
+    expect(alias).toBeDefined();
+    expect(alias!.signature).toContain('QML_NAMED_ELEMENT(Counter)');
+  });
+
+  it('component alias node is in the same file as the C++ class', () => {
+    const { nodes } = qtResolver.extract!('src/counter.h', QT_CPP_NAMED);
+    const alias = nodes.find((n) => n.kind === 'component' && n.name === 'Counter');
+    expect(alias!.filePath).toBe('src/counter.h');
+  });
+
+  it('emits a references relation from the alias to the QML name', () => {
+    const { references } = qtResolver.extract!('src/counter.h', QT_CPP_NAMED);
+    const ref = references.find((r) => r.referenceName === 'Counter');
+    expect(ref).toBeDefined();
+  });
+
+  it('detects Qt project via QML_ELEMENT pattern', () => {
+    const ctx = {
+      getAllFiles: () => ['src/widget.h'],
+      readFile: (f: string) =>
+        f === 'src/widget.h'
+          ? 'class Foo {\n    QML_ELEMENT\n};\n'
+          : null,
+      getNodesByName: () => [],
+      getNodesByQualifiedName: () => [],
+      getNodesByKind: () => [],
+      getNodesByLowerName: () => [],
+      fileExists: () => false,
+      getProjectRoot: () => '/tmp',
+      getImportMappings: () => [],
+    };
+    // @ts-expect-error — minimal mock
+    expect(qtResolver.detect(ctx)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// qtResolver — qmlRegisterType extraction
+// ---------------------------------------------------------------------------
+
+describe('qtResolver — qmlRegisterType extraction', () => {
+  const SRC_SAME_NAME = `
+#include <QObject>
+#include <QtQml>
+class Counter : public QObject { Q_OBJECT };
+
+void registerTypes() {
+    qmlRegisterType<Counter>("com.example", 1, 0, "Counter");
+}
+`.trim();
+
+  const SRC_DIFF_NAME = `
+#include <QObject>
+#include <QtQml>
+class InternalCounter : public QObject { Q_OBJECT };
+
+void registerTypes() {
+    qmlRegisterType<InternalCounter>("com.example", 1, 0, "Counter");
+}
+`.trim();
+
+  it('does NOT create a duplicate alias when QML name equals C++ class name', () => {
+    const { nodes } = qtResolver.extract!('src/register.cpp', SRC_SAME_NAME);
+    const aliases = nodes.filter((n) => n.kind === 'component' && n.name === 'Counter');
+    expect(aliases).toHaveLength(0);
+  });
+
+  it('creates a component alias node when QML name differs from C++ class name', () => {
+    const { nodes } = qtResolver.extract!('src/register.cpp', SRC_DIFF_NAME);
+    const alias = nodes.find((n) => n.kind === 'component' && n.name === 'Counter');
+    expect(alias).toBeDefined();
+    expect(alias!.signature).toContain('InternalCounter');
+  });
+
+  it('emits a references edge to the C++ class being registered', () => {
+    const { references } = qtResolver.extract!('src/register.cpp', SRC_DIFF_NAME);
+    const ref = references.find((r) => r.referenceName === 'InternalCounter');
+    expect(ref).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// qtResolver — Q_INVOKABLE method extraction
+// ---------------------------------------------------------------------------
+
+describe('qtResolver — Q_INVOKABLE method extraction', () => {
+  const QT_CPP = `
+#include <QObject>
+class Calculator : public QObject {
+    Q_OBJECT
+public:
+    explicit Calculator(QObject *parent = nullptr);
+    Q_INVOKABLE double add(double a, double b);
+    Q_INVOKABLE QString formatResult(double value) const;
+    int notInvokable() const;
+signals:
+    void resultReady(double result);
+};
+`.trim();
+
+  it('extracts Q_INVOKABLE methods as method nodes tagged invokable', () => {
+    const { nodes } = qtResolver.extract!('src/calculator.h', QT_CPP);
+    const invokable = nodes.filter((n) => n.signature?.startsWith('invokable'));
+    expect(invokable.length).toBeGreaterThanOrEqual(2);
+    expect(invokable.some((n) => n.name === 'add')).toBe(true);
+    expect(invokable.some((n) => n.name === 'formatResult')).toBe(true);
+  });
+
+  it('does not tag non-Q_INVOKABLE methods as invokable', () => {
+    const { nodes } = qtResolver.extract!('src/calculator.h', QT_CPP);
+    const invokable = nodes.filter((n) => n.signature?.startsWith('invokable'));
+    expect(invokable.some((n) => n.name === 'notInvokable')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// blankQtMacros — Qt 6 QML macros
+// ---------------------------------------------------------------------------
+
+describe('blankQtMacros — Qt 6 QML macros', () => {
+  it('blanks QML_ELEMENT to same-length spaces', () => {
+    const src = 'class Foo : public QObject {\n    Q_OBJECT\n    QML_ELEMENT\n};\n';
+    const result = blankQtMacros(src);
+    expect(result).not.toContain('QML_ELEMENT');
+    expect(result.length).toBe(src.length);
+  });
+
+  it('blanks QML_NAMED_ELEMENT(Name) including parentheses', () => {
+    const src = 'class Counter : public QObject {\n    Q_OBJECT\n    QML_NAMED_ELEMENT(Counter)\n};\n';
+    const result = blankQtMacros(src);
+    expect(result).not.toContain('QML_NAMED_ELEMENT');
+    expect(result.length).toBe(src.length);
+  });
+
+  it('blanks QML_SINGLETON', () => {
+    const src = 'class App : public QObject {\n    Q_OBJECT\n    QML_SINGLETON\n};\n';
+    const result = blankQtMacros(src);
+    expect(result).not.toContain('QML_SINGLETON');
+    expect(result.length).toBe(src.length);
+  });
+
+  it('blanks QML_UNCREATABLE("reason") including parentheses', () => {
+    const src = '    QML_UNCREATABLE("Cannot create abstract type")\n';
+    const result = blankQtMacros(src);
+    expect(result).not.toContain('QML_UNCREATABLE');
+    expect(result.length).toBe(src.length);
+  });
+
+  it('blanks QML_VALUE_TYPE(name) including parentheses', () => {
+    const src = '    QML_VALUE_TYPE(point)\n';
+    const result = blankQtMacros(src);
+    expect(result).not.toContain('QML_VALUE_TYPE');
+    expect(result.length).toBe(src.length);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1431,7 +1431,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/extraction/grammars.ts
+++ b/src/extraction/grammars.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import { Parser, Language as WasmLanguage } from 'web-tree-sitter';
 import { Language } from '../types';
 
-export type GrammarLanguage = Exclude<Language, 'svelte' | 'vue' | 'astro' | 'liquid' | 'razor' | 'yaml' | 'twig' | 'xml' | 'properties' | 'unknown'>;
+export type GrammarLanguage = Exclude<Language, 'svelte' | 'vue' | 'astro' | 'liquid' | 'razor' | 'yaml' | 'twig' | 'xml' | 'properties' | 'qml' | 'unknown'>;
 
 /**
  * WASM filename map — maps each language to its .wasm grammar file
@@ -108,6 +108,8 @@ export const EXTENSION_MAP: Record<string, Language> = {
   '.luau': 'luau',
   '.m': 'objc',
   '.mm': 'objc',
+  // Qt/QML declarative UI files
+  '.qml': 'qml',
   // XML: file-level tracking; the MyBatis extractor matches `<mapper namespace="...">`
   // shape and emits SQL-statement nodes (other XML returns empty).
   '.xml': 'xml',
@@ -358,7 +360,7 @@ export function isFileLevelOnlyLanguage(language: Language): boolean {
  * Get all supported languages (those with grammar definitions).
  */
 export function getSupportedLanguages(): Language[] {
-  return [...(Object.keys(WASM_GRAMMAR_FILES) as GrammarLanguage[]), 'svelte', 'vue', 'astro', 'liquid'];
+  return [...(Object.keys(WASM_GRAMMAR_FILES) as GrammarLanguage[]), 'svelte', 'vue', 'astro', 'liquid', 'qml'];
 }
 
 /**
@@ -436,6 +438,7 @@ export function getLanguageDisplayName(language: Language): string {
     twig: 'Twig',
     xml: 'XML',
     properties: 'Java properties',
+    qml: 'QML',
     unknown: 'Unknown',
   };
   return names[language] || language;

--- a/src/extraction/languages/c-cpp.ts
+++ b/src/extraction/languages/c-cpp.ts
@@ -262,7 +262,11 @@ export function blankQtMacros(source: string): string {
   if (!source.includes('Q_OBJECT') && !source.includes('Q_GADGET') &&
       !source.includes('signals') && !source.includes('Q_SIGNALS') &&
       !source.includes('slots') && !source.includes('Q_SLOTS') &&
-      !source.includes('Q_INVOKABLE')) {
+      !source.includes('Q_INVOKABLE') &&
+      !source.includes('QML_ELEMENT') && !source.includes('QML_NAMED_ELEMENT') &&
+      !source.includes('QML_SINGLETON') && !source.includes('QML_UNCREATABLE') &&
+      !source.includes('QML_INTERFACE') && !source.includes('QML_VALUE_TYPE') &&
+      !source.includes('QML_ANONYMOUS')) {
     return source;
   }
 
@@ -278,7 +282,12 @@ export function blankQtMacros(source: string): string {
     // Blank signals:/Q_SIGNALS: keyword (keep the colon for brace-balance)
     .replace(/\b(Q_SIGNALS|signals)\s*(?=:)/g, (m) => ' '.repeat(m.length))
     // Blank slots:/Q_SLOTS: keyword (keep the colon)
-    .replace(/\b(Q_SLOTS|slots)\s*(?=:)/g, (m) => ' '.repeat(m.length));
+    .replace(/\b(Q_SLOTS|slots)\s*(?=:)/g, (m) => ' '.repeat(m.length))
+    // Qt 6 QML registration macros — blank with arguments (parenthesised forms)
+    // e.g. QML_NAMED_ELEMENT(Counter), QML_UNCREATABLE("reason"), QML_VALUE_TYPE(point)
+    .replace(/\bQML_(?:NAMED_ELEMENT|UNCREATABLE|VALUE_TYPE|ANONYMOUS)\s*\([^)]*\)/g, (m) => ' '.repeat(m.length))
+    // Blank zero-arg Qt 6 QML macros
+    .replace(/\bQML_(?:ELEMENT|SINGLETON|INTERFACE|FOREIGN\s*\([^)]*\))\b/g, (m) => ' '.repeat(m.length));
 }
 
 /**

--- a/src/extraction/languages/c-cpp.ts
+++ b/src/extraction/languages/c-cpp.ts
@@ -239,10 +239,62 @@ export function blankCppExportMacros(source: string): string {
   );
 }
 
+/**
+ * Blank Qt-specific macros that cause tree-sitter to misparse C++ class bodies.
+ *
+ * - `Q_OBJECT` / `Q_GADGET` / `Q_NAMESPACE`: zero-arg macros inside class bodies
+ *   that tree-sitter may parse as variable declarations, polluting the symbol table.
+ *   Replaced with equal-length spaces to preserve byte offsets.
+ *
+ * - `signals:` / `Q_SIGNALS:` → `public:` / spaces+`:` (length-preserving):
+ *   tree-sitter doesn't know `signals` is an access specifier alias. Replacing it
+ *   with `public:` (which is shorter) is not byte-safe, so we blank the keyword
+ *   portion and keep the `:`. This leaves `        :` on the line, which tree-sitter
+ *   parses as a lone labeled statement, but the actual function declarations that
+ *   follow are still extracted by the Qt framework resolver's `extract()` pass,
+ *   so no symbols are lost.
+ *
+ * - `Q_INVOKABLE` (7 chars → 7 spaces): marks methods visible to QML. Blanking it
+ *   lets tree-sitter see a clean return type and extract the method normally.
+ */
+export function blankQtMacros(source: string): string {
+  // Fast path: not a Qt file
+  if (!source.includes('Q_OBJECT') && !source.includes('Q_GADGET') &&
+      !source.includes('signals') && !source.includes('Q_SIGNALS') &&
+      !source.includes('slots') && !source.includes('Q_SLOTS') &&
+      !source.includes('Q_INVOKABLE')) {
+    return source;
+  }
+
+  return source
+    // Blank zero-arg class macros (preserve byte count)
+    .replace(/\bQ_OBJECT\b/g, (m) => ' '.repeat(m.length))
+    .replace(/\bQ_GADGET\b/g, (m) => ' '.repeat(m.length))
+    .replace(/\bQ_NAMESPACE\b/g, (m) => ' '.repeat(m.length))
+    // Blank Q_INVOKABLE (return type follows immediately after — keep the space)
+    .replace(/\bQ_INVOKABLE\b/g, (m) => ' '.repeat(m.length))
+    // Blank Q_REQUIRED_RESULT, Q_DECL_OVERRIDE, Q_DECL_FINAL (Qt 4/5 compat macros)
+    .replace(/\bQ_(?:REQUIRED_RESULT|DECL_OVERRIDE|DECL_FINAL|DECL_NOEXCEPT|DECL_DEPRECATED(?:_X)?|DECL_UNUSED|DECL_PURE_VIRTUAL)\b/g, (m) => ' '.repeat(m.length))
+    // Blank signals:/Q_SIGNALS: keyword (keep the colon for brace-balance)
+    .replace(/\b(Q_SIGNALS|signals)\s*(?=:)/g, (m) => ' '.repeat(m.length))
+    // Blank slots:/Q_SLOTS: keyword (keep the colon)
+    .replace(/\b(Q_SLOTS|slots)\s*(?=:)/g, (m) => ' '.repeat(m.length));
+}
+
+/**
+ * Combined preParse for C++: first blank Qt macros, then blank export macros.
+ */
+export function cppPreParse(source: string): string {
+  return blankCppExportMacros(blankQtMacros(source));
+}
+
 export const cppExtractor: LanguageExtractor = {
   // Recover macro-annotated class/struct definitions (`class MYMODULE_API Foo : Base`)
   // that tree-sitter otherwise misparses into a phantom function (#1061/#946).
-  preParse: blankCppExportMacros,
+  // Also blanks Qt class macros (Q_OBJECT, Q_INVOKABLE, signals:, slots:) so the
+  // surrounding C++ parses cleanly; Qt signal/slot method nodes are extracted by
+  // the Qt framework resolver's extract() pass.
+  preParse: cppPreParse,
   functionTypes: ['function_definition'],
   classTypes: ['class_specifier'],
   methodTypes: ['function_definition'],

--- a/src/extraction/qml-extractor.ts
+++ b/src/extraction/qml-extractor.ts
@@ -1,0 +1,619 @@
+/**
+ * QML Extractor
+ *
+ * Custom extractor for Qt QML declarative UI files.
+ *
+ * QML files define a component hierarchy with embedded JavaScript.
+ * Rather than relying on a tree-sitter WASM grammar, this extractor
+ * uses a structured line-by-line parser that tracks nesting depth,
+ * exactly as the DFM/Svelte/Vue extractors do.
+ *
+ * Extracted information:
+ *  - `import` statements → `import` nodes + `imports` edges to C++ or QML modules
+ *  - Root component type → `component` node (the file IS the component)
+ *  - Nested component instantiations (`TypeName { }`) → `component` nodes + `instantiates` edges
+ *  - `property T name` declarations → `property` nodes
+ *  - `signal name(params)` declarations → `method` nodes
+ *  - `function name(…)` declarations → `function` nodes; body delegated to JS extractor
+ *  - Signal handler bindings (`onFoo: …`) → `method` nodes (handlers)
+ */
+
+import { Node, Edge, ExtractionResult, ExtractionError, UnresolvedReference, Language } from '../types';
+import { generateNodeId } from './tree-sitter-helpers';
+import { TreeSitterExtractor } from './tree-sitter';
+import { isLanguageSupported } from './grammars';
+
+// Common QtQuick built-in types that are instantiated by users but defined in Qt itself
+const QT_BUILTIN_TYPES = new Set([
+  'Item', 'Rectangle', 'Text', 'Image', 'MouseArea', 'Column', 'Row', 'Grid',
+  'Flow', 'Repeater', 'Loader', 'Timer', 'Animation', 'NumberAnimation',
+  'ColorAnimation', 'PropertyAnimation', 'SequentialAnimation', 'ParallelAnimation',
+  'State', 'Transition', 'Behavior', 'Connections', 'Component', 'Binding',
+  'ListView', 'GridView', 'PathView', 'ScrollView', 'ScrollBar', 'Flickable',
+  'TextInput', 'TextEdit', 'FocusScope', 'Keys', 'MultiPointTouchArea',
+  'PinchArea', 'DropArea', 'Canvas', 'ShaderEffect', 'Window', 'ApplicationWindow',
+  'Dialog', 'Popup', 'Drawer', 'Menu', 'MenuItem', 'MenuBar', 'ToolBar',
+  'ToolButton', 'Button', 'TextField', 'ComboBox', 'CheckBox', 'RadioButton',
+  'Slider', 'SpinBox', 'ProgressBar', 'BusyIndicator', 'Label', 'Frame',
+  'GroupBox', 'TabBar', 'TabButton', 'StackView', 'SwipeView', 'PageIndicator',
+  'Action', 'ActionGroup', 'ButtonGroup', 'ItemDelegate', 'CheckDelegate',
+  'RadioDelegate', 'SwitchDelegate', 'SwipeDelegate', 'RoundButton',
+  'AbstractButton', 'Container', 'Control', 'Pane', 'Page', 'StackLayout',
+  'ColumnLayout', 'RowLayout', 'GridLayout', 'Layout', 'Shortcut',
+  'SystemTrayIcon', 'ClosePolicy', 'SplitView', 'SplitHandle',
+  'HorizontalHeaderView', 'VerticalHeaderView', 'TreeView', 'TableView',
+  'QtObject', 'WorkerScript', 'XmlListModel', 'XmlRole',
+  'PathLine', 'PathCurve', 'PathArc', 'PathSvg', 'PathQuad', 'PathCubic',
+  'PathPercent', 'PathAttribute', 'PathAngleArc',
+  'PropertyChanges', 'AnchorChanges', 'ParentChange', 'StateChangeScript',
+  'AnchorAnimation', 'ParentAnimation', 'PathAnimation', 'PauseAnimation',
+  'ScriptAction', 'PropertyAction',
+  'Accessible', 'LayoutMirroring', 'TextDocument',
+  'QAbstractItemModel',
+]);
+
+// ---------------------------------------------------------------------------
+// Regex patterns for QML syntax
+// ---------------------------------------------------------------------------
+
+/** import QtQuick 2.15 / import "path" / import "script.js" as Alias */
+const RE_IMPORT = /^\s*import\s+(.+?)(?:\s+as\s+(\w+))?\s*$/;
+
+/** Component instantiation: TypeName { or Qualified.Type { */
+const RE_COMPONENT = /^\s*([A-Z][A-Za-z0-9]*(?:\.[A-Za-z][A-Za-z0-9]*)*)\s*\{/;
+
+/** property [readonly] [required] T name [: value] */
+const RE_PROPERTY = /^\s*(?:(?:readonly|required|default|final|virtual|override)\s+)*property\s+(\S+(?:<[^>]+>)?)\s+(\w+)/;
+
+/** signal name[(params)] */
+const RE_SIGNAL = /^\s*signal\s+(\w+)\s*(?:\(([^)]*)\))?/;
+
+/** function name(params) */
+const RE_FUNCTION = /^\s*function\s+(\w+)\s*\(([^)]*)\)/;
+
+/** Signal handler binding: onFoo: or onFoo { */
+const RE_HANDLER = /^\s*(on[A-Z][A-Za-z0-9.]*)\s*[:{]/;
+
+/** id: identifier */
+const RE_ID = /^\s*id\s*:\s*(\w+)/;
+
+/** enum declaration inside QML: enum Name { } */
+const RE_ENUM = /^\s*enum\s+(\w+)\s*\{/;
+
+/** Closing brace on its own line */
+const RE_CLOSE = /^\s*\}/;
+
+// ---------------------------------------------------------------------------
+
+interface ComponentFrame {
+  nodeId: string;
+  startLine: number;
+  typeName: string;
+  qmlId?: string;
+}
+
+export class QmlExtractor {
+  private readonly filePath: string;
+  private readonly lines: string[];
+  private nodes: Node[] = [];
+  private edges: Edge[] = [];
+  private unresolvedRefs: UnresolvedReference[] = [];
+  private errors: ExtractionError[] = [];
+
+  constructor(filePath: string, source: string) {
+    this.filePath = filePath;
+    this.lines = source.split('\n');
+  }
+
+  extract(): ExtractionResult {
+    const startTime = Date.now();
+
+    try {
+      this.parse();
+    } catch (error) {
+      this.errors.push({
+        message: `QML extraction error: ${error instanceof Error ? error.message : String(error)}`,
+        severity: 'error',
+        code: 'parse_error',
+      });
+    }
+
+    return {
+      nodes: this.nodes,
+      edges: this.edges,
+      unresolvedReferences: this.unresolvedRefs,
+      errors: this.errors,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+
+  private parse(): void {
+    const { lines } = this;
+
+    // Stack of open component frames (one per nesting level)
+    const stack: ComponentFrame[] = [];
+
+    // The outermost component is named after the .qml file
+    const fileName = this.filePath.split(/[/\\]/).pop() ?? this.filePath;
+    const componentName = fileName.replace(/\.qml$/i, '');
+
+    // Track line numbers for block-close detection
+    const braceDepth: number[] = []; // open-brace lines for each frame
+
+    // Pending JS function body collector
+    let jsBodyLines: string[] = [];
+    let jsBodyStartLine = 0;
+    let jsBodyDepth = 0;
+    let jsFunctionNodeId: string | null = null;
+    let jsFunctionParentId: string | null = null;
+
+    // Depth of the currently open multi-line enum (skip its body)
+    let enumDepth = 0;
+
+    // Track overall brace depth (lines with excess `{` can open a component)
+    let braceBalance = 0;
+
+    for (let i = 0; i < lines.length; i++) {
+      const rawLine = lines[i] ?? '';
+      const lineNum = i + 1;
+
+      // ------------------------------------------------------------------
+      // Strip inline // comments for pattern matching (but keep the line
+      // length by replacing with spaces to preserve column positions).
+      // Simple heuristic — doesn't handle comments inside strings.
+      // ------------------------------------------------------------------
+      const commentIdx = rawLine.indexOf('//');
+      const line = commentIdx >= 0 ? rawLine.slice(0, commentIdx) : rawLine;
+
+      // ------------------------------------------------------------------
+      // If we are inside a JS function body, collect lines until depth=0
+      // ------------------------------------------------------------------
+      if (jsFunctionNodeId !== null) {
+        jsBodyLines.push(rawLine);
+        for (const ch of rawLine) {
+          if (ch === '{') jsBodyDepth++;
+          else if (ch === '}') {
+            jsBodyDepth--;
+            if (jsBodyDepth === 0) {
+              // End of function body — delegate to JS extractor
+              this.extractJsBody(
+                jsBodyLines.join('\n'),
+                jsBodyStartLine,
+                jsFunctionNodeId,
+                jsFunctionParentId ?? (stack[stack.length - 1]?.nodeId ?? ''),
+              );
+              jsFunctionNodeId = null;
+              jsFunctionParentId = null;
+              jsBodyLines = [];
+              break;
+            }
+          }
+        }
+        continue;
+      }
+
+      // ------------------------------------------------------------------
+      // Import statements (top-level only, outside any component block)
+      // ------------------------------------------------------------------
+      if (braceBalance === 0) {
+        const importMatch = line.match(RE_IMPORT);
+        if (importMatch) {
+          this.handleImport(importMatch[1]!.trim(), importMatch[2], lineNum);
+          continue;
+        }
+      }
+
+      // ------------------------------------------------------------------
+      // Track opening braces — detect component instantiations
+      // ------------------------------------------------------------------
+      const componentMatch = line.match(RE_COMPONENT);
+      if (componentMatch) {
+        const typeName = componentMatch[1]!;
+        const parentFrame = stack[stack.length - 1];
+
+        if (stack.length === 0) {
+          // Root component — this IS the .qml file component
+          const nodeId = generateNodeId(this.filePath, 'component', componentName, lineNum);
+          const node: Node = {
+            id: nodeId,
+            kind: 'component',
+            name: componentName,
+            qualifiedName: `${this.filePath}::${componentName}`,
+            filePath: this.filePath,
+            language: 'qml',
+            startLine: lineNum,
+            endLine: lines.length, // will be patched on close
+            startColumn: 0,
+            endColumn: 0,
+            isExported: true,
+            updatedAt: Date.now(),
+          };
+          this.nodes.push(node);
+          stack.push({ nodeId, startLine: lineNum, typeName });
+
+          // Emit an `extends` edge: this component extends its root type
+          // (unless it's a QtObject or unknown built-in without user interest)
+          if (typeName !== componentName) {
+            this.unresolvedRefs.push({
+              fromNodeId: nodeId,
+              referenceName: typeName,
+              referenceKind: 'references',
+              line: lineNum,
+              column: 0,
+              filePath: this.filePath,
+              language: 'qml',
+            });
+          }
+        } else if (parentFrame) {
+          // Nested component — skip anonymous grouping objects (lowercase first
+          // letter) and Connections / Behavior that don't represent new types.
+          const firstChar = typeName[0];
+          if (firstChar && firstChar === firstChar.toUpperCase()) {
+            const nodeId = generateNodeId(this.filePath, 'component', `${typeName}@L${lineNum}`, lineNum);
+            const node: Node = {
+              id: nodeId,
+              kind: 'component',
+              name: typeName,
+              qualifiedName: `${this.filePath}::${typeName}@L${lineNum}`,
+              filePath: this.filePath,
+              language: 'qml',
+              startLine: lineNum,
+              endLine: lineNum, // patched on close
+              startColumn: (line.match(/^\s*/)?.[0].length ?? 0),
+              endColumn: 0,
+              updatedAt: Date.now(),
+            };
+            this.nodes.push(node);
+
+            // contains edge: parent component → nested component
+            this.edges.push({
+              source: parentFrame.nodeId,
+              target: nodeId,
+              kind: 'contains',
+            });
+
+            // instantiates edge: component file → the Qt/QML type it instantiates
+            if (!QT_BUILTIN_TYPES.has(typeName)) {
+              this.unresolvedRefs.push({
+                fromNodeId: parentFrame.nodeId,
+                referenceName: typeName,
+                referenceKind: 'references',
+                line: lineNum,
+                column: 0,
+                filePath: this.filePath,
+                language: 'qml',
+              });
+            }
+
+            stack.push({ nodeId, startLine: lineNum, typeName });
+          } else {
+            stack.push({ nodeId: parentFrame.nodeId, startLine: lineNum, typeName: '' });
+          }
+        }
+
+        braceBalance++;
+        braceDepth.push(lineNum);
+        continue;
+      }
+
+      // ------------------------------------------------------------------
+      // Enum declaration — skip its body (integers only, not components)
+      // ------------------------------------------------------------------
+      if (enumDepth === 0) {
+        const enumMatch = line.match(RE_ENUM);
+        if (enumMatch) {
+          enumDepth = 1;
+          braceBalance++;
+          continue;
+        }
+      } else {
+        // track nested braces inside enum
+        for (const ch of line) {
+          if (ch === '{') enumDepth++;
+          else if (ch === '}') {
+            enumDepth--;
+            if (enumDepth === 0) { braceBalance--; break; }
+          }
+        }
+        continue;
+      }
+
+      // ------------------------------------------------------------------
+      // Closing brace — pop component stack
+      // ------------------------------------------------------------------
+      if (RE_CLOSE.test(line) && braceBalance > 0) {
+        braceBalance--;
+        braceDepth.pop();
+
+        if (stack.length > 0) {
+          const frame = stack[stack.length - 1]!;
+          // Patch the endLine of the corresponding node
+          const node = this.nodes.find((n) => n.id === frame.nodeId);
+          if (node && node.endLine === (node.startLine)) {
+            node.endLine = lineNum;
+          } else if (node && node.endLine > node.startLine) {
+            // root component — leave it, already covers file
+          }
+          stack.pop();
+        }
+        continue;
+      }
+
+      // ------------------------------------------------------------------
+      // Content inside a component block
+      // ------------------------------------------------------------------
+      const currentFrame = stack[stack.length - 1];
+      if (!currentFrame) continue;
+
+      // id: identifier
+      const idMatch = line.match(RE_ID);
+      if (idMatch) {
+        currentFrame.qmlId = idMatch[1];
+        // Patch the node name to include the QML id for clarity
+        const node = this.nodes.find((n) => n.id === currentFrame.nodeId);
+        if (node && node.name !== componentName) {
+          // For nested nodes, enrich qualifiedName with the id
+          node.qualifiedName = `${this.filePath}::${idMatch[1]}(${currentFrame.typeName})`;
+        }
+        continue;
+      }
+
+      // property T name [: value]
+      const propMatch = line.match(RE_PROPERTY);
+      if (propMatch) {
+        const [, propType, propName] = propMatch;
+        const nodeId = generateNodeId(this.filePath, 'property', propName!, lineNum);
+        const node: Node = {
+          id: nodeId,
+          kind: 'property',
+          name: propName!,
+          qualifiedName: `${this.filePath}::${propName}`,
+          filePath: this.filePath,
+          language: 'qml',
+          startLine: lineNum,
+          endLine: lineNum,
+          startColumn: (line.match(/^\s*/)?.[0].length ?? 0),
+          endColumn: line.length,
+          signature: `property ${propType} ${propName}`,
+          updatedAt: Date.now(),
+        };
+        this.nodes.push(node);
+        this.edges.push({ source: currentFrame.nodeId, target: nodeId, kind: 'contains' });
+        continue;
+      }
+
+      // signal name(params)
+      const signalMatch = line.match(RE_SIGNAL);
+      if (signalMatch) {
+        const [, sigName, sigParams] = signalMatch;
+        const nodeId = generateNodeId(this.filePath, 'method', sigName!, lineNum);
+        const node: Node = {
+          id: nodeId,
+          kind: 'method',
+          name: sigName!,
+          qualifiedName: `${this.filePath}::${sigName}`,
+          filePath: this.filePath,
+          language: 'qml',
+          startLine: lineNum,
+          endLine: lineNum,
+          startColumn: (line.match(/^\s*/)?.[0].length ?? 0),
+          endColumn: line.length,
+          signature: `signal ${sigName}(${sigParams ?? ''})`,
+          updatedAt: Date.now(),
+        };
+        this.nodes.push(node);
+        this.edges.push({ source: currentFrame.nodeId, target: nodeId, kind: 'contains' });
+        continue;
+      }
+
+      // function name(params) { ... }
+      const funcMatch = line.match(RE_FUNCTION);
+      if (funcMatch) {
+        const [, funcName, funcParams] = funcMatch;
+        const nodeId = generateNodeId(this.filePath, 'function', funcName!, lineNum);
+        const node: Node = {
+          id: nodeId,
+          kind: 'function',
+          name: funcName!,
+          qualifiedName: `${this.filePath}::${funcName}`,
+          filePath: this.filePath,
+          language: 'qml',
+          startLine: lineNum,
+          endLine: lineNum, // patched when body ends
+          startColumn: (line.match(/^\s*/)?.[0].length ?? 0),
+          endColumn: 0,
+          signature: `function ${funcName}(${funcParams ?? ''})`,
+          updatedAt: Date.now(),
+        };
+        this.nodes.push(node);
+        this.edges.push({ source: currentFrame.nodeId, target: nodeId, kind: 'contains' });
+
+        // Start collecting the function body for JS extraction
+        const braceInLine = rawLine.indexOf('{');
+        if (braceInLine >= 0) {
+          jsFunctionNodeId = nodeId;
+          jsFunctionParentId = currentFrame.nodeId;
+          jsBodyStartLine = lineNum;
+          jsBodyLines = [rawLine.slice(braceInLine)];
+          jsBodyDepth = 1;
+          // count any } on this same line
+          for (let ci = braceInLine + 1; ci < rawLine.length; ci++) {
+            if (rawLine[ci] === '{') jsBodyDepth++;
+            else if (rawLine[ci] === '}') {
+              jsBodyDepth--;
+              if (jsBodyDepth === 0) {
+                this.extractJsBody(jsBodyLines.join('\n'), jsBodyStartLine, nodeId, currentFrame.nodeId);
+                jsFunctionNodeId = null;
+                break;
+              }
+            }
+          }
+        }
+        continue;
+      }
+
+      // Signal handler: onFoo: or onFoo {
+      const handlerMatch = line.match(RE_HANDLER);
+      if (handlerMatch) {
+        const handlerName = handlerMatch[1]!;
+        // Skip generic "on" properties that aren't signal handlers
+        if (handlerName.length > 2) {
+          const nodeId = generateNodeId(this.filePath, 'method', handlerName, lineNum);
+          const node: Node = {
+            id: nodeId,
+            kind: 'method',
+            name: handlerName,
+            qualifiedName: `${this.filePath}::${handlerName}`,
+            filePath: this.filePath,
+            language: 'qml',
+            startLine: lineNum,
+            endLine: lineNum,
+            startColumn: (line.match(/^\s*/)?.[0].length ?? 0),
+            endColumn: line.length,
+            signature: `handler ${handlerName}`,
+            updatedAt: Date.now(),
+          };
+          this.nodes.push(node);
+          this.edges.push({ source: currentFrame.nodeId, target: nodeId, kind: 'contains' });
+
+          // Derive the signal name from the handler: onFoo → foo, onFooChanged → fooChanged
+          const signalName = handlerName[2]!.toLowerCase() + handlerName.slice(3);
+          this.unresolvedRefs.push({
+            fromNodeId: nodeId,
+            referenceName: signalName,
+            referenceKind: 'calls',
+            line: lineNum,
+            column: 0,
+            filePath: this.filePath,
+            language: 'qml',
+          });
+        }
+        // Handle block handler body — treat as JS if followed by {
+        const braceInLine = rawLine.lastIndexOf('{');
+        if (braceInLine >= 0 && handlerMatch[0].endsWith('{')) {
+          // Multi-line handler body — delegate to JS
+          const handlerNodeId = generateNodeId(this.filePath, 'method', handlerName, lineNum);
+          jsFunctionNodeId = handlerNodeId;
+          jsFunctionParentId = currentFrame.nodeId;
+          jsBodyStartLine = lineNum;
+          jsBodyLines = [rawLine.slice(braceInLine)];
+          jsBodyDepth = 1;
+          for (let ci = braceInLine + 1; ci < rawLine.length; ci++) {
+            if (rawLine[ci] === '{') jsBodyDepth++;
+            else if (rawLine[ci] === '}') {
+              jsBodyDepth--;
+              if (jsBodyDepth === 0) {
+                this.extractJsBody(jsBodyLines.join('\n'), jsBodyStartLine, handlerNodeId, currentFrame.nodeId);
+                jsFunctionNodeId = null;
+                break;
+              }
+            }
+          }
+        }
+        continue;
+      }
+
+      // ------------------------------------------------------------------
+      // Any remaining lines with a { that we haven't matched as a component
+      // still increment the brace balance so the stack stays correct.
+      // ------------------------------------------------------------------
+      for (const ch of rawLine) {
+        if (ch === '{') { braceBalance++; braceDepth.push(lineNum); }
+        else if (ch === '}' && braceBalance > 0) {
+          braceBalance--;
+          braceDepth.pop();
+          if (stack.length > 0) {
+            const frame = stack[stack.length - 1]!;
+            const node = this.nodes.find((n) => n.id === frame.nodeId);
+            if (node && node.endLine < lineNum) node.endLine = lineNum;
+            // Only pop real component frames, not anonymous binding braces
+            // We already handled } on its own line above. Skip here to avoid double-pop.
+          }
+          break; // one } per line in this fallback
+        }
+      }
+    }
+
+    // Patch root component endLine to cover the whole file
+    if (this.nodes.length > 0) {
+      const root = this.nodes[0];
+      if (root && root.startLine > 0) {
+        root.endLine = lines.length;
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Import handling
+  // -------------------------------------------------------------------------
+
+  private handleImport(source: string, alias: string | undefined, lineNum: number): void {
+    // Normalize: strip version specifier (e.g. "QtQuick 2.15" → "QtQuick")
+    const cleanSource = source.replace(/\s+\d+(?:\.\d+)?$/, '').replace(/^["']|["']$/g, '');
+    const moduleName = cleanSource;
+    const importText = alias ? `import ${source} as ${alias}` : `import ${source}`;
+
+    const nodeId = generateNodeId(this.filePath, 'import', moduleName, lineNum);
+    const node: Node = {
+      id: nodeId,
+      kind: 'import',
+      name: moduleName,
+      qualifiedName: `${this.filePath}::import::${moduleName}`,
+      filePath: this.filePath,
+      language: 'qml',
+      startLine: lineNum,
+      endLine: lineNum,
+      startColumn: 0,
+      endColumn: importText.length,
+      signature: importText,
+      updatedAt: Date.now(),
+    };
+    this.nodes.push(node);
+
+    // Unresolved reference so the resolution pass can link to the C++ module or
+    // another QML component directory.
+    this.unresolvedRefs.push({
+      fromNodeId: nodeId,
+      referenceName: moduleName,
+      referenceKind: 'imports',
+      line: lineNum,
+      column: 0,
+      filePath: this.filePath,
+      language: 'qml',
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // JS body delegation
+  // -------------------------------------------------------------------------
+
+  private extractJsBody(
+    body: string,
+    startLine: number,
+    functionNodeId: string,
+    _parentNodeId: string,
+  ): void {
+    const lang: Language = 'javascript';
+    if (!isLanguageSupported(lang)) return;
+
+    try {
+      const extractor = new TreeSitterExtractor(this.filePath, body, lang);
+      const result = extractor.extract();
+
+      for (const ref of result.unresolvedReferences) {
+        // Offset lines back to the .qml file positions
+        this.unresolvedRefs.push({
+          ...ref,
+          fromNodeId: functionNodeId,
+          line: ref.line + startLine - 1,
+          language: 'qml',
+        });
+      }
+    } catch {
+      // Silently skip JS parse errors inside QML — the QML extraction itself
+      // is still valid; only intra-body call edges are lost.
+    }
+  }
+}

--- a/src/extraction/qml-extractor.ts
+++ b/src/extraction/qml-extractor.ts
@@ -74,6 +74,12 @@ const RE_FUNCTION = /^\s*function\s+(\w+)\s*\(([^)]*)\)/;
 /** Signal handler binding: onFoo: or onFoo { */
 const RE_HANDLER = /^\s*(on[A-Z][A-Za-z0-9.]*)\s*[:{]/;
 
+/** Attached type signal handler: TypeName.onFoo: or TypeName.onFoo { */
+const RE_ATTACHED_HANDLER = /^\s*([A-Z][A-Za-z0-9]*)\.(on[A-Z][A-Za-z0-9]*)\s*[:{]/;
+
+/** Inline component declaration (QML 6): component Name: BaseType { */
+const RE_INLINE_COMPONENT = /^\s*component\s+([A-Z][A-Za-z0-9]*)\s*:\s*([A-Z][A-Za-z0-9]*(?:\.[A-Za-z][A-Za-z0-9]*)*)\s*\{/;
+
 /** id: identifier */
 const RE_ID = /^\s*id\s*:\s*(\w+)/;
 
@@ -149,8 +155,10 @@ export class QmlExtractor {
     let jsFunctionNodeId: string | null = null;
     let jsFunctionParentId: string | null = null;
 
-    // Depth of the currently open multi-line enum (skip its body)
+    // Currently open enum block
     let enumDepth = 0;
+    let enumNodeId: string | null = null;
+    let enumName = '';
 
     // Track overall brace depth (lines with excess `{` can open a component)
     let braceBalance = 0;
@@ -203,6 +211,49 @@ export class QmlExtractor {
           this.handleImport(importMatch[1]!.trim(), importMatch[2], lineNum);
           continue;
         }
+      }
+
+      // ------------------------------------------------------------------
+      // Inline component declaration (QML 6): component Name: BaseType { ... }
+      // Must be checked before RE_COMPONENT since `component` starts lowercase.
+      // ------------------------------------------------------------------
+      const inlineCompMatch = line.match(RE_INLINE_COMPONENT);
+      if (inlineCompMatch) {
+        const [, inlineName, baseType] = inlineCompMatch;
+        const parentFrame = stack[stack.length - 1];
+        const nodeId = generateNodeId(this.filePath, 'component', inlineName!, lineNum);
+        const node: Node = {
+          id: nodeId,
+          kind: 'component',
+          name: inlineName!,
+          qualifiedName: `${this.filePath}::${inlineName}`,
+          filePath: this.filePath,
+          language: 'qml',
+          startLine: lineNum,
+          endLine: lineNum, // patched on close
+          startColumn: (line.match(/^\s*/)?.[0].length ?? 0),
+          endColumn: 0,
+          isExported: true,
+          updatedAt: Date.now(),
+        };
+        this.nodes.push(node);
+        if (parentFrame) {
+          this.edges.push({ source: parentFrame.nodeId, target: nodeId, kind: 'contains' });
+        }
+        // extends edge to the base type
+        this.unresolvedRefs.push({
+          fromNodeId: nodeId,
+          referenceName: baseType!,
+          referenceKind: 'references',
+          line: lineNum,
+          column: 0,
+          filePath: this.filePath,
+          language: 'qml',
+        });
+        stack.push({ nodeId, startLine: lineNum, typeName: inlineName! });
+        braceBalance++;
+        braceDepth.push(lineNum);
+        continue;
       }
 
       // ------------------------------------------------------------------
@@ -299,23 +350,75 @@ export class QmlExtractor {
       }
 
       // ------------------------------------------------------------------
-      // Enum declaration — skip its body (integers only, not components)
+      // Enum declaration — extract enum + enum_member nodes
       // ------------------------------------------------------------------
       if (enumDepth === 0) {
         const enumMatch = line.match(RE_ENUM);
         if (enumMatch) {
+          enumName = enumMatch[1]!;
+          const nodeId = generateNodeId(this.filePath, 'enum', enumName, lineNum);
+          enumNodeId = nodeId;
+          const currentFrame = stack[stack.length - 1];
+          const enumNode: Node = {
+            id: nodeId,
+            kind: 'enum',
+            name: enumName,
+            qualifiedName: `${this.filePath}::${enumName}`,
+            filePath: this.filePath,
+            language: 'qml',
+            startLine: lineNum,
+            endLine: lineNum,
+            startColumn: (line.match(/^\s*/)?.[0].length ?? 0),
+            endColumn: 0,
+            updatedAt: Date.now(),
+          };
+          this.nodes.push(enumNode);
+          if (currentFrame) {
+            this.edges.push({ source: currentFrame.nodeId, target: nodeId, kind: 'contains' });
+          }
           enumDepth = 1;
           braceBalance++;
+
+          // Process the rest of the opening line — may contain members and close
+          const afterBrace = line.slice(line.indexOf('{') + 1);
+          this.extractEnumLineMembers(afterBrace, enumName, nodeId, lineNum);
+          // Check if the enum closes on the same line
+          let depth = 1;
+          for (const ch of afterBrace) {
+            if (ch === '{') depth++;
+            else if (ch === '}') {
+              depth--;
+              if (depth === 0) {
+                enumNode.endLine = lineNum;
+                enumNodeId = null;
+                enumDepth = 0;
+                braceBalance--;
+                break;
+              }
+            }
+          }
           continue;
         }
       } else {
-        // track nested braces inside enum
+        // Track depth and extract enum members
+        let closed = false;
         for (const ch of line) {
           if (ch === '{') enumDepth++;
           else if (ch === '}') {
             enumDepth--;
-            if (enumDepth === 0) { braceBalance--; break; }
+            if (enumDepth === 0) {
+              const enumNode = this.nodes.find((n) => n.id === enumNodeId);
+              if (enumNode) enumNode.endLine = lineNum;
+              enumNodeId = null;
+              braceBalance--;
+              closed = true;
+              break;
+            }
           }
+        }
+        // Extract member identifier from lines inside the enum body
+        if (!closed && enumDepth > 0 && enumNodeId) {
+          this.extractEnumLineMembers(line, enumName, enumNodeId, lineNum);
         }
         continue;
       }
@@ -515,6 +618,54 @@ export class QmlExtractor {
         continue;
       }
 
+      // Attached type signal handler: TypeName.onFoo: or TypeName.onFoo {
+      // e.g. Component.onCompleted, Keys.onPressed, Layout.onChildrenChanged
+      const attachedMatch = line.match(RE_ATTACHED_HANDLER);
+      if (attachedMatch) {
+        const [, attachedType, handlerName] = attachedMatch;
+        const fullName = `${attachedType}.${handlerName}`;
+        const nodeId = generateNodeId(this.filePath, 'method', fullName, lineNum);
+        const node: Node = {
+          id: nodeId,
+          kind: 'method',
+          name: fullName,
+          qualifiedName: `${this.filePath}::${fullName}`,
+          filePath: this.filePath,
+          language: 'qml',
+          startLine: lineNum,
+          endLine: lineNum,
+          startColumn: (line.match(/^\s*/)?.[0].length ?? 0),
+          endColumn: line.length,
+          signature: `handler ${fullName}`,
+          updatedAt: Date.now(),
+        };
+        this.nodes.push(node);
+        this.edges.push({ source: currentFrame.nodeId, target: nodeId, kind: 'contains' });
+
+        // Emit reference to the underlying signal name (strip "on" prefix and lowercase)
+        const signalName = handlerName![2]!.toLowerCase() + handlerName!.slice(3);
+        this.unresolvedRefs.push({
+          fromNodeId: nodeId,
+          referenceName: signalName,
+          referenceKind: 'calls',
+          line: lineNum,
+          column: 0,
+          filePath: this.filePath,
+          language: 'qml',
+        });
+        // Also emit reference to the attached type (e.g. Component, Keys)
+        this.unresolvedRefs.push({
+          fromNodeId: nodeId,
+          referenceName: attachedType!,
+          referenceKind: 'references',
+          line: lineNum,
+          column: 0,
+          filePath: this.filePath,
+          language: 'qml',
+        });
+        continue;
+      }
+
       // ------------------------------------------------------------------
       // Any remaining lines with a { that we haven't matched as a component
       // still increment the brace balance so the stack stays correct.
@@ -547,6 +698,36 @@ export class QmlExtractor {
 
   // -------------------------------------------------------------------------
   // Import handling
+  // -------------------------------------------------------------------------
+  // Enum member helper — extract identifiers from a fragment of enum body text
+  // (handles both single-line `{ A, B, C }` and multi-line member lines).
+  // -------------------------------------------------------------------------
+
+  private extractEnumLineMembers(fragment: string, eName: string, eNodeId: string, lineNum: number): void {
+    // Split on commas and closing braces, take only word tokens
+    const tokens = fragment.replace(/\{/g, '').replace(/\}/g, '').split(',');
+    for (const tok of tokens) {
+      // May contain `= value` assignments — strip them
+      const memberName = tok.replace(/=.*$/, '').trim().split(/\s+/)[0];
+      if (!memberName || !/^\w+$/.test(memberName)) continue;
+      const memberId = generateNodeId(this.filePath, 'enum_member', `${eName}.${memberName}`, lineNum);
+      this.nodes.push({
+        id: memberId,
+        kind: 'enum_member',
+        name: memberName,
+        qualifiedName: `${this.filePath}::${eName}::${memberName}`,
+        filePath: this.filePath,
+        language: 'qml',
+        startLine: lineNum,
+        endLine: lineNum,
+        startColumn: 0,
+        endColumn: 0,
+        updatedAt: Date.now(),
+      });
+      this.edges.push({ source: eNodeId, target: memberId, kind: 'contains' });
+    }
+  }
+
   // -------------------------------------------------------------------------
 
   private handleImport(source: string, alias: string | undefined, lineNum: number): void {

--- a/src/extraction/tree-sitter.ts
+++ b/src/extraction/tree-sitter.ts
@@ -28,6 +28,7 @@ import { SvelteExtractor } from './svelte-extractor';
 import { AstroExtractor } from './astro-extractor';
 import { DfmExtractor } from './dfm-extractor';
 import { VueExtractor } from './vue-extractor';
+import { QmlExtractor } from './qml-extractor';
 import { MyBatisExtractor } from './mybatis-extractor';
 import {
   getAllFrameworkResolvers,
@@ -5714,6 +5715,10 @@ export function extractFromSource(
   } else if (detectedLanguage === 'vue') {
     // Use custom extractor for Vue
     const extractor = new VueExtractor(filePath, source);
+    result = extractor.extract();
+  } else if (detectedLanguage === 'qml') {
+    // Use custom extractor for Qt QML declarative UI
+    const extractor = new QmlExtractor(filePath, source);
     result = extractor.extract();
   } else if (detectedLanguage === 'astro') {
     // Use custom extractor for Astro (frontmatter + template delegation)

--- a/src/resolution/frameworks/index.ts
+++ b/src/resolution/frameworks/index.ts
@@ -27,6 +27,7 @@ import { swiftObjcBridgeResolver } from './swift-objc';
 import { reactNativeBridgeResolver } from './react-native';
 import { expoModulesResolver } from './expo-modules';
 import { fabricViewResolver } from './fabric';
+import { qtResolver } from './qt';
 
 /**
  * All registered framework resolvers
@@ -70,6 +71,8 @@ const FRAMEWORK_RESOLVERS: FrameworkResolver[] = [
   expoModulesResolver,
   // React Native Fabric / Codegen view components — TS spec → component nodes
   fabricViewResolver,
+  // Qt — C++ Q_PROPERTY/signals/slots extraction + QML↔C++ signal-slot bridging
+  qtResolver,
 ];
 
 /**

--- a/src/resolution/frameworks/qt.ts
+++ b/src/resolution/frameworks/qt.ts
@@ -7,8 +7,11 @@
  *  - Extracts `Q_PROPERTY(...)` macro declarations as `property` nodes
  *  - Extracts `signals:` / `Q_SIGNALS:` section declarations as `method` nodes
  *  - Extracts `slots:` / `Q_SLOTS:` section declarations as `method` nodes
+ *  - Extracts `Q_INVOKABLE` methods as QML-callable method nodes
  *  - Emits edges for `QObject::connect()` SIGNAL/SLOT macro calls
  *  - Emits edges for modern `connect(&Src, &Src::sig, &Dst, &Dst::slot)` calls
+ *  - Extracts `QML_NAMED_ELEMENT(X)` as a `component` alias node
+ *  - Detects `qmlRegisterType<T>(uri, maj, min, "QmlName")` and creates alias nodes
  *
  * QML side:
  *  - Resolves QML signal handler names (`onFooChanged`) to C++ `fooChanged` signals
@@ -77,6 +80,30 @@ const RE_Q_PROPERTY = /Q_PROPERTY\s*\(\s*([^)]+)\)/g;
  */
 const RE_CONNECT_MACRO = /connect\s*\(\s*\w[^,]*,\s*SIGNAL\s*\(\s*(\w+)\s*\([^)]*\)\s*\)\s*,\s*\w[^,]*,\s*SLOT\s*\(\s*(\w+)\s*\([^)]*\)\s*\)/g;
 const RE_CONNECT_PTR = /connect\s*\(\s*\w[^,]*,\s*&\s*(\w+)\s*::\s*(\w+)\s*,\s*\w[^,]*,\s*&\s*(\w+)\s*::\s*(\w+)/g;
+
+/**
+ * QML_NAMED_ELEMENT(QmlTypeName) — registers the C++ class under a custom QML name.
+ * Only the first occurrence per class is used.
+ */
+const RE_QML_NAMED_ELEMENT = /\bQML_NAMED_ELEMENT\s*\(\s*(\w+)\s*\)/g;
+
+/**
+ * QML_ELEMENT — registers the C++ class as a QML element with the same name.
+ * Presence is checked during detection to confirm a file uses Qt 6 QML patterns.
+ */
+const QML_ELEMENT_PATTERN = /\bQML_ELEMENT\b/;
+
+/**
+ * qmlRegisterType<CppClass>("uri", major, minor, "QmlName")
+ * Captures the C++ type and the QML element name.
+ */
+const RE_QML_REGISTER_TYPE = /qmlRegisterType\s*<\s*(\w+)\s*>\s*\(\s*"[^"]*"\s*,\s*\d+\s*,\s*\d+\s*,\s*"(\w+)"\s*\)/g;
+
+/**
+ * Q_INVOKABLE method declaration outside of signals:/slots: sections.
+ * Captures the return type and method name for tagging as invokable.
+ */
+const RE_Q_INVOKABLE_DECL = /^\s*Q_INVOKABLE\s+(?:(?:virtual|inline|static|explicit|const)\s+)*(\S[\s\S]*?)\s+(\w+)\s*\(([^)]*)\)\s*(?:const\s*)?(?:override\s*)?(?:final\s*)?(?:noexcept\s*)?;/;
 
 /**
  * Matches a class or struct that contains Q_OBJECT/Q_GADGET.
@@ -209,6 +236,31 @@ function extractQtFromCpp(
         });
       }
     }
+
+    // Extract Q_INVOKABLE methods in the class body (outside signals/slots)
+    // These are callable from QML and should be tagged as invokable.
+    if (!currentSection && currentClass) {
+      const invokableMatch = line.match(RE_Q_INVOKABLE_DECL);
+      if (invokableMatch) {
+        const methodName = invokableMatch[2]!;
+        const params = invokableMatch[3] ?? '';
+        const nodeId = generateNodeId(filePath, 'method', `${currentClass}::${methodName}`, lineNum);
+        nodes.push({
+          id: nodeId,
+          kind: 'method',
+          name: methodName,
+          qualifiedName: `${filePath}::${currentClass}::${methodName}`,
+          filePath,
+          language: 'cpp' as Language,
+          startLine: lineNum,
+          endLine: lineNum,
+          startColumn: line.search(/\S/),
+          endColumn: line.trimEnd().length,
+          signature: `invokable ${methodName}(${params})`,
+          updatedAt: Date.now(),
+        });
+      }
+    }
   }
 
   // ---- pass 2: Q_PROPERTY extraction ----
@@ -319,6 +371,79 @@ function extractQtFromCpp(
     );
   }
 
+  // ---- pass 4: QML_NAMED_ELEMENT extraction ----
+  // Creates a `component` alias node so QML `TypeName { }` can resolve to the C++ class.
+  RE_QML_NAMED_ELEMENT.lastIndex = 0;
+  let qmlNamedMatch: RegExpExecArray | null;
+  while ((qmlNamedMatch = RE_QML_NAMED_ELEMENT.exec(content)) !== null) {
+    const qmlName = qmlNamedMatch[1]!;
+    const lineNum = content.slice(0, qmlNamedMatch.index).split('\n').length;
+    const nodeId = generateNodeId(filePath, 'component', qmlName, lineNum);
+    nodes.push({
+      id: nodeId,
+      kind: 'component',
+      name: qmlName,
+      qualifiedName: `${filePath}::${qmlName}`,
+      filePath,
+      language: 'cpp' as Language,
+      startLine: lineNum,
+      endLine: lineNum,
+      startColumn: 0,
+      endColumn: 0,
+      signature: `QML_NAMED_ELEMENT(${qmlName})`,
+      updatedAt: Date.now(),
+    });
+    // Emit a reference from this alias component to the C++ class (determined by
+    // the closest preceding class header in the file).
+    references.push({
+      fromNodeId: nodeId,
+      referenceName: qmlName,
+      referenceKind: 'references',
+      line: lineNum,
+      column: 0,
+      filePath,
+      language: 'cpp' as Language,
+    });
+  }
+
+  // ---- pass 5: qmlRegisterType<CppClass>(uri, major, minor, "QmlName") ----
+  RE_QML_REGISTER_TYPE.lastIndex = 0;
+  let qmlRegMatch: RegExpExecArray | null;
+  while ((qmlRegMatch = RE_QML_REGISTER_TYPE.exec(content)) !== null) {
+    const cppClass = qmlRegMatch[1]!;
+    const qmlName = qmlRegMatch[2]!;
+    const lineNum = content.slice(0, qmlRegMatch.index).split('\n').length;
+    // Only create an alias node when the QML name differs from the C++ class name,
+    // since same-name resolution already works via the class node.
+    if (qmlName !== cppClass) {
+      const nodeId = generateNodeId(filePath, 'component', qmlName, lineNum);
+      nodes.push({
+        id: nodeId,
+        kind: 'component',
+        name: qmlName,
+        qualifiedName: `${filePath}::${qmlName}`,
+        filePath,
+        language: 'cpp' as Language,
+        startLine: lineNum,
+        endLine: lineNum,
+        startColumn: 0,
+        endColumn: 0,
+        signature: `qmlRegisterType<${cppClass}>("${qmlName}")`,
+        updatedAt: Date.now(),
+      });
+    }
+    // Always emit a reference from the file to the C++ class being registered
+    references.push({
+      fromNodeId: generateNodeId(filePath, 'file', filePath, 1),
+      referenceName: cppClass,
+      referenceKind: 'references',
+      line: lineNum,
+      column: 0,
+      filePath,
+      language: 'cpp' as Language,
+    });
+  }
+
   return { nodes, references };
 }
 
@@ -361,7 +486,7 @@ export const qtResolver: FrameworkResolver = {
     for (const file of allFiles) {
       if (!file.endsWith('.cpp') && !file.endsWith('.h') && !file.endsWith('.hpp')) continue;
       const content = context.readFile(file);
-      if (content && (QT_INCLUDE_PATTERN.test(content) || Q_OBJECT_PATTERN.test(content))) {
+      if (content && (QT_INCLUDE_PATTERN.test(content) || Q_OBJECT_PATTERN.test(content) || QML_ELEMENT_PATTERN.test(content))) {
         return true;
       }
     }

--- a/src/resolution/frameworks/qt.ts
+++ b/src/resolution/frameworks/qt.ts
@@ -1,0 +1,462 @@
+/**
+ * Qt Framework Resolver
+ *
+ * Handles Qt-specific C++ and QML patterns:
+ *
+ * C++ side:
+ *  - Extracts `Q_PROPERTY(...)` macro declarations as `property` nodes
+ *  - Extracts `signals:` / `Q_SIGNALS:` section declarations as `method` nodes
+ *  - Extracts `slots:` / `Q_SLOTS:` section declarations as `method` nodes
+ *  - Emits edges for `QObject::connect()` SIGNAL/SLOT macro calls
+ *  - Emits edges for modern `connect(&Src, &Src::sig, &Dst, &Dst::slot)` calls
+ *
+ * QML side:
+ *  - Resolves QML signal handler names (`onFooChanged`) to C++ `fooChanged` signals
+ *  - Resolves QML `import ModuleName` references to C++ modules registered via
+ *    `qmlRegisterType` or `Q_DECLARE_QML_ELEMENT`
+ */
+
+import * as path from 'path';
+import { Node, Language } from '../../types';
+import { generateNodeId } from '../../extraction/tree-sitter-helpers';
+import {
+  FrameworkResolver,
+  FrameworkExtractionResult,
+  UnresolvedRef,
+  ResolvedRef,
+  ResolutionContext,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Detection helpers
+// ---------------------------------------------------------------------------
+
+/** Header tokens that strongly indicate a Qt C++ file */
+const QT_INCLUDE_PATTERN = /^#include\s+[<"](Q[A-Z]\w+|QtCore|QtGui|QtWidgets|QtQuick|QtQml|QApplication|QObject|QWidget)[>"]/m;
+
+/** Q_OBJECT or Q_GADGET inside a class — the definitive Qt class marker */
+const Q_OBJECT_PATTERN = /\bQ_(?:OBJECT|GADGET|NAMESPACE|ENUM|FLAG|ENUMS|FLAGS)\b/;
+
+// ---------------------------------------------------------------------------
+// C++ extraction patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches a signals: or Q_SIGNALS: / slots: / Q_SLOTS: section header.
+ * Captures the keyword so we know whether we're in signals or slots.
+ * Also handles access-qualified forms: `public slots:`, `private slots:`, etc.
+ */
+const RE_SECTION = /^\s*(?:public\s+|private\s+|protected\s+)?(?:Q_SIGNALS|signals|Q_SLOTS|slots)\s*:/;
+
+/**
+ * Detect the section type from a matching line.
+ */
+function getSectionType(line: string): 'signals' | 'slots' | null {
+  if (/\b(?:Q_SIGNALS|signals)\s*:/.test(line)) return 'signals';
+  if (/\b(?:Q_SLOTS|slots)\s*:/.test(line)) return 'slots';
+  return null;
+}
+
+/**
+ * Match a function declaration inside a signals:/slots: section.
+ * Captures: returnType, methodName, params
+ */
+const RE_FUNC_DECL = /^\s*(?:Q_INVOKABLE\s+|virtual\s+|override\s+|final\s+)*(\S[\s\S]*?)\s+(\w+)\s*\(([^)]*)\)\s*(?:const\s*)?;/;
+
+/**
+ * Q_PROPERTY(type name READ getter [WRITE setter] [NOTIFY signal] [...])
+ * The macro can span multiple lines but usually fits on one.
+ */
+const RE_Q_PROPERTY = /Q_PROPERTY\s*\(\s*([^)]+)\)/g;
+
+/**
+ * Signals the connect() call pattern:
+ *   QObject::connect(sender, SIGNAL(sig(args)), receiver, SLOT(slot(args)))
+ * or new-style:
+ *   connect(sender, &ClassName::methodName, receiver, &ClassName::methodName)
+ */
+const RE_CONNECT_MACRO = /connect\s*\(\s*\w[^,]*,\s*SIGNAL\s*\(\s*(\w+)\s*\([^)]*\)\s*\)\s*,\s*\w[^,]*,\s*SLOT\s*\(\s*(\w+)\s*\([^)]*\)\s*\)/g;
+const RE_CONNECT_PTR = /connect\s*\(\s*\w[^,]*,\s*&\s*(\w+)\s*::\s*(\w+)\s*,\s*\w[^,]*,\s*&\s*(\w+)\s*::\s*(\w+)/g;
+
+/**
+ * Matches a class or struct that contains Q_OBJECT/Q_GADGET.
+ * Used to associate extracted members with a parent class.
+ */
+const RE_CLASS_HEADER = /^\s*(?:class|struct)\s+(?:[A-Z][A-Z0-9_]+\s+)?(\w+)\s*(?:final\s*)?(?::\s*[^{]+)?\{/;
+
+// ---------------------------------------------------------------------------
+// Q_PROPERTY parsing
+// ---------------------------------------------------------------------------
+
+interface QProp {
+  type: string;
+  name: string;
+  read?: string;
+  write?: string;
+  notify?: string;
+}
+
+function parseQProperty(macroBody: string): QProp | null {
+  // First token(s) = type, then name, then keyword pairs
+  const tokens = macroBody.trim().split(/\s+/);
+  if (tokens.length < 2) return null;
+
+  // The type may be multi-word (e.g. "unsigned int", "QList<int>")
+  // We detect the name as the last token before the first keyword
+  const keywords = new Set(['READ', 'WRITE', 'NOTIFY', 'RESET', 'REVISION', 'DESIGNABLE', 'SCRIPTABLE', 'STORED', 'USER', 'CONSTANT', 'FINAL', 'REQUIRED', 'BINDABLE', 'MEMBER']);
+
+  let nameIdx = -1;
+  for (let i = 1; i < tokens.length; i++) {
+    if (keywords.has(tokens[i]!)) { nameIdx = i - 1; break; }
+  }
+  if (nameIdx < 0) nameIdx = tokens.length - 1;
+
+  const name = tokens[nameIdx]!;
+  const type = tokens.slice(0, nameIdx).join(' ');
+
+  const result: QProp = { type, name };
+
+  // Parse keyword-value pairs
+  for (let i = nameIdx + 1; i < tokens.length - 1; i++) {
+    const kw = tokens[i]!;
+    const val = tokens[i + 1]!;
+    if (kw === 'READ') result.read = val;
+    else if (kw === 'WRITE') result.write = val;
+    else if (kw === 'NOTIFY') result.notify = val;
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Main extractor function
+// ---------------------------------------------------------------------------
+
+function extractQtFromCpp(
+  filePath: string,
+  content: string,
+): FrameworkExtractionResult {
+  const nodes: Node[] = [];
+  const references: UnresolvedRef[] = [];
+
+  // Quick bail-out: not a Qt file
+  if (!Q_OBJECT_PATTERN.test(content) && !QT_INCLUDE_PATTERN.test(content)) {
+    return { nodes, references };
+  }
+
+  const lines = content.split('\n');
+  let currentClass: string | null = null;
+  let currentSection: 'signals' | 'slots' | null = null;
+  let braceDepth = 0;
+  let classBraceDepth = -1;
+
+  // ---- pass 1: class + section + member extraction ----
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    const lineNum = i + 1;
+
+    // Track brace depth
+    for (const ch of line) {
+      if (ch === '{') braceDepth++;
+      else if (ch === '}') {
+        braceDepth--;
+        if (braceDepth === classBraceDepth) {
+          currentClass = null;
+          classBraceDepth = -1;
+          currentSection = null;
+        }
+      }
+    }
+
+    // Detect class header
+    const classMatch = line.match(RE_CLASS_HEADER);
+    if (classMatch && currentClass === null) {
+      currentClass = classMatch[1]!;
+      classBraceDepth = braceDepth - 1; // depth at open brace
+    }
+
+    // Detect section change
+    if (RE_SECTION.test(line)) {
+      currentSection = getSectionType(line);
+      continue;
+    }
+
+    // Reset section on any access specifier (public:, private:, protected:)
+    if (/^\s*(?:public|private|protected)\s*:/.test(line)) {
+      currentSection = null;
+      continue;
+    }
+
+    // Extract methods inside signals: / slots: sections
+    if (currentSection && currentClass) {
+      const declMatch = line.match(RE_FUNC_DECL);
+      if (declMatch) {
+        const [, , methodName, params] = declMatch;
+        if (!methodName) continue;
+        const nodeId = generateNodeId(filePath, 'method', `${currentClass}::${methodName}`, lineNum);
+        nodes.push({
+          id: nodeId,
+          kind: 'method',
+          name: methodName,
+          qualifiedName: `${filePath}::${currentClass}::${methodName}`,
+          filePath,
+          language: 'cpp' as Language,
+          startLine: lineNum,
+          endLine: lineNum,
+          startColumn: line.search(/\S/),
+          endColumn: line.trimEnd().length,
+          signature: `${currentSection === 'signals' ? 'signal' : 'slot'} ${methodName}(${params ?? ''})`,
+          updatedAt: Date.now(),
+        });
+      }
+    }
+  }
+
+  // ---- pass 2: Q_PROPERTY extraction ----
+  // Re-scan with regex over the full source (may span lines but usually one line)
+  let propMatch: RegExpExecArray | null;
+  RE_Q_PROPERTY.lastIndex = 0;
+  while ((propMatch = RE_Q_PROPERTY.exec(content)) !== null) {
+    const macroBody = propMatch[1]!;
+    const prop = parseQProperty(macroBody);
+    if (!prop || !prop.name) continue;
+
+    // Determine line number from the match offset
+    const lineNum = content.slice(0, propMatch.index).split('\n').length;
+    const nodeId = generateNodeId(filePath, 'property', prop.name, lineNum);
+    nodes.push({
+      id: nodeId,
+      kind: 'property',
+      name: prop.name,
+      qualifiedName: `${filePath}::${prop.name}`,
+      filePath,
+      language: 'cpp' as Language,
+      startLine: lineNum,
+      endLine: lineNum,
+      startColumn: 0,
+      endColumn: 0,
+      signature: `Q_PROPERTY(${prop.type} ${prop.name})`,
+      updatedAt: Date.now(),
+    });
+
+    // Emit references to getter, setter, notify signal
+    const propRefs = [
+      prop.read && { name: prop.read, kind: 'calls' as const },
+      prop.write && { name: prop.write, kind: 'calls' as const },
+      prop.notify && { name: prop.notify, kind: 'calls' as const },
+    ].filter((r): r is { name: string; kind: 'calls' } => !!r);
+
+    for (const ref of propRefs) {
+      references.push({
+        fromNodeId: nodeId,
+        referenceName: ref.name,
+        referenceKind: ref.kind,
+        line: lineNum,
+        column: 0,
+        filePath,
+        language: 'cpp' as Language,
+      });
+    }
+  }
+
+  // ---- pass 3: connect() call extraction ----
+  RE_CONNECT_MACRO.lastIndex = 0;
+  let connectMatch: RegExpExecArray | null;
+  while ((connectMatch = RE_CONNECT_MACRO.exec(content)) !== null) {
+    const signalName = connectMatch[1]!;
+    const slotName = connectMatch[2]!;
+    const lineNum = content.slice(0, connectMatch.index).split('\n').length;
+
+    references.push({
+      fromNodeId: generateNodeId(filePath, 'file', filePath, 1),
+      referenceName: signalName,
+      referenceKind: 'calls',
+      line: lineNum,
+      column: 0,
+      filePath,
+      language: 'cpp' as Language,
+    });
+    references.push({
+      fromNodeId: generateNodeId(filePath, 'file', filePath, 1),
+      referenceName: slotName,
+      referenceKind: 'calls',
+      line: lineNum,
+      column: 0,
+      filePath,
+      language: 'cpp' as Language,
+    });
+  }
+
+  RE_CONNECT_PTR.lastIndex = 0;
+  while ((connectMatch = RE_CONNECT_PTR.exec(content)) !== null) {
+    // &ClassName::signalName
+    const signalClass = connectMatch[1]!;
+    const signalName = connectMatch[2]!;
+    const slotClass = connectMatch[3]!;
+    const slotName = connectMatch[4]!;
+    const lineNum = content.slice(0, connectMatch.index).split('\n').length;
+
+    references.push(
+      {
+        fromNodeId: generateNodeId(filePath, 'file', filePath, 1),
+        referenceName: signalName,
+        referenceKind: 'calls',
+        line: lineNum,
+        column: 0,
+        filePath,
+        language: 'cpp' as Language,
+        candidates: [`${signalClass}::${signalName}`],
+      },
+      {
+        fromNodeId: generateNodeId(filePath, 'file', filePath, 1),
+        referenceName: slotName,
+        referenceKind: 'calls',
+        line: lineNum,
+        column: 0,
+        filePath,
+        language: 'cpp' as Language,
+        candidates: [`${slotClass}::${slotName}`],
+      },
+    );
+  }
+
+  return { nodes, references };
+}
+
+// ---------------------------------------------------------------------------
+// QML signal handler → C++ signal resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a QML signal handler name to the underlying signal name.
+ * `onFooChanged` → `fooChanged`, `onClicked` → `clicked`
+ */
+function handlerToSignalName(handlerName: string): string {
+  // handlerName is e.g. "onFooChanged" — strip leading "on" and lowercase first letter
+  const body = handlerName.slice(2);
+  return body[0]!.toLowerCase() + body.slice(1);
+}
+
+/**
+ * Checks whether a reference name looks like a QML signal handler.
+ */
+function isQmlSignalHandler(name: string): boolean {
+  return /^on[A-Z]/.test(name);
+}
+
+// ---------------------------------------------------------------------------
+// FrameworkResolver export
+// ---------------------------------------------------------------------------
+
+export const qtResolver: FrameworkResolver = {
+  name: 'qt',
+  languages: ['cpp', 'c', 'qml'],
+
+  detect(context: ResolutionContext): boolean {
+    const allFiles = context.getAllFiles();
+
+    // Check for .qml files in the project
+    if (allFiles.some((f) => f.endsWith('.qml'))) return true;
+
+    // Check for Qt headers in C++ files
+    for (const file of allFiles) {
+      if (!file.endsWith('.cpp') && !file.endsWith('.h') && !file.endsWith('.hpp')) continue;
+      const content = context.readFile(file);
+      if (content && (QT_INCLUDE_PATTERN.test(content) || Q_OBJECT_PATTERN.test(content))) {
+        return true;
+      }
+    }
+
+    // Check CMakeLists.txt for Qt
+    const cmake = context.readFile('CMakeLists.txt');
+    if (cmake && /find_package\s*\(\s*Qt/i.test(cmake)) return true;
+
+    // Check .pro file (qmake)
+    const proFile = allFiles.find((f) => f.endsWith('.pro'));
+    if (proFile) {
+      const pro = context.readFile(proFile);
+      if (pro && /QT\s*[+]?=/.test(pro)) return true;
+    }
+
+    return false;
+  },
+
+  extract(filePath: string, content: string): FrameworkExtractionResult {
+    const ext = path.extname(filePath).toLowerCase();
+
+    if (ext === '.cpp' || ext === '.h' || ext === '.hpp' || ext === '.cxx' || ext === '.cc') {
+      return extractQtFromCpp(filePath, content);
+    }
+
+    return { nodes: [], references: [] };
+  },
+
+  resolve(ref: UnresolvedRef, context: ResolutionContext): ResolvedRef | null {
+    // QML → C++ signal handler resolution
+    // A QML `onFooChanged:` binding references the `fooChanged` signal,
+    // which may be declared in a C++ QObject class.
+    if (ref.language === 'qml' && isQmlSignalHandler(ref.referenceName)) {
+      const signalName = handlerToSignalName(ref.referenceName);
+      const candidates = context.getNodesByName(signalName).filter(
+        (n: Node) => n.kind === 'method' && (n.language === 'cpp' || n.language === 'qml'),
+      );
+      if (candidates.length === 1) {
+        return {
+          original: ref,
+          targetNodeId: candidates[0]!.id,
+          confidence: 0.75,
+          resolvedBy: 'framework',
+        };
+      }
+      // Multiple candidates — pick the one in the same directory as the QML file
+      if (candidates.length > 1) {
+        const qmlDir = path.dirname(ref.filePath);
+        const sameDir = candidates.find((n: Node) => path.dirname(n.filePath) === qmlDir);
+        const target = sameDir ?? candidates[0]!;
+        return {
+          original: ref,
+          targetNodeId: target.id,
+          confidence: 0.65,
+          resolvedBy: 'framework',
+        };
+      }
+    }
+
+    // QML import → C++ module (registered via Q_DECLARE_QML_ELEMENT or qmlRegisterType)
+    if (ref.language === 'qml' && ref.referenceKind === 'imports') {
+      const moduleName = ref.referenceName;
+      // A QML module like "VerificationResultsDRC" might match a C++ class or file
+      const candidates = context.getNodesByName(moduleName);
+      if (candidates.length > 0) {
+        return {
+          original: ref,
+          targetNodeId: candidates[0]!.id,
+          confidence: 0.6,
+          resolvedBy: 'framework',
+        };
+      }
+    }
+
+    // QML component type → C++ class that registered it
+    if (ref.language === 'qml' && ref.referenceKind === 'references') {
+      const typeName = ref.referenceName;
+      const candidates = context.getNodesByName(typeName).filter(
+        (n: Node) => n.kind === 'class' || n.kind === 'component',
+      );
+      if (candidates.length === 1) {
+        return {
+          original: ref,
+          targetNodeId: candidates[0]!.id,
+          confidence: 0.7,
+          resolvedBy: 'framework',
+        };
+      }
+    }
+
+    return null;
+  },
+
+  claimsReference(name: string): boolean {
+    // Claim QML signal handler references even if no node is named that yet
+    return isQmlSignalHandler(name);
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,7 @@ export const LANGUAGES = [
   'twig',
   'xml',
   'properties',
+  'qml',
   'unknown',
 ] as const;
 


### PR DESCRIPTION
- Implemented a custom QML extractor to parse Qt QML files, extracting components, properties, signals, and functions.
- Integrated the QML extractor into the existing extraction framework.
- Added a Qt framework resolver to handle C++ and QML specific patterns, including Q_PROPERTY and signal/slot connections.
- Updated the types to include 'qml' as a supported language.
- Enhanced the resolution process to link QML signal handlers to corresponding C++ signals.