### PR TITLE
fix(installer): resolve Antigravity codegraph command out of fnm's ephemeral per-shell dir

### DIFF
--- a/src/installer/targets/antigravity.ts
+++ b/src/installer/targets/antigravity.ts
@@ -126,7 +126,19 @@ function resolveCodegraphCommand(): string {
       shell: '/bin/bash',
       windowsHide: true,
     }).trim();
-    if (resolved && fs.existsSync(resolved)) return resolved;
+    if (resolved && fs.existsSync(resolved)) {
+      // fnm resolves `codegraph` inside an ephemeral per-shell symlink dir
+      // (~/.local/state/fnm_multishells/<pid>/bin) that fnm removes when the
+      // installing shell exits, leaving a dangling command in the GUI app's
+      // MCP config. Canonicalize the containing directory so the path outlives
+      // the shell, while preserving the `codegraph` binary name (agents that
+      // validate the command by basename still match).
+      try {
+        return path.join(fs.realpathSync(path.dirname(resolved)), path.basename(resolved));
+      } catch {
+        return resolved;
+      }
+    }
   } catch {
     /* fall through to bare name */
   }


### PR DESCRIPTION
## Overview

On macOS with [fnm](https://github.com/Schniz/fnm), the Antigravity installer writes an MCP `command` that points into an ephemeral, per-shell directory. It works at install time but dangles once the installing shell exits, so Antigravity can no longer spawn the codegraph server.

Fixes #1443.

## Root cause

`resolveCodegraphCommand()` (`src/installer/targets/antigravity.ts`) resolves the absolute path via `command -v codegraph`. Under fnm, an interactive shell resolves `codegraph` to `~/.local/state/fnm_multishells/<pid>_<ts>/bin/codegraph` — a symlink directory fnm creates **per shell** and removes when that shell exits. That path is written verbatim into `~/.gemini/config/mcp_config.json`.

## Change

Canonicalize the resolved path's containing directory with `fs.realpathSync`, then re-join the basename:

```ts
return path.join(fs.realpathSync(path.dirname(resolved)), path.basename(resolved));
```

- Escapes the ephemeral `fnm_multishells/<pid>` dir, so the written path outlives the installing shell. For fnm it yields `~/.local/share/fnm/node-versions/<ver>/installation/bin/codegraph`.
- Preserves the `codegraph` basename. Some agents validate the MCP command by `filepath.Base`, so keeping the name matters — resolving the *full* path would land on `npm-shim.js` and break those checks.
- Falls back to the raw resolved path if `realpath` throws.
- No behavior change off macOS/fnm, or when resolution already yields a stable path.

## Verification

- `npx tsc --noEmit` — clean.
- `npx vitest run __tests__/installer-targets.test.ts` — 162/162 pass.
- Manual repro on macOS + fnm: `command -v codegraph` → `~/.local/state/fnm_multishells/<pid>/bin/codegraph` (dangles after the shell exits); after the change the written command resolves to the stable `node-versions/<ver>/installation/bin/codegraph` and runs.

## Note on tests

Happy to add a regression test. `resolveCodegraphCommand` isn't exported and the suite intentionally doesn't mock `execSync`, so a deterministic test needs a small seam (export the function, or mock `child_process`). Glad to go whichever way you prefer.
