### PR TITLE
fix(resolution): allow dot-prefixed path alias targets

### DIFF
--- a/__tests__/resolution.test.ts
+++ b/__tests__/resolution.test.ts
@@ -13,6 +13,7 @@ import { Node, UnresolvedReference } from '../src/types';
 import { ReferenceResolver, createResolver, ResolutionContext } from '../src/resolution';
 import { matchReference, resolveMethodOnType, matchByQualifiedName, preferCallSiteFile, matchMethodCall } from '../src/resolution/name-matcher';
 import { resolveImportPath, extractImportMappings, resolveJvmImport, loadCppIncludeDirs, clearCppIncludeDirCache, isPhpIncludePathRef } from '../src/resolution/import-resolver';
+import { applyAliases, type AliasMap } from '../src/resolution/path-aliases';
 import type { UnresolvedRef } from '../src/resolution/types';
 import { detectFrameworks, getAllFrameworkResolvers } from '../src/resolution/frameworks';
 import { QueryBuilder } from '../src/db/queries';
@@ -2194,6 +2195,23 @@ func main() {
   });
 
   describe('tsconfig path aliases', () => {
+    it('keeps dot-prefixed in-project alias targets while rejecting parent escapes', () => {
+      const aliases: AliasMap = {
+        baseUrl: tempDir,
+        patterns: [{
+          prefix: '@generated/',
+          suffix: '',
+          hasWildcard: true,
+          replacements: ['..generated/*', 'src/generated/*', '../outside/*'],
+        }],
+      };
+
+      expect(applyAliases('@generated/client', aliases, tempDir)).toEqual([
+        '..generated/client',
+        'src/generated/client',
+      ]);
+    });
+
     it('resolves an aliased import to the alias-mapped file (not a same-named file elsewhere)', async () => {
       // Two same-named exports in different directories. Without alias
       // resolution, name-matcher would pick whichever it finds first;

--- a/src/resolution/path-aliases.ts
+++ b/src/resolution/path-aliases.ts
@@ -231,9 +231,9 @@ export function applyAliases(
       // baseUrl is absolute; produce a path relative to projectRoot
       const absolute = path.resolve(aliases.baseUrl, filled);
       const relative = path.relative(projectRoot, absolute);
-      // Skip if the rewrite escapes the project root (unsafe + can't
-      // be looked up via the file index anyway).
-      if (relative.startsWith('..')) continue;
+      // Skip only real parent segments (not valid names such as `..generated`),
+      // plus absolute results from cross-drive paths on Windows.
+      if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) continue;
       out.push(relative.replace(/\\/g, '/'));
     }
     return out;


### PR DESCRIPTION
## Summary

Allow TypeScript/JavaScript path aliases to target valid in-project directories whose names begin with `..`, such as `..generated`.

## Problem

`applyAliases()` used `relative.startsWith('..')` to reject alias targets outside the project root. That also rejected valid directory names such as `..generated`, causing imports through those aliases to remain unresolved.

## Fix

Treat only an actual `..` path segment as a parent-directory escape. Cross-drive absolute results on Windows remain rejected.

## Tests

Added a regression test covering:

- a valid `..generated/*` target
- a normal `src/generated/*` target
- a real `../outside/*` escape

Validation:

- `npx vitest run __tests__/resolution.test.ts`
- `npm run build`