### PR TITLE
feat: add repository knowledge atlas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ Thumbs.db
 /coverage/
 .nyc_output/
 
+# Local browser-test artifacts
+/.playwright-cli/
+/output/playwright/
+
 # Environment
 .env
 .env.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### New Features
+
+- Repository-local Markdown (`.md`, `.mdx`, `.markdown`) now joins the code
+  graph: headings become searchable section nodes, relative links connect
+  documents and source files, and unambiguous inline-code symbol mentions link
+  documentation to their definitions. External URLs remain local-only source
+  text and are never fetched.
+- `codegraph ui` serves a bundled, read-only repository topology from the
+  existing local graph. Code symbols and Markdown sections share one
+  searchable, filterable atlas. Its weighted overview shows semantic,
+  directory, or language distribution; labels disclose progressively with
+  zoom; relationship rendering can switch between exact edges and visual-only
+  group aggregates; and the right panel independently filters node and edge
+  kinds while retaining exact persisted node inspection. The service binds to
+  loopback by default and has no CDN or runtime network dependency.
 
 ## [1.5.0] - 2026-07-21
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,26 @@ codegraph init
 
 </div>
 
-### 4. No more syncing!
+### 4. Open the repository atlas
+
+From the indexed project's directory:
+
+```bash
+codegraph ui
+```
+
+Open <http://127.0.0.1:7474> to explore the repository's code and Markdown
+documents by semantic role, directory, or language. The bundled web service is
+read-only and listens on loopback by default. Use `--port` when running more
+than one repository:
+
+```bash
+codegraph ui --port 7475 --limit 1200
+```
+
+Press `Ctrl+C` to stop the web service.
+
+### 5. No more syncing!
 
 Auto-sync is enabled by default. CodeGraph watches the project and updates the graph on every file change — while your agent edits code, or you add, modify, or delete files. **The index is never stale, and there is nothing to re-run.**
 
@@ -181,6 +200,12 @@ Every language below gets the same treatment — full structural extraction and 
 </p>
 
 <sub>Per-language details — extensions, frameworks, and what exactly gets extracted — in [Supported Languages](#supported-languages).</sub>
+
+Repository-local Markdown is part of the same graph: `.md`, `.mdx`, and
+`.markdown` headings become searchable sections, relative links connect
+documents and source files, and unambiguous symbols in inline code spans link
+prose to their code definitions. External URLs are left in the document but
+are not fetched or added to the graph.
 
 ---
 
@@ -411,6 +436,17 @@ Builds the per-project knowledge graph index, which then auto-syncs on every fil
 
 That's it — your agent will use CodeGraph tools automatically when a `.codegraph/` directory exists.
 
+To inspect the same graph visually, start the bundled read-only local UI:
+
+```bash
+codegraph ui
+```
+
+Open the printed `http://127.0.0.1:7474` address. The page renders code symbols,
+Markdown sections, and their persisted relationships from the existing index.
+It ships inside CodeGraph and makes no CDN requests. Use `--limit`, `--host`,
+or `--port` to change the initial view size or bind address.
+
 <details>
 <summary><strong>Manual Setup (Alternative)</strong></summary>
 
@@ -507,6 +543,7 @@ codegraph uninit [path]           # Remove CodeGraph from a project (--force to 
 codegraph index [path]            # Full index (--force to re-index, --quiet for less output)
 codegraph sync [path]             # Incremental update
 codegraph status [path]           # Show statistics
+codegraph ui [path]               # Serve the read-only local topology UI (--host, --port, --limit)
 codegraph unlock [path]           # Remove a stale lock file that's blocking indexing
 codegraph query <search>          # Search symbols (--kind, --limit, --json)
 codegraph explore <query>         # Relevant symbols' source + call paths in one shot (same output as the codegraph_explore MCP tool)
@@ -522,6 +559,22 @@ codegraph upgrade [version]       # Update to the latest release (--check, --for
 codegraph version                 # Print the installed version (also -v, --version)
 codegraph help [command]          # Show help, optionally for one command
 ```
+
+### Repository atlas
+
+After indexing a repository, start the bundled local UI:
+
+```bash
+codegraph ui .                    # Open http://127.0.0.1:7474
+codegraph ui /path/to/repo --port 7480 --limit 1200
+```
+
+The overview allocates area by semantic role so the repository's document,
+structure, type, behavior, data, and dependency distribution is visible at a
+glance. The right panel can regroup by directory or language, change node
+coloring, filter node and relationship kinds, choose aggregate or exact
+relationship views, and inspect the persisted identity and edges of any node.
+The service is read-only, loopback-only by default, and uses bundled assets.
 
 ### `codegraph affected`
 
@@ -795,6 +848,7 @@ is written):
 | Solidity | `.sol` | Full support (contracts, libraries, interfaces, structs, enums, modifiers, events, errors, state variables, `import`/`using` directives, `emit`/`revert` calls) |
 | Terraform / OpenTofu | `.tf`, `.tfvars`, `.tofu` | Full support (resources, data sources, modules, variables, outputs, providers incl. aliases, `locals`; `var.`/`local.`/`module.`/resource references with Terraform's per-directory scoping enforced; module calls bridged across the boundary — inputs to the child module's variables, `module.M.out` to the child's output, `source` to the module's files; cloudposse/atmos `remote-state` cross-component wiring when the component is statically named; `provider = aws.east` selections resolved up the module tree; `moved`/`import`/`removed`/`check` block references; `.tfvars` assignments linked to the variables they set) |
 | Nix | `.nix` | Full support (functions with simple/destructured/curried params, `let`/attrset bindings, `inherit`, `import ./path` file edges — `./dir` resolving through `default.nix` — plus NixOS module `imports = [ ./x.nix ]` lists and `callPackage ./pkg.nix` file edges; call edges; module-system option wiring — a config write like `launchd.user.agents.x = { ... }` links to the module declaring `options.launchd.user.agents`, so option flows trace across modules) |
+| Markdown | `.md`, `.mdx`, `.markdown` | Repository-document support (heading hierarchy as `section` nodes, searchable prose, strict repository-local links to documents/source files, and unique-only inline-code symbol references; fenced code and external URLs are not traversed) |
 
 ## Measured cross-file coverage
 

--- a/__tests__/cli-version.test.ts
+++ b/__tests__/cli-version.test.ts
@@ -42,6 +42,10 @@ describe('codegraph version affordances', () => {
     expect(run(['--help'])).toContain('version');
   });
 
+  it('lists the human-facing topology UI command in --help', () => {
+    expect(run(['--help'])).toMatch(/^\s+ui \[options\] \[path\]/m);
+  });
+
   it('`codegraph help` prints usage and the command list', () => {
     const out = run(['help']);
     expect(out).toContain('Usage: codegraph');

--- a/__tests__/graph-wire-contract.test.ts
+++ b/__tests__/graph-wire-contract.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { EDGE_KINDS, NODE_KINDS } from '../src/types';
+
+/**
+ * These arrays cross the TypeScript/Rust boundary as numeric indexes.
+ * Repository-document support may append kinds but may never renumber the
+ * existing CodeGraph protocol.
+ */
+describe('native graph wire contract', () => {
+  it('keeps every pre-document node kind at its original index', () => {
+    expect(NODE_KINDS.slice(0, 22)).toEqual([
+      'file',
+      'module',
+      'class',
+      'struct',
+      'interface',
+      'trait',
+      'protocol',
+      'function',
+      'method',
+      'property',
+      'field',
+      'variable',
+      'constant',
+      'enum',
+      'enum_member',
+      'type_alias',
+      'namespace',
+      'parameter',
+      'import',
+      'export',
+      'route',
+      'component',
+    ]);
+    expect(NODE_KINDS[22]).toBe('section');
+  });
+
+  it('does not change any existing edge-kind index', () => {
+    expect(EDGE_KINDS).toEqual([
+      'contains',
+      'calls',
+      'imports',
+      'exports',
+      'extends',
+      'implements',
+      'references',
+      'type_of',
+      'returns',
+      'instantiates',
+      'overrides',
+      'decorates',
+    ]);
+  });
+
+  it('keeps the checked-in Rust wire tables identical to TypeScript', () => {
+    const rust = fs.readFileSync(
+      path.resolve(__dirname, '../codegraph-kernel/src/buffers.rs'),
+      'utf8'
+    );
+    const readRustArray = (name: string): string[] => {
+      const match = rust.match(
+        new RegExp(`pub const ${name}: \\[&str; \\d+\\] = \\[([\\s\\S]*?)\\];`)
+      );
+      expect(match, `${name} must exist in buffers.rs`).not.toBeNull();
+      return [...match![1]!.matchAll(/"([^"]+)"/g)].map((entry) => entry[1]!);
+    };
+
+    expect(readRustArray('NODE_KINDS')).toEqual([...NODE_KINDS]);
+    expect(readRustArray('EDGE_KINDS')).toEqual([...EDGE_KINDS]);
+  });
+});

--- a/__tests__/markdown-documents.test.ts
+++ b/__tests__/markdown-documents.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CodeGraph } from '../src';
+import { extractFromSource } from '../src/extraction';
+import {
+  detectLanguage,
+  initGrammars,
+  isLanguageSupported,
+  isSourceFile,
+  loadAllGrammars,
+} from '../src/extraction/grammars';
+
+beforeAll(async () => {
+  await initGrammars();
+  await loadAllGrammars();
+});
+
+describe('repository Markdown extraction', () => {
+  it('registers Markdown as a custom indexable language', () => {
+    expect(detectLanguage('README.md')).toBe('markdown');
+    expect(detectLanguage('docs/guide.mdx')).toBe('markdown');
+    expect(detectLanguage('notes.markdown')).toBe('markdown');
+    expect(isSourceFile('README.md')).toBe(true);
+    expect(isLanguageSupported('markdown')).toBe(true);
+  });
+
+  it('extracts section hierarchy, prose, local links, and inline symbols', () => {
+    const result = extractFromSource(
+      'docs/architecture.md',
+      [
+        'Repository overview.',
+        '',
+        '# Architecture',
+        'Credential orchestration uses `AuthService` and `Store`.',
+        'See [source](../src/auth.ts), [details](#details), and [web](https://example.com).',
+        '',
+        '## Details',
+        'Calls `Graph.open()` and `parse_config`.',
+        '',
+        '```ts',
+        '# Not a heading',
+        'const HiddenSymbol = true;',
+        '[fake](../src/fake.ts)',
+        '```',
+        '',
+        '# Architecture',
+        'Duplicate title.',
+      ].join('\n')
+    );
+
+    expect(result.errors).toEqual([]);
+    const file = result.nodes.find((node) => node.kind === 'file');
+    const sections = result.nodes.filter((node) => node.kind === 'section');
+    const architecture = sections.find(
+      (node) => node.qualifiedName === 'docs/architecture.md#architecture'
+    );
+    const details = sections.find((node) => node.name === 'Details');
+    const duplicate = sections.find(
+      (node) => node.qualifiedName === 'docs/architecture.md#architecture-1'
+    );
+
+    expect(file?.language).toBe('markdown');
+    expect(file?.docstring).toBe('Repository overview.');
+    expect(architecture?.docstring).toContain('Credential orchestration');
+    expect(details).toBeDefined();
+    expect(duplicate).toBeDefined();
+    expect(sections.some((node) => node.name === 'Not a heading')).toBe(false);
+
+    expect(
+      result.edges.some(
+        (edge) =>
+          edge.kind === 'contains' &&
+          edge.source === architecture?.id &&
+          edge.target === details?.id
+      )
+    ).toBe(true);
+    expect(
+      result.edges.some(
+        (edge) =>
+          edge.kind === 'references' &&
+          edge.source === architecture?.id &&
+          edge.target === details?.id
+      )
+    ).toBe(true);
+
+    const refs = result.unresolvedReferences.map((ref) => [
+      ref.referenceKind,
+      ref.referenceName,
+    ]);
+    expect(refs).toContainEqual(['document_link', 'src/auth.ts']);
+    expect(refs).toContainEqual(['document_symbol', 'AuthService']);
+    expect(refs).toContainEqual(['document_symbol', 'Store']);
+    expect(refs).toContainEqual(['document_symbol', 'Graph.open']);
+    expect(refs).toContainEqual(['document_symbol', 'parse_config']);
+    expect(refs).not.toContainEqual(['document_link', 'src/fake.ts']);
+    expect(
+      result.unresolvedReferences.some((ref) =>
+        ref.referenceName.includes('example.com')
+      )
+    ).toBe(false);
+  });
+
+  it('supports Setext headings and reference-style local links', () => {
+    const result = extractFromSource(
+      'docs/guide.md',
+      [
+        'Guide',
+        '=====',
+        '',
+        'Read the [design][design-doc].',
+        '',
+        '[design-doc]: ./design.md#storage',
+      ].join('\n')
+    );
+
+    const guide = result.nodes.find(
+      (node) =>
+        node.kind === 'section' &&
+        node.qualifiedName === 'docs/guide.md#guide'
+    );
+    expect(guide?.startLine).toBe(1);
+    expect(result.unresolvedReferences).toContainEqual(
+      expect.objectContaining({
+        fromNodeId: guide?.id,
+        referenceKind: 'document_link',
+        referenceName: 'docs/design.md#storage',
+      })
+    );
+  });
+});
+
+describe('repository Markdown indexing', () => {
+  let tempDir: string | undefined;
+  let graph: CodeGraph | undefined;
+
+  afterEach(() => {
+    graph?.close();
+    graph = undefined;
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  });
+
+  it('resolves document links and unique code symbols end to end', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-markdown-'));
+    const write = (relativePath: string, content: string): void => {
+      const target = path.join(tempDir!, relativePath);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, content);
+    };
+
+    write(
+      'src/auth.ts',
+      'export class AuthService { authenticate(): boolean { return true; } }\n'
+    );
+    write('src/config-a.ts', 'export function parseConfig(): void {}\n');
+    write('src/config-b.ts', 'export function parseConfig(): void {}\n');
+    write(
+      'docs/architecture.md',
+      [
+        '# Architecture',
+        'Credential orchestration uses `AuthService` and the ambiguous `parseConfig`.',
+        'Read the [implementation](../src/auth.ts) and [API](./details.md#api).',
+        'The [external guide](https://example.com/guide) stays outside the graph.',
+      ].join('\n')
+    );
+    write('docs/details.md', '# API\nStable authentication surface.\n');
+
+    graph = CodeGraph.initSync(tempDir);
+    await graph.indexAll();
+
+    const architecture = graph
+      .getNodesByKind('section')
+      .find(
+        (node) =>
+          node.qualifiedName === 'docs/architecture.md#architecture'
+      );
+    const api = graph
+      .getNodesByKind('section')
+      .find((node) => node.qualifiedName === 'docs/details.md#api');
+    const auth = graph
+      .getNodesByKind('class')
+      .find((node) => node.name === 'AuthService');
+    const authFile = graph.getNode('file:src/auth.ts');
+
+    expect(architecture).toBeDefined();
+    expect(api).toBeDefined();
+    expect(auth).toBeDefined();
+    expect(authFile).toBeDefined();
+
+    const outgoing = graph.getOutgoingEdges(architecture!.id);
+    expect(outgoing).toContainEqual(
+      expect.objectContaining({
+        target: authFile!.id,
+        kind: 'references',
+        metadata: expect.objectContaining({ docRef: 'link' }),
+      })
+    );
+    expect(outgoing).toContainEqual(
+      expect.objectContaining({
+        target: api!.id,
+        kind: 'references',
+        metadata: expect.objectContaining({ docRef: 'link' }),
+      })
+    );
+    expect(outgoing).toContainEqual(
+      expect.objectContaining({
+        target: auth!.id,
+        kind: 'references',
+        metadata: expect.objectContaining({ docRef: 'symbol' }),
+      })
+    );
+
+    const ambiguousTargets = new Set(
+      graph
+        .getNodesByKind('function')
+        .filter((node) => node.name === 'parseConfig')
+        .map((node) => node.id)
+    );
+    expect(outgoing.some((edge) => ambiguousTargets.has(edge.target))).toBe(false);
+    expect(
+      graph
+        .searchNodes('credential orchestration')
+        .some((result) => result.node.id === architecture!.id)
+    ).toBe(true);
+
+    // The normal per-file lifecycle also applies to documents: changing a
+    // heading removes its old node/edge and resolves the updated anchor.
+    write(
+      'docs/architecture.md',
+      [
+        '# Architecture',
+        'Credential orchestration uses `AuthService` and the ambiguous `parseConfig`.',
+        'Read the [implementation](../src/auth.ts) and [API](./details.md#public-api).',
+      ].join('\n')
+    );
+    write('docs/details.md', '# Public API\nStable authentication surface.\n');
+    await graph.sync();
+
+    const publicApi = graph
+      .getNodesByKind('section')
+      .find((node) => node.qualifiedName === 'docs/details.md#public-api');
+    expect(graph.getNode(api!.id)).toBeNull();
+    expect(publicApi).toBeDefined();
+    expect(
+      graph
+        .getOutgoingEdges(architecture!.id)
+        .some(
+          (edge) =>
+            edge.target === publicApi!.id &&
+            edge.metadata?.docRef === 'link'
+        )
+    ).toBe(true);
+  });
+
+  it('preserves every existing source node and relationship when Markdown is added', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-markdown-additive-'));
+    const write = (relativePath: string, content: string): void => {
+      const target = path.join(tempDir!, relativePath);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, content);
+    };
+
+    write(
+      'src/service.ts',
+      [
+        'export function helper(): number { return 42; }',
+        'export class Service {',
+        '  run(): number { return helper(); }',
+        '}',
+      ].join('\n')
+    );
+    write(
+      'src/main.ts',
+      [
+        "import { Service } from './service';",
+        'export function main(): number {',
+        '  return new Service().run();',
+        '}',
+      ].join('\n')
+    );
+
+    graph = CodeGraph.initSync(tempDir);
+    await graph.indexAll();
+
+    const beforeNodes = graph
+      .getFiles()
+      .flatMap((file) => graph!.getNodesInFile(file.path))
+      .filter((node) => node.language !== 'markdown');
+    const beforeNodeIds = new Set(beforeNodes.map((node) => node.id));
+    const edgeKey = (edge: ReturnType<CodeGraph['getOutgoingEdges']>[number]): string =>
+      JSON.stringify([
+        edge.source,
+        edge.target,
+        edge.kind,
+        edge.line ?? null,
+        edge.column ?? null,
+        edge.metadata ?? null,
+        edge.provenance ?? null,
+      ]);
+    const beforeEdges = new Set(
+      beforeNodes.flatMap((node) => graph!.getOutgoingEdges(node.id)).map(edgeKey)
+    );
+
+    expect(beforeNodeIds.size).toBeGreaterThan(4);
+    expect(beforeEdges.size).toBeGreaterThan(2);
+    expect(
+      [...beforeEdges].some((key) => key.includes('"calls"'))
+    ).toBe(true);
+
+    write(
+      'docs/architecture.md',
+      [
+        '# Architecture',
+        'The entry point uses `Service`, `main`, and `helper`.',
+        'See the [implementation](../src/service.ts).',
+      ].join('\n')
+    );
+    await graph.sync();
+
+    const afterNodes = graph
+      .getFiles()
+      .flatMap((file) => graph!.getNodesInFile(file.path))
+      .filter((node) => node.language !== 'markdown');
+    const afterNodeIds = new Set(afterNodes.map((node) => node.id));
+    const afterEdges = new Set(
+      afterNodes.flatMap((node) => graph!.getOutgoingEdges(node.id)).map(edgeKey)
+    );
+
+    expect(afterNodeIds).toEqual(beforeNodeIds);
+    for (const edge of beforeEdges) {
+      expect(afterEdges.has(edge), `missing original edge ${edge}`).toBe(true);
+    }
+  });
+});

--- a/__tests__/security.test.ts
+++ b/__tests__/security.test.ts
@@ -513,7 +513,7 @@ describe('Source file detection (isSourceFile)', () => {
 
   it('rejects unsupported extensions and extensionless files', () => {
     expect(isSourceFile('src/component.css')).toBe(false);
-    expect(isSourceFile('README.md')).toBe(false);
+    expect(isSourceFile('README.md')).toBe(true);
     expect(isSourceFile('Makefile')).toBe(false);
     expect(isSourceFile('.gitignore')).toBe(false);
   });

--- a/__tests__/topology-ui.test.ts
+++ b/__tests__/topology-ui.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CodeGraph, startTopologyServer, TopologyServer } from '../src';
+
+describe('repository topology UI service', () => {
+  let tempDir: string | undefined;
+  let graph: CodeGraph | undefined;
+  let server: TopologyServer | undefined;
+
+  afterEach(async () => {
+    await server?.close();
+    server = undefined;
+    graph?.close();
+    graph = undefined;
+    if (tempDir) {
+      fs.rmSync(tempDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 4,
+        retryDelay: 50,
+      });
+    }
+    tempDir = undefined;
+  });
+
+  async function createProject(): Promise<void> {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-topology-ui-'));
+    fs.mkdirSync(path.join(tempDir, 'src'), { recursive: true });
+    fs.mkdirSync(path.join(tempDir, 'docs'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, 'src', 'service.ts'),
+      [
+        'export class TopologyService {',
+        '  render(): string { return "ready"; }',
+        '}',
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(tempDir, 'docs', 'architecture.md'),
+      [
+        '# Repository Topology',
+        'The UI displays `TopologyService` beside this document.',
+        'Read the [source](../src/service.ts).',
+      ].join('\n')
+    );
+    graph = CodeGraph.initSync(tempDir);
+    const result = await graph.indexAll();
+    expect(result.success).toBe(true);
+    server = await startTopologyServer(graph, { port: 0, nodeLimit: 100 });
+  }
+
+  it('serves bundled assets and a read-only protocol contract', async () => {
+    await createProject();
+
+    const page = await fetch(server!.url);
+    expect(page.status).toBe(200);
+    expect(page.headers.get('content-security-policy')).toContain("default-src 'self'");
+    const pageBody = await page.text();
+    expect(pageBody).toContain('CodeGraph topology');
+    expect(pageBody).toContain('Repository distribution');
+    expect(pageBody).toContain('data-testid="group-distribution"');
+
+    const script = await fetch(`${server!.url}/app.js`);
+    expect(script.status).toBe(200);
+    expect(script.headers.get('content-type')).toContain('text/javascript');
+    const scriptBody = await script.text();
+    expect(scriptBody).toContain('/api/graph');
+    expect(scriptBody).toContain('function semanticRole');
+    expect(scriptBody).toContain('function splitTreemap');
+
+    const contract = await fetch(`${server!.url}/api/contract`).then((response) =>
+      response.json()
+    );
+    expect(contract.readOnly).toBe(true);
+    expect(contract.nodeKinds).toContain('section');
+    expect(contract.edgeKinds).toContain('references');
+  });
+
+  it('returns exact persisted nodes and induced edges in a bounded snapshot', async () => {
+    await createProject();
+
+    const response = await fetch(`${server!.url}/api/graph?limit=100`);
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    const ids = new Set<string>(payload.nodes.map((node: { id: string }) => node.id));
+    expect(payload.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'class', name: 'TopologyService' }),
+        expect.objectContaining({ kind: 'section', name: 'Repository Topology' }),
+      ])
+    );
+    expect(payload.edges.length).toBeGreaterThan(0);
+    for (const edge of payload.edges) {
+      expect(ids.has(edge.source)).toBe(true);
+      expect(ids.has(edge.target)).toBe(true);
+      expect(graph!.getOutgoingEdges(edge.source)).toContainEqual(edge);
+    }
+    expect(payload.stats.nodeCount).toBeGreaterThanOrEqual(payload.nodes.length);
+    expect(payload.truncated).toBe(false);
+  });
+
+  it('searches the full graph and inspects persisted incoming and outgoing relationships', async () => {
+    await createProject();
+
+    const searchResponse = await fetch(
+      `${server!.url}/api/search?q=${encodeURIComponent('TopologyService')}`
+    );
+    expect(searchResponse.status).toBe(200);
+    const searchPayload = await searchResponse.json();
+    const service = searchPayload.results.find(
+      (result: { node: { name: string } }) => result.node.name === 'TopologyService'
+    )?.node;
+    expect(service).toBeDefined();
+
+    const nodeResponse = await fetch(
+      `${server!.url}/api/node?id=${encodeURIComponent(service.id)}`
+    );
+    expect(nodeResponse.status).toBe(200);
+    const nodePayload = await nodeResponse.json();
+    expect(nodePayload.node.id).toBe(service.id);
+    expect(nodePayload.totalIncoming + nodePayload.totalOutgoing).toBeGreaterThan(0);
+    expect(nodePayload.neighbors.length).toBeGreaterThan(0);
+  });
+
+  it('validates filters and rejects mutation requests', async () => {
+    await createProject();
+
+    const invalidKind = await fetch(`${server!.url}/api/graph?kinds=not-a-kind`);
+    expect(invalidKind.status).toBe(400);
+    expect(await invalidKind.json()).toEqual({ error: 'Unknown node kind' });
+
+    const mutation = await fetch(`${server!.url}/api/stats`, { method: 'POST' });
+    expect(mutation.status).toBe(405);
+    expect(mutation.headers.get('allow')).toBe('GET, HEAD');
+  });
+});

--- a/__tests__/watcher.test.ts
+++ b/__tests__/watcher.test.ts
@@ -442,8 +442,8 @@ describe('FileWatcher', () => {
       // gate must drop it before scheduling sync. (It must exist on disk:
       // a VANISHED non-source path is the deleted-directory shape, which
       // deliberately schedules a sync — #1285.)
-      fs.writeFileSync(path.join(testDir, 'src', 'readme.md'), '# docs\n');
-      __emitWatchEventForTests(testDir, 'src/readme.md');
+      fs.writeFileSync(path.join(testDir, 'src', 'readme.txt'), 'docs\n');
+      __emitWatchEventForTests(testDir, 'src/readme.txt');
 
       // Wait a bit longer than debounce — sync should NOT trigger.
       await new Promise((r) => setTimeout(r, 400));

--- a/codegraph-kernel/src/buffers.rs
+++ b/codegraph-kernel/src/buffers.rs
@@ -77,7 +77,7 @@ pub const EDGE_ROW_SIZE: usize = 44;
 pub const REF_ROW_SIZE: usize = 40;
 
 /// Mirror of NODE_KINDS in src/types.ts — order is the wire contract.
-pub const NODE_KINDS: [&str; 22] = [
+pub const NODE_KINDS: [&str; 23] = [
     "file",
     "module",
     "class",
@@ -100,6 +100,7 @@ pub const NODE_KINDS: [&str; 22] = [
     "export",
     "route",
     "component",
+    "section",
 ];
 
 /// Mirror of EDGE_KINDS in src/types.ts — order is the wire contract.

--- a/docs/design/repository-documents-v1.md
+++ b/docs/design/repository-documents-v1.md
@@ -1,0 +1,161 @@
+# Repository Documents V1
+
+## Status
+
+Proposed and implemented as an intentionally small first step toward making
+CodeGraph a graph of the whole repository, rather than code symbols alone.
+
+## Goal
+
+Index repository-local Markdown alongside source code so that documentation
+structure and high-confidence links between documentation and code are
+available through the existing graph, search, context, and impact APIs.
+
+The implementation must remain deterministic, local-only, and useful without
+an LLM or network access.
+
+## Scope
+
+V1 indexes `.md`, `.mdx`, and `.markdown` files.
+
+It adds:
+
+- a normal `file` node for every indexed Markdown file;
+- a `section` node for every Markdown heading;
+- `contains` edges that preserve the document hierarchy;
+- `references` edges for repository-local Markdown links;
+- `references` edges for unambiguous code symbols named in inline code spans;
+- searchable document prose through the existing `docstring` FTS field.
+
+V1 deliberately does not parse plain text, PDF, Office files, images, audio,
+or other document formats.
+
+## Graph model
+
+### Markdown files
+
+A Markdown file uses the existing `file` node kind and the new `markdown`
+language. Text before the first heading is stored as the file node's
+`docstring`.
+
+### Sections
+
+`section` is appended to `NODE_KINDS` so the native extraction wire values of
+all existing kinds stay stable.
+
+Each ATX or Setext heading creates a section node:
+
+| Field | Value |
+| --- | --- |
+| `name` | visible heading text |
+| `qualifiedName` | `<repo-relative-path>#<slug>` |
+| `filePath` | repository-relative Markdown path |
+| `language` | `markdown` |
+| source range | heading through the line before the next heading of the same or a higher level |
+| `docstring` | normalized prose directly below the heading, capped at 4 KiB |
+
+Duplicate heading slugs receive the same numeric suffix convention used by
+GitHub-style anchors (`name`, `name-1`, `name-2`).
+
+The file contains top-level sections. A section contains the nearest following
+deeper section. This makes the Markdown outline traversable with the existing
+graph API.
+
+## References
+
+### Repository-local links
+
+Inline and reference-style Markdown links are normalized relative to the
+containing document:
+
+- `#design` targets a section in the same file;
+- `../README.md` targets a file node;
+- `architecture.md#storage` targets a section node;
+- links to source files target their file nodes.
+
+They are resolved strictly by normalized file path or exact qualified name.
+There is no fuzzy fallback, so a typo does not silently create a wrong edge.
+The persisted edge kind is the existing `references` kind, with
+`metadata.docRef = "link"` for callers that want to distinguish it.
+
+V1 does not interpret source-line fragments as symbol references.
+
+### Code symbols in prose
+
+An inline code span is considered a symbol candidate only when it looks like a
+single identifier or qualified identifier, for example `AuthService`,
+`parse_config`, `Graph.open()`, or `crate::Store`.
+
+The reference resolves only when:
+
+- the full qualified name identifies one definition; or
+- an unqualified name has exactly one definition in the repository.
+
+Ambiguous names remain unresolved. No fuzzy name matching or language-family
+gate is used for these documentation-to-code references. Persisted edges use
+`metadata.docRef = "symbol"`.
+
+Code spans containing whitespace, shell syntax, URLs, or file paths are not
+treated as symbols. Fenced code blocks are excluded from both link and symbol
+extraction.
+
+## External links
+
+HTTP(S), protocol-relative, `mailto:`, and other URI-scheme links are not
+fetched and do not create graph nodes in V1. The URL remains in the source and
+therefore in a section's source range, but is omitted from the repository
+graph.
+
+Creating external nodes now would require unresolved design decisions around
+canonical identity, availability checks, credentials, refresh policy,
+deletion, and trust. A later version can add an explicit `external_resource`
+node and `external_dependency` edge without changing the local document model.
+
+## Parsing and safety
+
+The Markdown extractor is a dependency-free, line-oriented parser. It handles
+the structural features needed by the graph and is not intended to render
+Markdown.
+
+- fenced code blocks are skipped;
+- URL decoding is guarded against malformed escapes;
+- links that normalize outside the repository are discarded;
+- extracted prose is capped at 4 KiB per node;
+- the repository indexer's existing file-size and ignore rules still apply.
+
+## Compatibility
+
+- Existing node- and edge-kind numeric values remain unchanged.
+- The Rust kernel mirrors the appended `section` kind so native extraction
+  compatibility checks continue to pass.
+- Markdown uses a custom TypeScript extractor and requires no tree-sitter
+  grammar or kernel support.
+- Existing graph APIs need no schema change: document links are ordinary
+  `contains` and `references` edges, and prose uses `docstring`.
+- The topology UI is a read-only service over the existing graph. Its design,
+  API, security boundary, and zero-regression contract are specified in
+  [Repository Topology UI V1](repository-topology-ui-v1.md).
+
+## Acceptance criteria
+
+Given a repository with source code and Markdown:
+
+1. Markdown files and their heading hierarchy are queryable as nodes.
+2. Document prose is discoverable through natural search/context retrieval.
+3. Local links resolve to the correct document section or source file.
+4. An unambiguous inline code symbol resolves to its definition.
+5. Ambiguous symbols and external URLs do not produce incorrect edges.
+6. Incremental indexing and deletion use the existing per-file lifecycle.
+7. TypeScript build, unit tests, integration tests, and native kind-table
+   parity pass.
+8. The embedded local UI service renders code and document topology without a
+   CDN or a second extraction pipeline.
+
+## Deferred work
+
+- external-resource nodes and crawlers;
+- non-Markdown document formats;
+- source-line fragments that resolve to symbols;
+- semantic/LLM-assisted entity and relationship extraction;
+- backlinks inferred from prose without explicit links or code spans;
+- Markdown AST fidelity beyond the supported structural subset.

--- a/docs/design/repository-topology-ui-v1.md
+++ b/docs/design/repository-topology-ui-v1.md
@@ -1,0 +1,269 @@
+# Repository Topology UI V1
+
+## Status
+
+Proposed for the repository-documents V1 and implemented in the same change.
+
+## Goals
+
+Provide a local, read-only visual topology of the graph already stored by
+CodeGraph, including source symbols, repository Markdown files, document
+sections, and every relationship kind produced by the existing indexer.
+
+The UI is a view over CodeGraph. It is not a second extraction pipeline and it
+must not change, replace, aggregate, or reinterpret persisted relationships.
+
+## Non-regression contract
+
+Repository-document support is additive:
+
+- every pre-existing node-kind numeric value remains unchanged;
+- every pre-existing edge-kind numeric value remains unchanged;
+- non-Markdown files continue through the existing tree-sitter/kernel
+  extraction and resolution paths without a new filter or fallback;
+- indexing or synchronizing Markdown must not delete or rewrite nodes or edges
+  belonging to existing source files;
+- the TypeScript and Rust native wire-kind tables must stay identical.
+
+This contract is enforced by:
+
+1. pinning the complete pre-document node-kind prefix and edge-kind table;
+2. indexing a source-only repository, adding Markdown, synchronizing, and
+   asserting that every original source node and edge still exists;
+3. running the existing extraction/resolution suites;
+4. compiling and testing the Rust kernel protocol.
+
+## Service boundary
+
+`codegraph ui [path]` opens the existing project synchronously and starts a
+Node HTTP server. The default address is `http://127.0.0.1:7474`.
+
+The server:
+
+- reads through the public `CodeGraph` query surface;
+- never initializes, indexes, synchronizes, watches, or writes a project;
+- binds to loopback unless the caller explicitly supplies another host;
+- serves only bundled static assets and JSON APIs;
+- has no CDN or runtime network dependency;
+- closes the graph connection on process termination.
+
+The MCP stdio server remains unchanged. The topology server is a separate,
+human-facing command so neither protocol owns the other process lifecycle.
+
+## HTTP API
+
+### `GET /api/graph`
+
+Returns a deterministic, bounded topology snapshot:
+
+- nodes ordered by graph degree, with repository file nodes preferred as
+  stable topology anchors;
+- all persisted edges whose source and target are both in the snapshot;
+- whole-project statistics and a `truncated` flag;
+- an optional comma-separated node-kind filter;
+- a hard server-side node limit.
+
+The limit protects browser memory; it is a presentation limit only. The
+database and all graph relationships remain complete.
+
+### `GET /api/search?q=...`
+
+Uses CodeGraph's existing search implementation and returns a bounded list of
+matching nodes. It does not maintain a second search index.
+
+### `GET /api/node?id=...`
+
+Returns one node plus a bounded first page of its persisted incoming and
+outgoing edges, the full relationship counts, a truncation marker, and the
+known endpoint nodes. This lets the UI inspect relationships that are outside
+the initial bounded snapshot without an unbounded browser response.
+
+### `GET /api/stats`
+
+Returns the existing whole-project graph statistics.
+
+## Front-end
+
+The bundled front-end uses browser-native SVG and JavaScript. Its layout is a
+deterministic repository topology:
+
+- file nodes act as anchors;
+- symbols and document sections cluster around their owning file;
+- directed edges retain their persisted CodeGraph kind;
+- pan and zoom operate locally in the browser.
+
+The interaction model borrows the useful parts of Graphify's generated page:
+
+- node search;
+- kind legend and filtering;
+- click-to-inspect details;
+- clickable incoming and outgoing neighbors;
+- visible node/edge/project counts.
+
+Unlike Graphify's current HTML exporter, V1 does not load `vis-network` from a
+public CDN, so an offline CodeGraph installation remains fully local.
+
+## Security
+
+- Dynamic graph content is rendered with DOM text nodes, not injected HTML.
+- Responses set a same-origin Content Security Policy and disable MIME
+  sniffing.
+- Static paths are an allow-list, not filesystem-derived request paths.
+- API query lengths, result sizes, node limits, and node-kind values are
+  validated and bounded.
+- There is no source-file content endpoint in V1.
+
+## Acceptance criteria
+
+1. `codegraph ui` is visible in CLI help and serves an initialized project.
+2. The page loads without third-party network requests.
+3. Code and Markdown nodes appear in the same topology.
+4. Every edge returned by the API is an unchanged persisted CodeGraph edge.
+5. Search, kind filtering, node inspection, pan, and zoom work in a real
+   browser.
+6. API, CLI, build, Rust protocol, integration, and browser smoke tests pass.
+
+## Deferred work
+
+- graph community detection or aggregated meta-graphs;
+- mutable annotations and graph editing;
+- source-code preview;
+- live watcher updates or server-sent events;
+- remote access controls;
+- external-resource nodes and crawlers.
+
+---
+
+## V2 visual overview
+
+### Problem
+
+The first implementation placed every visible node into a file constellation
+and labeled files, sections, and high-degree symbols. That worked for
+inspection, but on a real repository the labels became the dominant visual
+mark. The viewer could read individual names yet could not quickly perceive:
+
+- which semantic categories dominate the repository;
+- how code, documents, types, behavior, and dependencies are distributed;
+- which top-level directories or languages carry most of the graph;
+- where relationships cross those groups.
+
+### Design references
+
+V2 follows two established visualization principles:
+
+- space-filling hierarchy views use area to make macro distribution and micro
+  detail visible at the same time, as in treemaps;
+- code graph explorers separate an overview from focused node inspection and
+  provide explicit controls for node types, edge types, labels, and grouping.
+
+The implementation remains dependency-free and bundled. These are interaction
+and information-design references, not runtime libraries.
+
+References:
+
+- D3 hierarchy and treemap design:
+  <https://d3js.org/d3-hierarchy/treemap>
+- GitNexus code-knowledge graph explorer:
+  <https://github.com/nxpatterns/gitnexus>
+
+### Default view
+
+The graph canvas becomes a weighted, binary-partition treemap:
+
+- each group receives screen area proportional to its visible node count;
+- the default grouping is **semantic role**:
+  `Documents`, `Structure`, `Types`, `Behavior`, `Data`, and `Dependencies`;
+- users can regroup the same nodes by top-level directory or language;
+- every group shows its name, node count, and percentage of the current view;
+- nodes are compact dots within their group, sized by local degree;
+- node color can encode kind, language, or semantic role.
+
+This makes classification and distribution readable before the user selects a
+single node.
+
+### Relationship levels
+
+Relationship rendering has four explicit levels:
+
+1. **Between groups** (default): exact persisted edges are counted by
+   source/target group and rendered as weighted aggregate curves.
+2. **Selected node**: only exact edges incident to the selected node are
+   rendered.
+3. **All visible**: every exact edge in the bounded snapshot is rendered.
+4. **None**: no relationship layer.
+
+Aggregation is visual only. The inspector continues to retrieve exact
+persisted edges and full counts from the graph API.
+
+Users can independently include or exclude each persisted edge kind. Aggregate
+counts and exact-edge views always respect those choices.
+
+### Label policy
+
+Long labels no longer determine the overview geometry.
+
+- `Auto` (default) shows only group labels at overview zoom, adds key-node
+  labels after zooming, and reveals more labels at detail zoom.
+- `Key nodes` labels only high-degree nodes.
+- `All` labels every visible node.
+- `None` hides all node labels.
+
+Displayed node labels are compacted to 20 characters. Full names and qualified
+names remain available through the SVG title, search results, and inspector.
+Hovering or selecting a node always reveals its compact label.
+
+### Optional generated display labels
+
+Generated summaries are allowed only as a presentation overlay. A future
+OpenAI-compatible provider (for example a low-cost DeepSeek Flash-class model)
+may generate:
+
+- a short display alias for a long document heading or symbol label;
+- a one-line summary for a visual group;
+- a compact explanation of why a selected document and code symbol connect.
+
+The overlay must obey these invariants:
+
+- it is disabled by default and the UI works fully offline without it;
+- generated text is stored in a separate UI sidecar/cache, never in the graph
+  node or edge tables;
+- cache keys use the immutable node ID plus a source-content hash;
+- `name`, `qualifiedName`, node IDs, edge kinds, edge endpoints, metadata, and
+  relationship counts are never rewritten;
+- provider failure, timeout, or missing credentials falls back to the
+  deterministic compact label;
+- repository content is not sent externally without explicit user
+  configuration.
+
+This keeps graph identity and relationship truth deterministic while allowing
+low-cost models to improve presentation when users opt in.
+
+### Right-side controls
+
+The useful V1 right panel remains the interaction center. V2 adds:
+
+- group by: semantic role / directory / language;
+- color by: node kind / language / semantic role;
+- relationships: between groups / selected node / all visible / none;
+- labels: auto / key nodes / all / none;
+- node-kind filters;
+- edge-kind filters;
+- live group-distribution bars.
+
+The inspector remains below these controls and continues to show the exact
+node identity plus incoming and outgoing neighbors.
+
+### V2 acceptance criteria
+
+1. A 1,000+ node repository shows its dominant categories and proportions
+   without reading node labels.
+2. The default view renders substantially fewer node labels than nodes.
+3. Regrouping by semantic role, directory, or language recomputes the visual
+   distribution without another server request.
+4. Aggregate relationship curves preserve exact visible-edge counts.
+5. Node- and edge-kind filters update groups, counts, and relationship totals.
+6. Direct node selection and the right-side inspector still expose exact
+   persisted relationships.
+7. Search, regrouping, filtering, label modes, relationship modes, pan, and
+   zoom pass real-browser tests with no console errors or external requests.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc && npm run copy-assets && node -e \"require('fs').chmodSync('dist/bin/codegraph.js', 0o755)\"",
     "preuninstall": "node dist/bin/uninstall.js",
-    "copy-assets": "node -e \"const fs=require('fs');fs.mkdirSync('dist/db',{recursive:true});fs.copyFileSync('src/db/schema.sql','dist/db/schema.sql');fs.mkdirSync('dist/extraction/wasm',{recursive:true});fs.readdirSync('src/extraction/wasm').filter(f=>f.endsWith('.wasm')).forEach(f=>fs.copyFileSync('src/extraction/wasm/'+f,'dist/extraction/wasm/'+f))\"",
+    "copy-assets": "node -e \"const fs=require('fs');fs.mkdirSync('dist/db',{recursive:true});fs.copyFileSync('src/db/schema.sql','dist/db/schema.sql');fs.mkdirSync('dist/extraction/wasm',{recursive:true});fs.readdirSync('src/extraction/wasm').filter(f=>f.endsWith('.wasm')).forEach(f=>fs.copyFileSync('src/extraction/wasm/'+f,'dist/extraction/wasm/'+f));fs.cpSync('src/ui/assets','dist/ui/assets',{recursive:true})\"",
     "dev": "tsc --watch",
     "build:kernel": "bash scripts/build-kernel.sh",
     "cli": "npm run build && node dist/bin/codegraph.js",

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -1668,6 +1668,78 @@ function printFileTree(
 }
 
 /**
+ * codegraph ui [path]
+ */
+program
+  .command('ui [path]')
+  .description('Open a read-only local web UI for the repository topology')
+  .option('--host <host>', 'Bind address', '127.0.0.1')
+  .option('-p, --port <port>', 'TCP port', '7474')
+  .option('-l, --limit <nodes>', 'Maximum nodes in the initial browser view', '800')
+  .action(async (
+    pathArg: string | undefined,
+    options: { host: string; port: string; limit: string }
+  ) => {
+    const projectPath = resolveProjectPath(pathArg);
+    const port = Number(options.port);
+    const nodeLimit = Number(options.limit);
+    if (!Number.isInteger(port) || port < 0 || port > 65535) {
+      error('Port must be an integer from 0 to 65535');
+      process.exitCode = 1;
+      return;
+    }
+    if (!Number.isInteger(nodeLimit) || nodeLimit < 1 || nodeLimit > 2000) {
+      error('Limit must be an integer from 1 to 2000');
+      process.exitCode = 1;
+      return;
+    }
+
+    let cg: import('../index').CodeGraph | null = null;
+    let uiServer: import('../ui/topology-server').TopologyServer | null = null;
+    try {
+      const { CodeGraph } = await loadCodeGraph();
+      const { startTopologyServer } = await import('../ui/topology-server');
+      cg = CodeGraph.openSync(projectPath);
+      uiServer = await startTopologyServer(cg, {
+        host: options.host,
+        port,
+        nodeLimit,
+      });
+      console.log(chalk.bold('\nCodeGraph repository topology\n'));
+      console.log(`  ${chalk.cyan(uiServer.url)}`);
+      console.log(chalk.dim(`  ${projectPath}`));
+      console.log(chalk.dim('\n  Read only · bundled assets · press Ctrl+C to stop\n'));
+
+      await new Promise<void>((resolve) => {
+        let stopping = false;
+        const stop = (): void => {
+          if (stopping) return;
+          stopping = true;
+          void (async () => {
+            try {
+              await uiServer?.close();
+            } finally {
+              cg?.close();
+              resolve();
+            }
+          })();
+        };
+        process.once('SIGINT', stop);
+        process.once('SIGTERM', stop);
+      });
+    } catch (err) {
+      try {
+        await uiServer?.close();
+      } catch {
+        // Preserve the original startup failure.
+      }
+      cg?.close();
+      error(`Failed to start topology UI: ${err instanceof Error ? err.message : String(err)}`);
+      process.exitCode = 1;
+    }
+  });
+
+/**
  * codegraph daemon — interactive manager for the background daemons. Arrow keys
  * to pick one (the current project's daemon floats to the top, auto-selected),
  * enter to stop it. Falls back to a plain list when output isn't a TTY.

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -159,6 +159,7 @@ const DEFAULT_BUILD_OPTIONS: Required<BuildContextOptions> = {
 const HIGH_VALUE_NODE_KINDS: NodeKind[] = [
   'function', 'method', 'class', 'interface', 'type_alias', 'struct', 'trait',
   'component', 'route', 'variable', 'constant', 'enum', 'module', 'namespace',
+  'section',
 ];
 
 /**

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1071,6 +1071,68 @@ export class QueryBuilder {
   }
 
   /**
+   * Select a deterministic, bounded set of well-connected nodes for a visual
+   * topology. The persisted graph is not aggregated or rewritten: callers can
+   * recover the exact induced edge set with {@link findEdgesBetweenNodes}.
+   *
+   * Degree is computed in SQL so a browser view never has to materialize the
+   * complete node table just to choose a bounded snapshot.
+   */
+  getTopologyNodes(
+    limit: number,
+    kinds?: readonly NodeKind[]
+  ): { nodes: Node[]; totalMatchedNodes: number } {
+    const hasKindFilter = kinds !== undefined && kinds.length > 0;
+    const kindClause = hasKindFilter
+      ? ` WHERE n.kind IN (${kinds!.map(() => '?').join(',')})`
+      : '';
+    const countClause = hasKindFilter
+      ? ` WHERE kind IN (${kinds!.map(() => '?').join(',')})`
+      : '';
+    const kindParams = hasKindFilter ? [...kinds!] : [];
+
+    const totalRow = this.db
+      .prepare(`SELECT COUNT(*) AS count FROM nodes${countClause}`)
+      .get(...kindParams) as { count: number };
+
+    const rows = this.db.prepare(`
+      WITH endpoint_degrees AS (
+        SELECT endpoint, SUM(degree) AS degree
+        FROM (
+          SELECT source AS endpoint, COUNT(*) AS degree
+          FROM edges
+          GROUP BY source
+          UNION ALL
+          SELECT target AS endpoint, COUNT(*) AS degree
+          FROM edges
+          GROUP BY target
+        )
+        GROUP BY endpoint
+      )
+      SELECT n.*
+      FROM nodes n
+      LEFT JOIN endpoint_degrees d ON d.endpoint = n.id
+      ${kindClause}
+      ORDER BY
+        COALESCE(d.degree, 0) DESC,
+        CASE n.kind
+          WHEN 'file' THEN 0
+          WHEN 'section' THEN 1
+          ELSE 2
+        END,
+        n.file_path,
+        n.start_line,
+        n.id
+      LIMIT ?
+    `).all(...kindParams, limit) as NodeRow[];
+
+    return {
+      nodes: rows.map(rowToNode),
+      totalMatchedNodes: totalRow.count,
+    };
+  }
+
+  /**
    * Stream nodes of one language whose `decorators` JSON array contains
    * `decorator`. The LIKE on the JSON text is a cheap index-free pre-filter
    * (a decorator name can appear as a substring of another), so callers must
@@ -1754,6 +1816,40 @@ export class QueryBuilder {
     }
     const rows = this.stmts.getEdgesByTarget.all(targetId) as EdgeRow[];
     return rows.map(rowToEdge);
+  }
+
+  /**
+   * Bounded outgoing-edge page plus the exact persisted total. Used by
+   * read-only visual clients so a high-degree hub never materializes an
+   * unbounded response (or an unbounded intermediate array).
+   */
+  getOutgoingEdgesLimited(
+    sourceId: string,
+    limit: number
+  ): { edges: Edge[]; total: number } {
+    const count = this.db
+      .prepare('SELECT COUNT(*) AS count FROM edges WHERE source = ?')
+      .get(sourceId) as { count: number };
+    const rows = this.db
+      .prepare('SELECT * FROM edges WHERE source = ? ORDER BY rowid LIMIT ?')
+      .all(sourceId, limit) as EdgeRow[];
+    return { edges: rows.map(rowToEdge), total: count.count };
+  }
+
+  /**
+   * Bounded incoming-edge page plus the exact persisted total.
+   */
+  getIncomingEdgesLimited(
+    targetId: string,
+    limit: number
+  ): { edges: Edge[]; total: number } {
+    const count = this.db
+      .prepare('SELECT COUNT(*) AS count FROM edges WHERE target = ?')
+      .get(targetId) as { count: number };
+    const rows = this.db
+      .prepare('SELECT * FROM edges WHERE target = ? ORDER BY rowid LIMIT ?')
+      .all(targetId, limit) as EdgeRow[];
+    return { edges: rows.map(rowToEdge), total: count.count };
   }
 
   /**

--- a/src/extraction/grammars.ts
+++ b/src/extraction/grammars.ts
@@ -11,7 +11,7 @@ import * as fsp from 'fs/promises';
 import { Parser, Language as WasmLanguage } from 'web-tree-sitter';
 import { Language } from '../types';
 
-export type GrammarLanguage = Exclude<Language, 'svelte' | 'vue' | 'astro' | 'liquid' | 'razor' | 'yaml' | 'twig' | 'xml' | 'properties' | 'unknown'>;
+export type GrammarLanguage = Exclude<Language, 'svelte' | 'vue' | 'astro' | 'liquid' | 'razor' | 'yaml' | 'twig' | 'xml' | 'properties' | 'markdown' | 'unknown'>;
 
 /**
  * WASM filename map — maps each language to its .wasm grammar file
@@ -56,6 +56,10 @@ const WASM_GRAMMAR_FILES: Record<GrammarLanguage, string> = {
  * File extension to Language mapping
  */
 export const EXTENSION_MAP: Record<string, Language> = {
+  // Repository-local documentation — custom structural extractor.
+  '.md': 'markdown',
+  '.mdx': 'markdown',
+  '.markdown': 'markdown',
   '.ts': 'typescript',
   '.tsx': 'tsx',
   // ESM/CJS TypeScript module extensions — parsed as TS (no JSX). (#366)
@@ -527,6 +531,7 @@ function looksLikeObjc(source: string): boolean {
  * Returns true if the grammar exists, even if not yet loaded.
  */
 export function isLanguageSupported(language: Language): boolean {
+  if (language === 'markdown') return true; // custom repository-document extractor
   if (language === 'svelte') return true; // custom extractor (script block delegation)
   if (language === 'vue') return true; // custom extractor (script block delegation)
   if (language === 'astro') return true; // custom extractor (frontmatter/script block delegation)
@@ -544,6 +549,7 @@ export function isLanguageSupported(language: Language): boolean {
  * Check if a grammar has been loaded and is ready for parsing.
  */
 export function isGrammarLoaded(language: Language): boolean {
+  if (language === 'markdown') return true;
   if (language === 'svelte' || language === 'vue' || language === 'astro' || language === 'liquid' || language === 'razor') return true;
   if (language === 'yaml' || language === 'twig') return true; // no WASM grammar needed
   if (language === 'xml' || language === 'properties') return true; // no WASM grammar needed
@@ -567,7 +573,7 @@ export function isFileLevelOnlyLanguage(language: Language): boolean {
  * Get all supported languages (those with grammar definitions).
  */
 export function getSupportedLanguages(): Language[] {
-  return [...(Object.keys(WASM_GRAMMAR_FILES) as GrammarLanguage[]), 'svelte', 'vue', 'astro', 'liquid'];
+  return [...(Object.keys(WASM_GRAMMAR_FILES) as GrammarLanguage[]), 'svelte', 'vue', 'astro', 'liquid', 'markdown'];
 }
 
 /**
@@ -656,6 +662,7 @@ export function getLanguageDisplayName(language: Language): string {
     terraform: 'Terraform',
     arkts: 'ArkTS',
     unknown: 'Unknown',
+    markdown: 'Markdown',
   };
   return names[language] || language;
 }

--- a/src/extraction/markdown-extractor.ts
+++ b/src/extraction/markdown-extractor.ts
@@ -1,0 +1,482 @@
+import * as path from 'path';
+import {
+  Edge,
+  ExtractionError,
+  ExtractionResult,
+  Node,
+  UnresolvedReference,
+} from '../types';
+import { generateNodeId } from './tree-sitter-helpers';
+
+const MAX_DOCSTRING_LENGTH = 4096;
+
+interface Heading {
+  level: number;
+  title: string;
+  slug: string;
+  line: number;
+  contentStartLine: number;
+  startColumn: number;
+  endLine: number;
+  id: string;
+  qualifiedName: string;
+  parentId: string;
+}
+
+interface InternalTarget {
+  filePath: string;
+  fragment?: string;
+}
+
+/**
+ * Dependency-free structural Markdown extraction.
+ *
+ * This intentionally parses only the subset needed by the repository graph:
+ * headings, local links, and high-signal inline-code symbol mentions. It does
+ * not try to render Markdown or replace a full CommonMark parser.
+ */
+export class MarkdownExtractor {
+  private readonly filePath: string;
+  private readonly lines: string[];
+  private readonly fencedLines: boolean[];
+  private readonly headingLines = new Set<number>();
+  private readonly nodes: Node[] = [];
+  private readonly edges: Edge[] = [];
+  private readonly unresolvedReferences: UnresolvedReference[] = [];
+  private readonly errors: ExtractionError[] = [];
+  private readonly sectionIdsBySlug = new Map<string, string>();
+  private headings: Heading[] = [];
+
+  constructor(filePath: string, source: string) {
+    this.filePath = filePath.replace(/\\/g, '/');
+    this.lines = source.split(/\r?\n/);
+    this.fencedLines = this.markFencedLines();
+  }
+
+  extract(): ExtractionResult {
+    const startTime = Date.now();
+
+    try {
+      const fileNode = this.createFileNode();
+      this.headings = this.extractHeadings(fileNode.id);
+      this.attachDocstrings(fileNode);
+      this.extractReferences(fileNode.id);
+    } catch (error) {
+      this.errors.push({
+        message: `Markdown extraction error: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        filePath: this.filePath,
+        severity: 'error',
+        code: 'parse_error',
+      });
+    }
+
+    return {
+      nodes: this.nodes,
+      edges: this.edges,
+      unresolvedReferences: this.unresolvedReferences,
+      errors: this.errors,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  private createFileNode(): Node {
+    const lastLine = this.lines[this.lines.length - 1] ?? '';
+    const node: Node = {
+      id: `file:${this.filePath}`,
+      kind: 'file',
+      name: path.posix.basename(this.filePath),
+      qualifiedName: this.filePath,
+      filePath: this.filePath,
+      language: 'markdown',
+      startLine: 1,
+      endLine: Math.max(1, this.lines.length),
+      startColumn: 0,
+      endColumn: lastLine.length,
+      updatedAt: Date.now(),
+    };
+    this.nodes.push(node);
+    return node;
+  }
+
+  private markFencedLines(): boolean[] {
+    const marked = new Array<boolean>(this.lines.length).fill(false);
+    let open: { marker: string; length: number } | null = null;
+
+    for (let index = 0; index < this.lines.length; index++) {
+      const line = this.lines[index] ?? '';
+      if (open) {
+        marked[index] = true;
+        const close = /^\s{0,3}(`{3,}|~{3,})\s*$/.exec(line);
+        if (
+          close &&
+          close[1]![0] === open.marker &&
+          close[1]!.length >= open.length
+        ) {
+          open = null;
+        }
+        continue;
+      }
+
+      const start = /^\s{0,3}(`{3,}|~{3,})/.exec(line);
+      if (start) {
+        marked[index] = true;
+        open = { marker: start[1]![0]!, length: start[1]!.length };
+      }
+    }
+
+    return marked;
+  }
+
+  private extractHeadings(fileNodeId: string): Heading[] {
+    const headings: Heading[] = [];
+    const slugCounts = new Map<string, number>();
+
+    for (let index = 0; index < this.lines.length; index++) {
+      if (this.fencedLines[index]) continue;
+      const line = this.lines[index] ?? '';
+      const atx = /^(\s{0,3})(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$/.exec(line);
+
+      let level: number;
+      let rawTitle: string;
+      let startColumn: number;
+      let contentStartLine: number;
+
+      if (atx) {
+        level = atx[2]!.length;
+        rawTitle = atx[3]!;
+        startColumn = atx[1]!.length;
+        contentStartLine = index + 2;
+        this.headingLines.add(index + 1);
+      } else {
+        const underline = this.lines[index + 1];
+        const setext =
+          underline !== undefined &&
+          !this.fencedLines[index + 1] &&
+          /^\s{0,3}(=+|-+)\s*$/.exec(underline);
+        if (!setext || line.trim().length === 0) continue;
+        level = setext[1]![0] === '=' ? 1 : 2;
+        rawTitle = line.trim();
+        startColumn = line.indexOf(rawTitle);
+        contentStartLine = index + 3;
+        this.headingLines.add(index + 1);
+        this.headingLines.add(index + 2);
+        index++;
+      }
+
+      const title = this.cleanHeading(rawTitle);
+      if (!title) continue;
+      const baseSlug = this.slugify(title) || 'section';
+      const count = slugCounts.get(baseSlug) ?? 0;
+      slugCounts.set(baseSlug, count + 1);
+      const slug = count === 0 ? baseSlug : `${baseSlug}-${count}`;
+      const lineNumber = index + (atx ? 1 : 0);
+      const qualifiedName = `${this.filePath}#${slug}`;
+      const id = generateNodeId(this.filePath, 'section', qualifiedName, lineNumber);
+
+      headings.push({
+        level,
+        title,
+        slug,
+        line: lineNumber,
+        contentStartLine,
+        startColumn,
+        endLine: this.lines.length,
+        id,
+        qualifiedName,
+        parentId: fileNodeId,
+      });
+    }
+
+    const stack: Heading[] = [];
+    for (const heading of headings) {
+      while (stack.length > 0 && stack[stack.length - 1]!.level >= heading.level) {
+        stack.pop()!.endLine = Math.max(1, heading.line - 1);
+      }
+      heading.parentId = stack[stack.length - 1]?.id ?? fileNodeId;
+      stack.push(heading);
+    }
+
+    for (const heading of headings) {
+      const endLine = Math.max(heading.line, heading.endLine);
+      const endColumn = (this.lines[endLine - 1] ?? '').length;
+      this.nodes.push({
+        id: heading.id,
+        kind: 'section',
+        name: heading.title,
+        qualifiedName: heading.qualifiedName,
+        filePath: this.filePath,
+        language: 'markdown',
+        startLine: heading.line,
+        endLine,
+        startColumn: heading.startColumn,
+        endColumn,
+        updatedAt: Date.now(),
+      });
+      this.sectionIdsBySlug.set(heading.slug, heading.id);
+      this.edges.push({
+        source: heading.parentId,
+        target: heading.id,
+        kind: 'contains',
+        line: heading.line,
+        column: heading.startColumn,
+        provenance: 'heuristic',
+      });
+    }
+
+    return headings;
+  }
+
+  private attachDocstrings(fileNode: Node): void {
+    const firstHeadingLine = this.headings[0]?.line ?? this.lines.length + 1;
+    fileNode.docstring = this.extractProse(1, firstHeadingLine - 1);
+    const nodesById = new Map(this.nodes.map((node) => [node.id, node]));
+
+    for (let index = 0; index < this.headings.length; index++) {
+      const heading = this.headings[index]!;
+      const nextHeadingLine = this.headings[index + 1]?.line ?? this.lines.length + 1;
+      const node = nodesById.get(heading.id);
+      if (node) {
+        node.docstring = this.extractProse(
+          heading.contentStartLine,
+          nextHeadingLine - 1
+        );
+      }
+    }
+  }
+
+  private extractProse(startLine: number, endLine: number): string | undefined {
+    if (endLine < startLine) return undefined;
+    const prose: string[] = [];
+
+    for (
+      let lineNumber = Math.max(1, startLine);
+      lineNumber <= Math.min(endLine, this.lines.length);
+      lineNumber++
+    ) {
+      if (this.fencedLines[lineNumber - 1] || this.headingLines.has(lineNumber)) {
+        continue;
+      }
+      const raw = this.lines[lineNumber - 1] ?? '';
+      if (/^\s{0,3}\[[^\]]+\]:\s*\S+/.test(raw)) continue;
+      const cleaned = raw
+        .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+        .replace(/\[([^\]]+)\]\[[^\]]+\]/g, '$1')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/^\s{0,3}>\s?/, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+      if (cleaned) prose.push(cleaned);
+    }
+
+    const value = prose.join('\n').trim();
+    if (!value) return undefined;
+    return value.length <= MAX_DOCSTRING_LENGTH
+      ? value
+      : `${value.slice(0, MAX_DOCSTRING_LENGTH - 1)}…`;
+  }
+
+  private extractReferences(fileNodeId: string): void {
+    const referenceDefinitions = new Map<string, string>();
+    for (let index = 0; index < this.lines.length; index++) {
+      if (this.fencedLines[index]) continue;
+      const definition =
+        /^\s{0,3}\[([^\]]+)\]:\s*(?:<([^>]+)>|(\S+))/.exec(
+          this.lines[index] ?? ''
+        );
+      if (definition) {
+        referenceDefinitions.set(
+          definition[1]!.trim().toLowerCase(),
+          definition[2] ?? definition[3]!
+        );
+      }
+    }
+
+    let headingIndex = 0;
+    let ownerId = fileNodeId;
+
+    for (let index = 0; index < this.lines.length; index++) {
+      const lineNumber = index + 1;
+      while (
+        headingIndex < this.headings.length &&
+        this.headings[headingIndex]!.line <= lineNumber
+      ) {
+        ownerId = this.headings[headingIndex]!.id;
+        headingIndex++;
+      }
+      if (this.fencedLines[index]) continue;
+      const line = this.lines[index] ?? '';
+      if (/^\s{0,3}\[[^\]]+\]:\s*\S+/.test(line)) continue;
+
+      const inlineLink =
+        /(!?)\[([^\]\n]*)\]\(\s*(?:<([^>\n]+)>|([^\s)\n]+))(?:\s+["'][^"'\n]*["'])?\s*\)/g;
+      let linkMatch: RegExpExecArray | null;
+      while ((linkMatch = inlineLink.exec(line)) !== null) {
+        if (linkMatch[1] === '!') continue;
+        const target = linkMatch[3] ?? linkMatch[4];
+        if (target) {
+          this.emitLink(ownerId, target, lineNumber, linkMatch.index);
+        }
+      }
+
+      const referenceLink = /(!?)\[([^\]\n]+)\]\[([^\]\n]+)\]/g;
+      while ((linkMatch = referenceLink.exec(line)) !== null) {
+        if (linkMatch[1] === '!') continue;
+        const target = referenceDefinitions.get(linkMatch[3]!.trim().toLowerCase());
+        if (target) {
+          this.emitLink(ownerId, target, lineNumber, linkMatch.index);
+        }
+      }
+
+      const inlineCode = /(`+)([^`\n]+?)\1/g;
+      let codeMatch: RegExpExecArray | null;
+      while ((codeMatch = inlineCode.exec(line)) !== null) {
+        const candidate = this.normalizeSymbolCandidate(codeMatch[2]!);
+        if (!candidate) continue;
+        this.unresolvedReferences.push({
+          fromNodeId: ownerId,
+          referenceName: candidate,
+          referenceKind: 'document_symbol',
+          line: lineNumber,
+          column: codeMatch.index,
+          filePath: this.filePath,
+          language: 'markdown',
+        });
+      }
+    }
+  }
+
+  private emitLink(
+    fromNodeId: string,
+    rawTarget: string,
+    line: number,
+    column: number
+  ): void {
+    const target = this.normalizeInternalTarget(rawTarget);
+    if (!target) return;
+
+    const referenceName = target.fragment
+      ? `${target.filePath}#${target.fragment}`
+      : target.filePath;
+
+    if (target.filePath === this.filePath) {
+      const targetId = target.fragment
+        ? this.sectionIdsBySlug.get(target.fragment)
+        : `file:${this.filePath}`;
+      if (targetId) {
+        if (targetId !== fromNodeId) {
+          this.edges.push({
+            source: fromNodeId,
+            target: targetId,
+            kind: 'references',
+            line,
+            column,
+            provenance: 'heuristic',
+            metadata: {
+              docRef: 'link',
+              refName: referenceName,
+              refKind: 'document_link',
+            },
+          });
+        }
+        return;
+      }
+    }
+
+    this.unresolvedReferences.push({
+      fromNodeId,
+      referenceName,
+      referenceKind: 'document_link',
+      line,
+      column,
+      filePath: this.filePath,
+      language: 'markdown',
+    });
+  }
+
+  private normalizeInternalTarget(rawTarget: string): InternalTarget | null {
+    let target = rawTarget.trim();
+    if (!target || target.startsWith('//')) return null;
+    if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(target)) return null;
+
+    try {
+      target = decodeURIComponent(target);
+    } catch {
+      return null;
+    }
+
+    const hashIndex = target.indexOf('#');
+    const rawPath = (hashIndex >= 0 ? target.slice(0, hashIndex) : target)
+      .split('?', 1)[0]!
+      .replace(/\\/g, '/');
+    const rawFragment = hashIndex >= 0 ? target.slice(hashIndex + 1) : '';
+
+    let targetPath: string;
+    if (!rawPath) {
+      targetPath = this.filePath;
+    } else if (rawPath.startsWith('/')) {
+      targetPath = path.posix.normalize(rawPath.slice(1));
+    } else {
+      targetPath = path.posix.normalize(
+        path.posix.join(path.posix.dirname(this.filePath), rawPath)
+      );
+    }
+
+    if (
+      !targetPath ||
+      targetPath === '..' ||
+      targetPath.startsWith('../') ||
+      path.posix.isAbsolute(targetPath)
+    ) {
+      return null;
+    }
+
+    const fragment = rawFragment ? this.slugify(rawFragment) : undefined;
+    return fragment ? { filePath: targetPath, fragment } : { filePath: targetPath };
+  }
+
+  private normalizeSymbolCandidate(raw: string): string | null {
+    const candidate = raw.trim();
+    if (
+      !/^[A-Za-z_$][A-Za-z0-9_$]*(?:(?:::|\.|->)[A-Za-z_$][A-Za-z0-9_$]*)*(?:\(\))?$/.test(
+        candidate
+      )
+    ) {
+      return null;
+    }
+
+    const hasStrongSignal =
+      /(?:::|\.|->)/.test(candidate) ||
+      candidate.endsWith('()') ||
+      /^[A-Z]/.test(candidate) ||
+      /[A-Z]/.test(candidate.slice(1)) ||
+      candidate.includes('_');
+    if (!hasStrongSignal) return null;
+
+    return candidate.replace(/\(\)$/, '').replace(/->/g, '.');
+  }
+
+  private cleanHeading(raw: string): string {
+    return raw
+      .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+      .replace(/`+([^`]+)`+/g, '$1')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/[*_~]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  private slugify(value: string): string {
+    return value
+      .trim()
+      .toLowerCase()
+      .replace(/<[^>]+>/g, '')
+      .replace(/[^\p{L}\p{N}\s_-]/gu, '')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
+  }
+}

--- a/src/extraction/tree-sitter.ts
+++ b/src/extraction/tree-sitter.ts
@@ -30,6 +30,7 @@ import { DfmExtractor } from './dfm-extractor';
 import { VueExtractor } from './vue-extractor';
 import { MyBatisExtractor } from './mybatis-extractor';
 import { CfmlExtractor } from './cfml-extractor';
+import { MarkdownExtractor } from './markdown-extractor';
 import { tryKernelExtract, takeDeferredPreParse } from './kernel';
 import {
   getAllFrameworkResolvers,
@@ -6663,8 +6664,13 @@ export function extractFromSource(
 
   let result: ExtractionResult;
 
-  // Use custom extractor for Svelte
-  if (detectedLanguage === 'svelte') {
+  // Repository-local Markdown uses a lightweight structural extractor rather
+  // than a tree-sitter grammar.
+  if (detectedLanguage === 'markdown') {
+    const extractor = new MarkdownExtractor(filePath, source);
+    result = extractor.extract();
+  } else if (detectedLanguage === 'svelte') {
+    // Use custom extractor for Svelte
     const extractor = new SvelteExtractor(filePath, source);
     result = extractor.extract();
   } else if (detectedLanguage === 'vue') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,9 @@ import {
   SegmentMatch,
   Context,
   GraphStats,
+  TopologyNeighborhood,
+  TopologySnapshot,
+  TopologySnapshotOptions,
   TaskInput,
   TaskContext,
   BuildContextOptions,
@@ -92,6 +95,12 @@ export {
 export { Mutex, FileLock, processInBatches, debounce, throttle, MemoryMonitor } from './utils';
 export { FileWatcher, WatchOptions, PendingFile, LockUnavailableError } from './sync';
 export { MCPServer } from './mcp';
+export {
+  startTopologyServer,
+  TopologyGraphReader,
+  TopologyServer,
+  TopologyServerOptions,
+} from './ui/topology-server';
 
 /**
  * Options for initializing a new CodeGraph project
@@ -1300,6 +1309,62 @@ export class CodeGraph {
    */
   searchNodes(query: string, options?: SearchOptions): SearchResult[] {
     return this.queries.searchNodes(query, options);
+  }
+
+  /**
+   * Return an exact, read-only induced subgraph suitable for a visual client.
+   *
+   * The node selection is bounded and degree-ranked; the returned edges are
+   * the unchanged persisted edges between those nodes. This method never
+   * indexes, synchronizes, aggregates, or mutates the graph.
+   */
+  getTopologySnapshot(options: TopologySnapshotOptions = {}): TopologySnapshot {
+    const requestedLimit = Number.isFinite(options.limit) ? Math.trunc(options.limit!) : 800;
+    const limit = Math.max(1, Math.min(2000, requestedLimit));
+    const kinds = options.kinds && options.kinds.length > 0
+      ? [...new Set(options.kinds)]
+      : undefined;
+    const selected = this.queries.getTopologyNodes(limit, kinds);
+    const edges = this.queries.findEdgesBetweenNodes(selected.nodes.map((node) => node.id));
+
+    return {
+      nodes: selected.nodes,
+      edges,
+      stats: this.getStats(),
+      totalMatchedNodes: selected.totalMatchedNodes,
+      truncated: selected.totalMatchedNodes > selected.nodes.length,
+    };
+  }
+
+  /**
+   * Return one node's exact persisted relationship counts and a bounded edge
+   * page for the topology inspector.
+   */
+  getTopologyNeighborhood(nodeId: string, limit = 1000): TopologyNeighborhood | null {
+    const node = this.queries.getNodeById(nodeId);
+    if (!node) return null;
+    const boundedLimit = Number.isFinite(limit)
+      ? Math.max(1, Math.min(1000, Math.trunc(limit)))
+      : 1000;
+    const incoming = this.queries.getIncomingEdgesLimited(nodeId, boundedLimit);
+    const outgoing = this.queries.getOutgoingEdgesLimited(nodeId, boundedLimit);
+    const neighborIds = new Set<string>();
+    for (const edge of [...incoming.edges, ...outgoing.edges]) {
+      if (edge.source !== nodeId) neighborIds.add(edge.source);
+      if (edge.target !== nodeId) neighborIds.add(edge.target);
+    }
+    const neighborMap = this.queries.getNodesByIds([...neighborIds]);
+
+    return {
+      node,
+      incoming: incoming.edges,
+      outgoing: outgoing.edges,
+      neighbors: [...neighborMap.values()],
+      totalIncoming: incoming.total,
+      totalOutgoing: outgoing.total,
+      truncated:
+        incoming.total > incoming.edges.length || outgoing.total > outgoing.edges.length,
+    };
   }
 
   /**

--- a/src/resolution/index.ts
+++ b/src/resolution/index.ts
@@ -16,7 +16,7 @@ import {
   FrameworkResolver,
   ImportMapping,
 } from './types';
-import { matchReference, matchFunctionRef, matchDottedCallChain, matchScopedCallChain, matchMethodCall, sameLanguageFamily, crossesKnownFamily, dumpNameMatcherProfile, clearNameMatcherMemos } from './name-matcher';
+import { matchReference, matchFunctionRef, matchDottedCallChain, matchScopedCallChain, matchMethodCall, matchDocumentLink, matchDocumentSymbol, sameLanguageFamily, crossesKnownFamily, dumpNameMatcherProfile, clearNameMatcherMemos } from './name-matcher';
 import { resolveViaImport, resolveJvmImport, extractImportMappings, extractReExports, loadCppIncludeDirs, isPhpIncludePathRef, isCobolCopybookRef, isNixPathImportRef, clearImportResolverMemos } from './import-resolver';
 import { ResolverPool, minRefsForPool } from './resolver-pool';
 import { detectFrameworks } from './frameworks';
@@ -853,6 +853,16 @@ export class ReferenceResolver {
    * Resolve a single reference
    */
   resolveOne(ref: UnresolvedRef): ResolvedRef | null {
+    // Repository-document references are deliberately strict and
+    // cross-language. Handle them before built-in detection, name-existence
+    // prefilters, and the normal language-family gate.
+    if (ref.referenceKind === 'document_link') {
+      return matchDocumentLink(ref, this.context);
+    }
+    if (ref.referenceKind === 'document_symbol') {
+      return matchDocumentSymbol(ref, this.context);
+    }
+
     // Skip built-in/external references
     if (this.isBuiltInOrExternal(ref)) {
       return null;
@@ -1056,8 +1066,16 @@ export class ReferenceResolver {
       // by metadata.resolvedBy === 'function-ref'. callers/impact already
       // traverse `references`, so registration sites surface with no
       // graph-layer changes.
-      let kind: Edge['kind'] =
-        ref.original.referenceKind === 'function_ref' ? 'references' : ref.original.referenceKind;
+      let kind: Edge['kind'];
+      switch (ref.original.referenceKind) {
+        case 'function_ref':
+        case 'document_link':
+        case 'document_symbol':
+          kind = 'references';
+          break;
+        default:
+          kind = ref.original.referenceKind;
+      }
 
       // Promote "extends" to "implements" when a class/struct targets an interface
       if (kind === 'extends') {
@@ -1108,6 +1126,11 @@ export class ReferenceResolver {
           // tooling label "callback registration" and lets validation diff
           // exactly the edges this feature added.
           ...(ref.original.referenceKind === 'function_ref' ? { fnRef: true } : {}),
+          ...(ref.original.referenceKind === 'document_link'
+            ? { docRef: 'link' }
+            : ref.original.referenceKind === 'document_symbol'
+            ? { docRef: 'symbol' }
+            : {}),
         },
       };
     });

--- a/src/resolution/name-matcher.ts
+++ b/src/resolution/name-matcher.ts
@@ -104,6 +104,136 @@ export function matchByFilePath(
 }
 
 /**
+ * Resolve a repository-document link without any suffix, proximity, or fuzzy
+ * fallback. Markdown extraction already normalizes the path from the
+ * referencing document, so only an exact file path / section qualified name
+ * is trustworthy here.
+ */
+export function matchDocumentLink(
+  ref: UnresolvedRef,
+  context: ResolutionContext
+): ResolvedRef | null {
+  const exact = context
+    .getNodesByQualifiedName(ref.referenceName)
+    .filter(
+      (node) =>
+        (node.kind === 'file' || node.kind === 'section') &&
+        node.qualifiedName === ref.referenceName
+    );
+  if (exact.length === 1) {
+    return {
+      original: ref,
+      targetNodeId: exact[0]!.id,
+      confidence: 1,
+      resolvedBy: 'file-path',
+    };
+  }
+
+  // Some ResolutionContext implementations optimize qualified-name lookup for
+  // symbols only. Keep file links portable by checking the exact normalized
+  // path through the basename index as well.
+  if (!ref.referenceName.includes('#')) {
+    const fileName = ref.referenceName.split('/').pop();
+    if (!fileName) return null;
+    const files = context
+      .getNodesByName(fileName)
+      .filter(
+        (node) =>
+          node.kind === 'file' &&
+          (node.filePath === ref.referenceName ||
+            node.qualifiedName === ref.referenceName)
+      );
+    if (files.length === 1) {
+      return {
+        original: ref,
+        targetNodeId: files[0]!.id,
+        confidence: 1,
+        resolvedBy: 'file-path',
+      };
+    }
+  }
+
+  return null;
+}
+
+const DOCUMENT_SYMBOL_KINDS = new Set<Node['kind']>([
+  'module',
+  'class',
+  'struct',
+  'interface',
+  'trait',
+  'protocol',
+  'function',
+  'method',
+  'property',
+  'field',
+  'variable',
+  'constant',
+  'enum',
+  'enum_member',
+  'type_alias',
+  'namespace',
+  'route',
+  'component',
+]);
+
+/**
+ * Resolve an inline-code symbol mention conservatively. A qualified spelling
+ * must have one exact suffix match; an unqualified spelling must name exactly
+ * one definition in the repository. Documentation never enters the normal
+ * fuzzy matcher because a missing edge is safer than a plausible-but-wrong
+ * code relationship.
+ */
+export function matchDocumentSymbol(
+  ref: UnresolvedRef,
+  context: ResolutionContext
+): ResolvedRef | null {
+  const normalized = ref.referenceName.replace(/\(\)$/, '').replace(/->/g, '.');
+  const parts = normalized.split(/::|\./).filter(Boolean);
+  const name = parts[parts.length - 1];
+  if (!name) return null;
+
+  const byId = new Map(
+    context
+      .getNodesByName(name)
+      .filter((node) => DOCUMENT_SYMBOL_KINDS.has(node.kind))
+      .map((node) => [node.id, node])
+  );
+  const candidates = [...byId.values()];
+
+  if (parts.length === 1) {
+    if (candidates.length !== 1) return null;
+    return {
+      original: ref,
+      targetNodeId: candidates[0]!.id,
+      confidence: 0.85,
+      resolvedBy: 'document-symbol',
+    };
+  }
+
+  const variants = new Set([
+    normalized,
+    normalized.replace(/\./g, '::'),
+    normalized.replace(/::/g, '.'),
+  ]);
+  const qualified = candidates.filter((candidate) =>
+    [...variants].some(
+      (variant) =>
+        candidate.qualifiedName === variant ||
+        candidate.qualifiedName.endsWith(`::${variant}`) ||
+        candidate.qualifiedName.endsWith(`.${variant}`)
+    )
+  );
+  if (qualified.length !== 1) return null;
+  return {
+    original: ref,
+    targetNodeId: qualified[0]!.id,
+    confidence: 0.95,
+    resolvedBy: 'document-symbol',
+  };
+}
+
+/**
  * Among several file nodes that all match a bare include/import by basename,
  * pick the one closest to the referencing file: same directory first, then by
  * directory-tree proximity, with the same language family as a tiebreak. A

--- a/src/resolution/types.ts
+++ b/src/resolution/types.ts
@@ -42,7 +42,7 @@ export interface ResolvedRef {
   /** Confidence score (0-1) */
   confidence: number;
   /** How it was resolved */
-  resolvedBy: 'exact-match' | 'import' | 'qualified-name' | 'framework' | 'fuzzy' | 'instance-method' | 'file-path' | 'function-ref';
+  resolvedBy: 'exact-match' | 'import' | 'qualified-name' | 'framework' | 'fuzzy' | 'instance-method' | 'file-path' | 'function-ref' | 'document-symbol';
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export const NODE_KINDS = [
   'export',
   'route',
   'component',
+  'section',
 ] as const;
 
 export type NodeKind = (typeof NODE_KINDS)[number];
@@ -117,6 +118,7 @@ export const LANGUAGES = [
   'erlang',
   'terraform',
   'unknown',
+  'markdown',
 ] as const;
 
 export type Language = (typeof LANGUAGES)[number];
@@ -319,12 +321,16 @@ export interface ExtractionError {
 }
 
 /**
- * Kinds an unresolved reference can carry. `function_ref` is internal-only —
- * a function name used as a VALUE (callback registration, #756). It never
- * becomes an edge kind: resolution maps it to a `references` edge targeting
- * function/method nodes only (see `matchFunctionRef`).
+ * Kinds an unresolved reference can carry. The extra kinds are internal-only:
+ * callback registrations, repository-document links, and document-to-symbol
+ * mentions. They never become edge kinds; resolution maps them to
+ * `references` edges with distinguishing metadata.
  */
-export type ReferenceKind = EdgeKind | 'function_ref';
+export type ReferenceKind =
+  | EdgeKind
+  | 'function_ref'
+  | 'document_link'
+  | 'document_symbol';
 
 /**
  * A reference that couldn't be resolved during extraction
@@ -389,6 +395,53 @@ export interface Subgraph {
    * for graph traversals that don't run the search-ranking path.
    */
   confidence?: 'high' | 'low';
+}
+
+/**
+ * Options for the read-only topology snapshot used by visual clients.
+ *
+ * A snapshot is intentionally bounded for browser memory. This does not limit
+ * or aggregate the persisted graph.
+ */
+export interface TopologySnapshotOptions {
+  /** Maximum nodes to return. The implementation clamps this to a safe range. */
+  limit?: number;
+
+  /** Optional node kinds to include. Empty or omitted means every kind. */
+  kinds?: NodeKind[];
+}
+
+/**
+ * A deterministic, bounded view of the persisted graph for visualization.
+ */
+export interface TopologySnapshot {
+  /** Nodes selected for the visual snapshot. */
+  nodes: Node[];
+
+  /** Persisted edges whose endpoints are both present in `nodes`. */
+  edges: Edge[];
+
+  /** Whole-project statistics, not just snapshot statistics. */
+  stats: GraphStats;
+
+  /** Number of nodes matching the requested kind filter in the full graph. */
+  totalMatchedNodes: number;
+
+  /** True when matching nodes were omitted only because of the view limit. */
+  truncated: boolean;
+}
+
+/**
+ * A bounded, count-preserving view of one node's exact persisted edges.
+ */
+export interface TopologyNeighborhood {
+  node: Node;
+  incoming: Edge[];
+  outgoing: Edge[];
+  neighbors: Node[];
+  totalIncoming: number;
+  totalOutgoing: number;
+  truncated: boolean;
 }
 
 /**

--- a/src/ui/assets/app.js
+++ b/src/ui/assets/app.js
@@ -1,0 +1,1010 @@
+(() => {
+  'use strict';
+
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+  const VIEWBOX = { width: 1400, height: 900 };
+  const ATLAS_RECT = { x: 34, y: 64, width: 1332, height: 792 };
+  const PALETTE = [
+    '#6ee7b7', '#60a5fa', '#fbbf24', '#f472b6',
+    '#a78bfa', '#22d3ee', '#fb923c', '#a3e635',
+    '#fb7185', '#2dd4bf', '#c084fc', '#cbd5e1',
+  ];
+  const SEMANTIC_ORDER = [
+    'Documents', 'Structure', 'Types', 'Behavior', 'Data', 'Dependencies', 'Other',
+  ];
+  const SEMANTIC_PALETTE = new Map(SEMANTIC_ORDER.map((name, index) => [name, index]));
+
+  const state = {
+    snapshot: null,
+    contract: null,
+    nodesById: new Map(),
+    degrees: new Map(),
+    hiddenKinds: new Set(),
+    hiddenEdgeKinds: new Set(),
+    grouping: 'semantic',
+    coloring: 'kind',
+    relations: 'aggregate',
+    labels: 'auto',
+    layout: { groups: [], nodePositions: new Map(), nodeToGroup: new Map() },
+    selectedId: null,
+    transform: { x: 0, y: 0, scale: 1 },
+    panning: null,
+    searchTimer: null,
+  };
+
+  const graphSvg = document.getElementById('graph');
+  const viewport = document.getElementById('viewport');
+  const groupLayer = document.getElementById('group-layer');
+  const aggregateEdgeLayer = document.getElementById('aggregate-edge-layer');
+  const exactEdgeLayer = document.getElementById('exact-edge-layer');
+  const nodeLayer = document.getElementById('node-layer');
+  const message = document.getElementById('graph-message');
+  const legend = document.getElementById('legend');
+  const edgeLegend = document.getElementById('edge-legend');
+  const distribution = document.getElementById('distribution');
+  const inspector = document.getElementById('inspector');
+  const selectionKind = document.getElementById('selection-kind');
+  const search = document.getElementById('search');
+  const searchResults = document.getElementById('search-results');
+  const projectCounts = document.getElementById('project-counts');
+  const viewCounts = document.getElementById('view-counts');
+  const truncationNote = document.getElementById('truncation-note');
+  const canvasEyebrow = document.getElementById('canvas-eyebrow');
+  const canvasMetrics = document.getElementById('canvas-metrics');
+  const groupCount = document.getElementById('group-count');
+  const groupBySelect = document.getElementById('group-by');
+  const colorBySelect = document.getElementById('color-by');
+  const relationModeSelect = document.getElementById('relation-mode');
+  const labelModeSelect = document.getElementById('label-mode');
+
+  function safeClass(value) {
+    return String(value).replace(/[^a-z0-9_-]/gi, '');
+  }
+
+  function kindClass(kind) {
+    return `kind-${safeClass(kind)}`;
+  }
+
+  function paletteClass(index) {
+    return `palette-${Math.abs(index) % PALETTE.length}`;
+  }
+
+  function createSvg(tag, attributes = {}) {
+    const element = document.createElementNS(SVG_NS, tag);
+    for (const [name, value] of Object.entries(attributes)) {
+      element.setAttribute(name, String(value));
+    }
+    return element;
+  }
+
+  function formatNumber(value) {
+    return new Intl.NumberFormat().format(value || 0);
+  }
+
+  function compactLabel(value, maxLength = 20) {
+    const text = String(value || '').trim() || '(unnamed)';
+    return text.length > maxLength ? `${text.slice(0, maxLength - 3)}...` : text;
+  }
+
+  function hashString(value) {
+    let hash = 2166136261;
+    for (let index = 0; index < value.length; index += 1) {
+      hash ^= value.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+    return hash >>> 0;
+  }
+
+  async function fetchJson(url) {
+    const response = await fetch(url, { headers: { Accept: 'application/json' } });
+    const body = await response.json();
+    if (!response.ok) throw new Error(body.error || `Request failed (${response.status})`);
+    return body;
+  }
+
+  function semanticRole(node) {
+    switch (node.kind) {
+      case 'section':
+        return 'Documents';
+      case 'file':
+      case 'module':
+      case 'namespace':
+        return node.language === 'markdown' ? 'Documents' : 'Structure';
+      case 'class':
+      case 'struct':
+      case 'interface':
+      case 'trait':
+      case 'protocol':
+      case 'enum':
+      case 'type_alias':
+        return 'Types';
+      case 'function':
+      case 'method':
+      case 'component':
+      case 'route':
+        return 'Behavior';
+      case 'property':
+      case 'field':
+      case 'variable':
+      case 'constant':
+      case 'enum_member':
+      case 'parameter':
+        return 'Data';
+      case 'import':
+      case 'export':
+        return 'Dependencies';
+      default:
+        return 'Other';
+    }
+  }
+
+  function topLevelDirectory(filePath) {
+    const normalized = String(filePath || '').replace(/\\/g, '/').replace(/^\.\//, '');
+    const parts = normalized.split('/').filter(Boolean);
+    return parts.length > 1 ? parts[0] : '[root]';
+  }
+
+  function groupName(node) {
+    if (state.grouping === 'directory') return topLevelDirectory(node.filePath);
+    if (state.grouping === 'language') return node.language || 'unknown';
+    return semanticRole(node);
+  }
+
+  function groupSort(a, b) {
+    if (state.grouping === 'semantic') {
+      const aIndex = SEMANTIC_ORDER.indexOf(a.name);
+      const bIndex = SEMANTIC_ORDER.indexOf(b.name);
+      return aIndex - bIndex;
+    }
+    return b.nodes.length - a.nodes.length || a.name.localeCompare(b.name);
+  }
+
+  function degreeMap(snapshot) {
+    const degrees = new Map(snapshot.nodes.map((node) => [node.id, 0]));
+    for (const edge of snapshot.edges) {
+      degrees.set(edge.source, (degrees.get(edge.source) || 0) + 1);
+      degrees.set(edge.target, (degrees.get(edge.target) || 0) + 1);
+    }
+    return degrees;
+  }
+
+  function visibleNode(node) {
+    return !state.hiddenKinds.has(node.kind);
+  }
+
+  function visibleNodes() {
+    return state.snapshot ? state.snapshot.nodes.filter(visibleNode) : [];
+  }
+
+  function visibleEdges(nodes = visibleNodes()) {
+    if (!state.snapshot) return [];
+    const visibleIds = new Set(nodes.map((node) => node.id));
+    return state.snapshot.edges.filter(
+      (edge) =>
+        visibleIds.has(edge.source) &&
+        visibleIds.has(edge.target) &&
+        !state.hiddenEdgeKinds.has(edge.kind)
+    );
+  }
+
+  function splitTreemap(items, rect, output) {
+    if (items.length === 0) return;
+    if (items.length === 1) {
+      output.set(items[0].name, rect);
+      return;
+    }
+
+    const total = items.reduce((sum, item) => sum + item.nodes.length, 0);
+    const target = total / 2;
+    let running = 0;
+    let splitIndex = 1;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (let index = 1; index < items.length; index += 1) {
+      running += items[index - 1].nodes.length;
+      const distance = Math.abs(target - running);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        splitIndex = index;
+      }
+    }
+
+    const left = items.slice(0, splitIndex);
+    const right = items.slice(splitIndex);
+    const leftWeight = left.reduce((sum, item) => sum + item.nodes.length, 0);
+    const ratio = Math.max(0.08, Math.min(0.92, leftWeight / total));
+
+    if (rect.width >= rect.height) {
+      const leftWidth = rect.width * ratio;
+      splitTreemap(left, { ...rect, width: leftWidth }, output);
+      splitTreemap(
+        right,
+        { x: rect.x + leftWidth, y: rect.y, width: rect.width - leftWidth, height: rect.height },
+        output
+      );
+    } else {
+      const topHeight = rect.height * ratio;
+      splitTreemap(left, { ...rect, height: topHeight }, output);
+      splitTreemap(
+        right,
+        { x: rect.x, y: rect.y + topHeight, width: rect.width, height: rect.height - topHeight },
+        output
+      );
+    }
+  }
+
+  function groupPaletteIndex(group) {
+    if (state.grouping === 'semantic') return SEMANTIC_PALETTE.get(group.name) || 0;
+    return hashString(group.name) % PALETTE.length;
+  }
+
+  function buildLayout(nodes) {
+    const grouped = new Map();
+    for (const node of nodes) {
+      const name = groupName(node);
+      if (!grouped.has(name)) grouped.set(name, []);
+      grouped.get(name).push(node);
+    }
+
+    const groups = [...grouped.entries()]
+      .map(([name, groupNodes]) => ({ name, nodes: groupNodes }))
+      .sort(groupSort);
+    const rectangles = new Map();
+    splitTreemap(groups, ATLAS_RECT, rectangles);
+    const nodePositions = new Map();
+    const nodeToGroup = new Map();
+
+    for (const group of groups) {
+      const rawRect = rectangles.get(group.name);
+      const gap = 4;
+      const rect = {
+        x: rawRect.x + gap,
+        y: rawRect.y + gap,
+        width: Math.max(2, rawRect.width - gap * 2),
+        height: Math.max(2, rawRect.height - gap * 2),
+      };
+      const center = { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+      const headerHeight = rect.height >= 62 ? 29 : rect.height >= 34 ? 18 : 4;
+      const inner = {
+        x: rect.x + 8,
+        y: rect.y + headerHeight,
+        width: Math.max(2, rect.width - 16),
+        height: Math.max(2, rect.height - headerHeight - 7),
+      };
+      const ordered = [...group.nodes].sort(
+        (a, b) =>
+          (state.degrees.get(b.id) || 0) - (state.degrees.get(a.id) || 0) ||
+          a.kind.localeCompare(b.kind) ||
+          a.name.localeCompare(b.name)
+      );
+      const aspect = Math.max(0.2, inner.width / Math.max(inner.height, 1));
+      const columns = Math.max(1, Math.ceil(Math.sqrt(ordered.length * aspect)));
+      const rows = Math.max(1, Math.ceil(ordered.length / columns));
+      const cellWidth = inner.width / columns;
+      const cellHeight = inner.height / rows;
+      const keyCount = Math.max(1, Math.ceil(ordered.length * 0.025));
+
+      ordered.forEach((node, index) => {
+        const column = index % columns;
+        const row = Math.floor(index / columns);
+        const jitter = hashString(node.id);
+        const jitterX = (((jitter & 255) / 255) - 0.5) * Math.min(5, cellWidth * 0.32);
+        const jitterY = ((((jitter >>> 8) & 255) / 255) - 0.5) * Math.min(5, cellHeight * 0.32);
+        const degree = state.degrees.get(node.id) || 0;
+        const radius = Math.max(
+          1.7,
+          Math.min(7.2, Math.min(cellWidth, cellHeight) * 0.24 + Math.log2(degree + 1) * 0.45)
+        );
+        nodePositions.set(node.id, {
+          x: inner.x + cellWidth * (column + 0.5) + jitterX,
+          y: inner.y + cellHeight * (row + 0.5) + jitterY,
+          radius,
+          key: index < keyCount,
+        });
+        nodeToGroup.set(node.id, group.name);
+      });
+
+      group.rect = rect;
+      group.center = center;
+      group.paletteIndex = groupPaletteIndex(group);
+    }
+
+    state.layout = { groups, nodePositions, nodeToGroup };
+  }
+
+  function nodeColorClass(node) {
+    if (state.coloring === 'kind') return kindClass(node.kind);
+    if (state.coloring === 'semantic') {
+      return paletteClass(SEMANTIC_PALETTE.get(semanticRole(node)) || 0);
+    }
+    return paletteClass(hashString(node.language || 'unknown') % PALETTE.length);
+  }
+
+  function renderGroups(edges) {
+    groupLayer.replaceChildren();
+    const internalCounts = new Map();
+    for (const edge of edges) {
+      const sourceGroup = state.layout.nodeToGroup.get(edge.source);
+      const targetGroup = state.layout.nodeToGroup.get(edge.target);
+      if (sourceGroup && sourceGroup === targetGroup) {
+        internalCounts.set(sourceGroup, (internalCounts.get(sourceGroup) || 0) + 1);
+      }
+    }
+    const totalNodes = state.layout.groups.reduce((sum, group) => sum + group.nodes.length, 0);
+
+    for (const group of state.layout.groups) {
+      const color = PALETTE[group.paletteIndex];
+      const element = createSvg('g', {
+        class: `group ${paletteClass(group.paletteIndex)}`,
+        'data-group': group.name,
+      });
+      const box = createSvg('rect', {
+        class: 'group-box',
+        x: group.rect.x,
+        y: group.rect.y,
+        width: group.rect.width,
+        height: group.rect.height,
+        rx: Math.min(10, group.rect.width / 6, group.rect.height / 6),
+        fill: `${color}12`,
+        stroke: `${color}78`,
+      });
+      const title = createSvg('title');
+      const percentage = totalNodes ? (group.nodes.length / totalNodes) * 100 : 0;
+      title.textContent =
+        `${group.name}: ${formatNumber(group.nodes.length)} nodes (${percentage.toFixed(1)}%), ` +
+        `${formatNumber(internalCounts.get(group.name) || 0)} internal visible relationships`;
+      box.appendChild(title);
+      box.addEventListener('dblclick', (event) => {
+        event.stopPropagation();
+        focusGroup(group);
+      });
+      element.appendChild(box);
+
+      if (group.rect.width >= 64 && group.rect.height >= 30) {
+        const groupTitle = createSvg('text', {
+          class: 'group-title',
+          x: group.rect.x + 9,
+          y: group.rect.y + 16,
+        });
+        groupTitle.textContent = compactLabel(group.name, Math.max(8, Math.floor(group.rect.width / 7)));
+        element.appendChild(groupTitle);
+      }
+      if (group.rect.width >= 92 && group.rect.height >= 48) {
+        const meta = createSvg('text', {
+          class: 'group-meta',
+          x: group.rect.x + 9,
+          y: group.rect.y + 28,
+        });
+        meta.textContent = `${formatNumber(group.nodes.length)} · ${percentage.toFixed(1)}%`;
+        element.appendChild(meta);
+      }
+      groupLayer.appendChild(element);
+    }
+  }
+
+  function curvedGroupPath(source, target) {
+    const dx = target.x - source.x;
+    const dy = target.y - source.y;
+    const length = Math.max(Math.hypot(dx, dy), 1);
+    const bend = Math.min(80, length * 0.14);
+    const middleX = (source.x + target.x) / 2 - (dy / length) * bend;
+    const middleY = (source.y + target.y) / 2 + (dx / length) * bend;
+    return `M ${source.x} ${source.y} Q ${middleX} ${middleY} ${target.x} ${target.y}`;
+  }
+
+  function renderAggregateEdges(edges) {
+    const groupsByName = new Map(state.layout.groups.map((group) => [group.name, group]));
+    const aggregates = new Map();
+    for (const edge of edges) {
+      const sourceGroup = state.layout.nodeToGroup.get(edge.source);
+      const targetGroup = state.layout.nodeToGroup.get(edge.target);
+      if (!sourceGroup || !targetGroup || sourceGroup === targetGroup) continue;
+      const key = `${sourceGroup}\u0000${targetGroup}`;
+      const aggregate = aggregates.get(key) || {
+        sourceGroup,
+        targetGroup,
+        count: 0,
+        kinds: new Map(),
+      };
+      aggregate.count += 1;
+      aggregate.kinds.set(edge.kind, (aggregate.kinds.get(edge.kind) || 0) + 1);
+      aggregates.set(key, aggregate);
+    }
+
+    for (const aggregate of aggregates.values()) {
+      const source = groupsByName.get(aggregate.sourceGroup);
+      const target = groupsByName.get(aggregate.targetGroup);
+      if (!source || !target) continue;
+      const path = createSvg('path', {
+        class: 'aggregate-edge',
+        d: curvedGroupPath(source.center, target.center),
+        'stroke-width': Math.min(5, 0.65 + Math.log2(aggregate.count + 1) * 0.62),
+        'data-source-group': aggregate.sourceGroup,
+        'data-target-group': aggregate.targetGroup,
+      });
+      const kinds = [...aggregate.kinds.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+        .map(([kind, count]) => `${kind} ${formatNumber(count)}`)
+        .join(', ');
+      const title = createSvg('title');
+      title.textContent =
+        `${aggregate.sourceGroup} -> ${aggregate.targetGroup}: ` +
+        `${formatNumber(aggregate.count)} exact visible relationships (${kinds})`;
+      path.appendChild(title);
+      aggregateEdgeLayer.appendChild(path);
+    }
+    return aggregates.size;
+  }
+
+  function renderExactEdges(edges) {
+    let rendered = 0;
+    for (const edge of edges) {
+      const source = state.layout.nodePositions.get(edge.source);
+      const target = state.layout.nodePositions.get(edge.target);
+      if (!source || !target) continue;
+      const selected =
+        Boolean(state.selectedId) &&
+        (edge.source === state.selectedId || edge.target === state.selectedId);
+      const line = createSvg('line', {
+        class: `exact-edge${selected ? ' is-selected-edge' : ''}`,
+        x1: source.x,
+        y1: source.y,
+        x2: target.x,
+        y2: target.y,
+        'data-kind': edge.kind,
+        'data-source': edge.source,
+        'data-target': edge.target,
+      });
+      const title = createSvg('title');
+      title.textContent = edge.kind;
+      line.appendChild(title);
+      exactEdgeLayer.appendChild(line);
+      rendered += 1;
+    }
+    return rendered;
+  }
+
+  function renderRelationships(edges) {
+    aggregateEdgeLayer.replaceChildren();
+    exactEdgeLayer.replaceChildren();
+    if (state.relations === 'none') return 0;
+    if (state.relations === 'aggregate') return renderAggregateEdges(edges);
+    if (state.relations === 'selected') {
+      if (!state.selectedId) return 0;
+      return renderExactEdges(
+        edges.filter(
+          (edge) => edge.source === state.selectedId || edge.target === state.selectedId
+        )
+      );
+    }
+    return renderExactEdges(edges);
+  }
+
+  function renderNodes(nodes) {
+    nodeLayer.replaceChildren();
+    for (const node of nodes) {
+      const position = state.layout.nodePositions.get(node.id);
+      if (!position) continue;
+      const element = createSvg('g', {
+        class:
+          `node ${nodeColorClass(node)}` +
+          `${node.id === state.selectedId ? ' is-selected' : ''}`,
+        transform: `translate(${position.x} ${position.y})`,
+        tabindex: '0',
+        role: 'button',
+        'aria-label': `${node.kind} ${node.name}`,
+        'data-id': node.id,
+        'data-key': position.key ? 'true' : 'false',
+      });
+      element.appendChild(createSvg('circle', { r: position.radius }));
+      const label = createSvg('text', {
+        class: 'node-label',
+        x: position.radius + 3,
+        y: 3,
+      });
+      label.textContent = compactLabel(node.name);
+      element.appendChild(label);
+      const title = createSvg('title');
+      title.textContent = `${node.kind}: ${node.qualifiedName}`;
+      element.appendChild(title);
+      element.addEventListener('click', (event) => {
+        event.stopPropagation();
+        void inspectNode(node.id, false);
+      });
+      element.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          void inspectNode(node.id, false);
+        }
+      });
+      nodeLayer.appendChild(element);
+    }
+    updateLabels();
+  }
+
+  function renderDistribution() {
+    distribution.replaceChildren();
+    const total = state.layout.groups.reduce((sum, group) => sum + group.nodes.length, 0);
+    const groups = [...state.layout.groups].sort(
+      (a, b) => b.nodes.length - a.nodes.length || a.name.localeCompare(b.name)
+    );
+    groupCount.textContent = `${formatNumber(groups.length)} groups`;
+    for (const group of groups) {
+      const row = document.createElement('div');
+      row.className = 'distribution-row';
+      row.dataset.group = group.name;
+      const copy = document.createElement('div');
+      copy.className = 'distribution-copy';
+      const name = document.createElement('strong');
+      name.textContent = group.name;
+      name.title = group.name;
+      const count = document.createElement('span');
+      count.textContent = formatNumber(group.nodes.length);
+      copy.append(name, count);
+      const percentage = document.createElement('span');
+      percentage.textContent = total ? `${((group.nodes.length / total) * 100).toFixed(1)}%` : '0%';
+      const progress = document.createElement('progress');
+      progress.max = Math.max(1, total);
+      progress.value = group.nodes.length;
+      row.append(copy, percentage, progress);
+      row.addEventListener('dblclick', () => focusGroup(group));
+      distribution.appendChild(row);
+    }
+  }
+
+  function legendItem(kind, count, edgeKind = false) {
+    const label = document.createElement('label');
+    const colorClass = edgeKind
+      ? paletteClass(hashString(kind) % PALETTE.length)
+      : kindClass(kind);
+    label.className = `legend-item ${colorClass}`;
+    const hiddenSet = edgeKind ? state.hiddenEdgeKinds : state.hiddenKinds;
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = !hiddenSet.has(kind);
+    checkbox.setAttribute('aria-label', `Show ${kind} ${edgeKind ? 'relationships' : 'nodes'}`);
+    checkbox.addEventListener('change', () => {
+      if (checkbox.checked) hiddenSet.delete(kind);
+      else hiddenSet.add(kind);
+      label.classList.toggle('is-hidden', !checkbox.checked);
+      renderVisualization();
+    });
+
+    const dot = document.createElement('span');
+    dot.className = 'legend-dot';
+    const name = document.createElement('span');
+    name.className = 'legend-label';
+    name.textContent = kind;
+    const amount = document.createElement('span');
+    amount.className = 'legend-count';
+    amount.textContent = formatNumber(count);
+    label.append(checkbox, dot, name, amount);
+    return label;
+  }
+
+  function renderLegends(snapshot) {
+    legend.replaceChildren();
+    edgeLegend.replaceChildren();
+    const nodeKinds = Object.entries(snapshot.stats.nodesByKind)
+      .filter(([, count]) => count > 0)
+      .sort(([a], [b]) => a.localeCompare(b));
+    const edgeKinds = Object.entries(snapshot.stats.edgesByKind)
+      .filter(([, count]) => count > 0)
+      .sort(([a], [b]) => a.localeCompare(b));
+    for (const [kind, count] of nodeKinds) legend.appendChild(legendItem(kind, count));
+    for (const [kind, count] of edgeKinds) {
+      edgeLegend.appendChild(legendItem(kind, count, true));
+    }
+  }
+
+  function updateLabels() {
+    const scale = state.transform.scale;
+    for (const element of nodeLayer.querySelectorAll('.node')) {
+      let show = false;
+      if (state.labels === 'all') show = true;
+      else if (state.labels === 'key') show = element.dataset.key === 'true';
+      else if (state.labels === 'auto') {
+        show = scale >= 2.5 || (scale >= 1.45 && element.dataset.key === 'true');
+      }
+      element.classList.toggle('show-label', show);
+    }
+  }
+
+  function updateSummary(nodes, edges, renderedRelations) {
+    if (!state.snapshot) return;
+    projectCounts.textContent =
+      `${formatNumber(state.snapshot.stats.nodeCount)} nodes · ` +
+      `${formatNumber(state.snapshot.stats.edgeCount)} edges`;
+    viewCounts.textContent =
+      `${formatNumber(nodes.length)} nodes · ${formatNumber(edges.length)} edges`;
+    truncationNote.textContent = state.snapshot.truncated
+      ? `Atlas shows ${formatNumber(state.snapshot.nodes.length)} of ` +
+        `${formatNumber(state.snapshot.totalMatchedNodes)} degree-ranked nodes. ` +
+        'Search and the inspector still query the full graph.'
+      : '';
+
+    canvasMetrics.replaceChildren();
+    const metrics = [
+      `${formatNumber(state.layout.groups.length)} groups`,
+      state.relations === 'aggregate'
+        ? `${formatNumber(renderedRelations)} group flows`
+        : `${formatNumber(renderedRelations)} visible links`,
+    ];
+    for (const value of metrics) {
+      const item = document.createElement('span');
+      item.textContent = value;
+      canvasMetrics.appendChild(item);
+    }
+    const groupingLabels = {
+      semantic: 'semantic role',
+      directory: 'top-level directory',
+      language: 'language',
+    };
+    canvasEyebrow.textContent = `Grouped by ${groupingLabels[state.grouping]}`;
+  }
+
+  function renderVisualization() {
+    if (!state.snapshot) return;
+    const nodes = visibleNodes();
+    const edges = visibleEdges(nodes);
+    buildLayout(nodes);
+    renderGroups(edges);
+    const renderedRelations = renderRelationships(edges);
+    renderNodes(nodes);
+    renderDistribution();
+    updateSummary(nodes, edges, renderedRelations);
+  }
+
+  function selectedElement() {
+    return nodeLayer.querySelector('.node.is-selected');
+  }
+
+  function selectNodeElement(id) {
+    selectedElement()?.classList.remove('is-selected');
+    const next = [...nodeLayer.querySelectorAll('.node')].find(
+      (element) => element.dataset.id === id
+    );
+    next?.classList.add('is-selected');
+    state.selectedId = id;
+    if (state.relations === 'selected') {
+      const nodes = visibleNodes();
+      const edges = visibleEdges(nodes);
+      const relationCount = renderRelationships(edges);
+      updateSummary(nodes, edges, relationCount);
+    }
+    return next;
+  }
+
+  function focusNode(id) {
+    const position = state.layout.nodePositions.get(id);
+    if (!position) return false;
+    state.transform.scale = Math.max(state.transform.scale, 2.25);
+    state.transform.x = VIEWBOX.width / 2 - position.x * state.transform.scale;
+    state.transform.y = VIEWBOX.height / 2 - position.y * state.transform.scale;
+    updateTransform();
+    selectNodeElement(id);
+    return true;
+  }
+
+  function focusGroup(group) {
+    const horizontalScale = (VIEWBOX.width * 0.86) / Math.max(group.rect.width, 1);
+    const verticalScale = (VIEWBOX.height * 0.82) / Math.max(group.rect.height, 1);
+    state.transform.scale = Math.max(1, Math.min(4, horizontalScale, verticalScale));
+    state.transform.x =
+      VIEWBOX.width / 2 - (group.rect.x + group.rect.width / 2) * state.transform.scale;
+    state.transform.y =
+      VIEWBOX.height / 2 - (group.rect.y + group.rect.height / 2) * state.transform.scale;
+    updateTransform();
+  }
+
+  function detailRow(term, value) {
+    const dt = document.createElement('dt');
+    dt.textContent = term;
+    const dd = document.createElement('dd');
+    dd.textContent = value;
+    return [dt, dd];
+  }
+
+  function renderRelationList(title, edges, total, neighbors, direction) {
+    const fragment = document.createDocumentFragment();
+    const heading = document.createElement('h3');
+    heading.className = 'relation-heading';
+    heading.textContent = `${title} (${formatNumber(total)})`;
+    fragment.appendChild(heading);
+
+    const list = document.createElement('div');
+    list.className = 'neighbor-list';
+    const neighborMap = new Map(neighbors.map((node) => [node.id, node]));
+    for (const edge of edges.slice(0, 100)) {
+      const neighborId = direction === 'incoming' ? edge.source : edge.target;
+      const neighbor = neighborMap.get(neighborId);
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'neighbor-button';
+      const name = document.createElement('span');
+      name.textContent = neighbor ? neighbor.name : neighborId;
+      const kind = document.createElement('span');
+      kind.textContent = edge.kind;
+      button.append(name, kind);
+      button.addEventListener('click', () => {
+        focusNode(neighborId);
+        void inspectNode(neighborId, false);
+      });
+      list.appendChild(button);
+    }
+    if (edges.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'empty-state';
+      empty.textContent = 'No relationships in this direction.';
+      list.appendChild(empty);
+    }
+    fragment.appendChild(list);
+    return fragment;
+  }
+
+  async function inspectNode(id, focus) {
+    try {
+      const payload = await fetchJson(`/api/node?id=${encodeURIComponent(id)}`);
+      const inAtlas = focus ? focusNode(id) : Boolean(selectNodeElement(id));
+      selectionKind.hidden = false;
+      selectionKind.textContent = payload.node.kind;
+      selectionKind.className = `kind-pill ${kindClass(payload.node.kind)}`;
+
+      inspector.replaceChildren();
+      const title = document.createElement('h3');
+      title.className = 'node-title';
+      title.textContent = payload.node.name;
+      const path = document.createElement('p');
+      path.className = 'node-path';
+      path.textContent = payload.node.qualifiedName;
+      const details = document.createElement('dl');
+      details.className = 'detail-grid';
+      details.append(
+        ...detailRow('File', payload.node.filePath),
+        ...detailRow('Language', payload.node.language),
+        ...detailRow('Lines', `${payload.node.startLine}-${payload.node.endLine}`),
+        ...detailRow('Node ID', payload.node.id)
+      );
+      inspector.append(title, path, details);
+      inspector.append(
+        renderRelationList(
+          'Incoming',
+          payload.incoming,
+          payload.totalIncoming,
+          payload.neighbors,
+          'incoming'
+        ),
+        renderRelationList(
+          'Outgoing',
+          payload.outgoing,
+          payload.totalOutgoing,
+          payload.neighbors,
+          'outgoing'
+        )
+      );
+      if (!inAtlas) {
+        const note = document.createElement('p');
+        note.className = 'truncated-note';
+        note.textContent =
+          'This node is outside the bounded atlas snapshot; its exact identity and relationships are still shown.';
+        inspector.prepend(note);
+      }
+      if (payload.truncated) {
+        const note = document.createElement('p');
+        note.className = 'truncated-note';
+        note.textContent =
+          `Inspector preview: ${formatNumber(payload.totalIncoming)} incoming and ` +
+          `${formatNumber(payload.totalOutgoing)} outgoing relationships in the full graph.`;
+        inspector.appendChild(note);
+      }
+    } catch (error) {
+      inspector.replaceChildren();
+      const paragraph = document.createElement('p');
+      paragraph.className = 'empty-state';
+      paragraph.textContent = error instanceof Error ? error.message : String(error);
+      inspector.appendChild(paragraph);
+    }
+  }
+
+  function renderSearchResults(results) {
+    searchResults.replaceChildren();
+    if (results.length === 0) {
+      searchResults.hidden = true;
+      return;
+    }
+    for (const result of results) {
+      const node = result.node;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = `search-result ${kindClass(node.kind)}`;
+      const dot = document.createElement('span');
+      dot.className = 'search-result-dot';
+      const copy = document.createElement('span');
+      copy.className = 'search-result-copy';
+      const title = document.createElement('strong');
+      title.textContent = node.name;
+      const subtitle = document.createElement('small');
+      subtitle.textContent = `${node.kind} · ${node.filePath}`;
+      copy.append(title, subtitle);
+      const language = document.createElement('small');
+      language.textContent = node.language;
+      button.append(dot, copy, language);
+      button.addEventListener('click', () => {
+        searchResults.hidden = true;
+        search.value = '';
+        const focused = focusNode(node.id);
+        void inspectNode(node.id, !focused);
+      });
+      searchResults.appendChild(button);
+    }
+    searchResults.hidden = false;
+  }
+
+  function updateTransform() {
+    viewport.setAttribute(
+      'transform',
+      `translate(${state.transform.x} ${state.transform.y}) scale(${state.transform.scale})`
+    );
+    updateLabels();
+  }
+
+  function fitGraph() {
+    state.transform = { x: 0, y: 0, scale: 1 };
+    updateTransform();
+  }
+
+  function showAll(hiddenSet, container) {
+    hiddenSet.clear();
+    for (const item of container.querySelectorAll('.legend-item')) {
+      item.classList.remove('is-hidden');
+      const checkbox = item.querySelector('input');
+      if (checkbox) checkbox.checked = true;
+    }
+    renderVisualization();
+  }
+
+  function resetView() {
+    state.hiddenKinds.clear();
+    state.hiddenEdgeKinds.clear();
+    state.grouping = 'semantic';
+    state.coloring = 'kind';
+    state.relations = 'aggregate';
+    state.labels = 'auto';
+    groupBySelect.value = state.grouping;
+    colorBySelect.value = state.coloring;
+    relationModeSelect.value = state.relations;
+    labelModeSelect.value = state.labels;
+    renderLegends(state.snapshot);
+    fitGraph();
+    renderVisualization();
+  }
+
+  function installInteractions() {
+    graphSvg.addEventListener('wheel', (event) => {
+      event.preventDefault();
+      const rect = graphSvg.getBoundingClientRect();
+      const x = ((event.clientX - rect.left) / rect.width) * VIEWBOX.width;
+      const y = ((event.clientY - rect.top) / rect.height) * VIEWBOX.height;
+      const oldScale = state.transform.scale;
+      const nextScale = Math.max(0.35, Math.min(4, oldScale * Math.exp(-event.deltaY * 0.001)));
+      const worldX = (x - state.transform.x) / oldScale;
+      const worldY = (y - state.transform.y) / oldScale;
+      state.transform.scale = nextScale;
+      state.transform.x = x - worldX * nextScale;
+      state.transform.y = y - worldY * nextScale;
+      updateTransform();
+    }, { passive: false });
+
+    graphSvg.addEventListener('pointerdown', (event) => {
+      if (event.target.closest?.('.node')) return;
+      graphSvg.setPointerCapture(event.pointerId);
+      state.panning = {
+        pointerId: event.pointerId,
+        x: event.clientX,
+        y: event.clientY,
+        originX: state.transform.x,
+        originY: state.transform.y,
+      };
+      graphSvg.classList.add('panning');
+    });
+
+    graphSvg.addEventListener('pointermove', (event) => {
+      if (!state.panning || state.panning.pointerId !== event.pointerId) return;
+      const rect = graphSvg.getBoundingClientRect();
+      state.transform.x =
+        state.panning.originX +
+        ((event.clientX - state.panning.x) / rect.width) * VIEWBOX.width;
+      state.transform.y =
+        state.panning.originY +
+        ((event.clientY - state.panning.y) / rect.height) * VIEWBOX.height;
+      updateTransform();
+    });
+
+    const finishPan = (event) => {
+      if (state.panning?.pointerId === event.pointerId) {
+        state.panning = null;
+        graphSvg.classList.remove('panning');
+      }
+    };
+    graphSvg.addEventListener('pointerup', finishPan);
+    graphSvg.addEventListener('pointercancel', finishPan);
+
+    document.getElementById('fit-button').addEventListener('click', fitGraph);
+    document.getElementById('reset-view-button').addEventListener('click', resetView);
+    document.getElementById('show-all-button').addEventListener(
+      'click',
+      () => showAll(state.hiddenKinds, legend)
+    );
+    document.getElementById('show-all-edges-button').addEventListener(
+      'click',
+      () => showAll(state.hiddenEdgeKinds, edgeLegend)
+    );
+
+    groupBySelect.addEventListener('change', () => {
+      state.grouping = groupBySelect.value;
+      fitGraph();
+      renderVisualization();
+    });
+    colorBySelect.addEventListener('change', () => {
+      state.coloring = colorBySelect.value;
+      renderVisualization();
+    });
+    relationModeSelect.addEventListener('change', () => {
+      state.relations = relationModeSelect.value;
+      renderVisualization();
+    });
+    labelModeSelect.addEventListener('change', () => {
+      state.labels = labelModeSelect.value;
+      updateLabels();
+    });
+
+    search.addEventListener('input', () => {
+      window.clearTimeout(state.searchTimer);
+      const query = search.value.trim();
+      if (!query) {
+        searchResults.hidden = true;
+        return;
+      }
+      state.searchTimer = window.setTimeout(async () => {
+        try {
+          const payload = await fetchJson(`/api/search?q=${encodeURIComponent(query)}&limit=20`);
+          if (search.value.trim() === query) renderSearchResults(payload.results);
+        } catch {
+          searchResults.hidden = true;
+        }
+      }, 180);
+    });
+
+    document.addEventListener('pointerdown', (event) => {
+      if (!searchResults.contains(event.target) && event.target !== search) {
+        searchResults.hidden = true;
+      }
+    });
+  }
+
+  async function initialize() {
+    installInteractions();
+    try {
+      const [contract, snapshot] = await Promise.all([
+        fetchJson('/api/contract'),
+        fetchJson('/api/graph'),
+      ]);
+      if (!contract.readOnly) throw new Error('Topology endpoint is not read-only');
+      state.contract = contract;
+      state.snapshot = snapshot;
+      state.nodesById = new Map(snapshot.nodes.map((node) => [node.id, node]));
+      state.degrees = degreeMap(snapshot);
+      renderLegends(snapshot);
+      renderVisualization();
+      message.hidden = true;
+      document.body.dataset.ready = 'true';
+    } catch (error) {
+      message.textContent = error instanceof Error ? error.message : String(error);
+      message.classList.add('error');
+      document.body.dataset.ready = 'error';
+    }
+  }
+
+  void initialize();
+})();

--- a/src/ui/assets/favicon.svg
+++ b/src/ui/assets/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="16" fill="#0c1714"/>
+  <path d="M19 20 45 44M18 47l28-30" stroke="#34d399" stroke-width="5" stroke-linecap="round"/>
+  <circle cx="18" cy="18" r="7" fill="#6ee7b7"/>
+  <circle cx="46" cy="46" r="7" fill="#34d399"/>
+  <circle cx="18" cy="47" r="5" fill="#fbbf24"/>
+  <circle cx="46" cy="17" r="5" fill="#60a5fa"/>
+</svg>

--- a/src/ui/assets/index.html
+++ b/src/ui/assets/index.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark">
+    <title>CodeGraph topology</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+    <link rel="stylesheet" href="/styles.css">
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true"></span>
+        <div>
+          <strong>CodeGraph</strong>
+          <span>repository atlas</span>
+        </div>
+      </div>
+      <div class="search-shell">
+        <label class="sr-only" for="search">Search graph nodes</label>
+        <input
+          id="search"
+          data-testid="graph-search"
+          type="search"
+          maxlength="200"
+          placeholder="Search symbols, files, and document sections"
+          autocomplete="off"
+        >
+        <div id="search-results" class="search-results" hidden></div>
+      </div>
+      <div class="toolbar">
+        <button id="fit-button" type="button">Overview</button>
+        <span id="read-only-badge" class="badge">read only</span>
+      </div>
+    </header>
+
+    <main class="workspace">
+      <section class="graph-panel" aria-label="Repository graph">
+        <div class="canvas-heading">
+          <div>
+            <span id="canvas-eyebrow">Grouped by semantic role</span>
+            <strong id="canvas-title">Repository distribution</strong>
+          </div>
+          <div id="canvas-metrics" class="canvas-metrics"></div>
+        </div>
+        <svg
+          id="graph"
+          data-testid="topology-graph"
+          viewBox="0 0 1400 900"
+          role="img"
+          aria-label="Interactive repository topology atlas"
+        >
+          <defs>
+            <marker
+              id="arrow"
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerWidth="5"
+              markerHeight="5"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 0 L 10 5 L 0 10 z"></path>
+            </marker>
+            <marker
+              id="aggregate-arrow"
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 0 L 10 5 L 0 10 z"></path>
+            </marker>
+          </defs>
+          <g id="viewport">
+            <g id="group-layer"></g>
+            <g id="aggregate-edge-layer"></g>
+            <g id="exact-edge-layer"></g>
+            <g id="node-layer"></g>
+          </g>
+        </svg>
+        <div id="graph-message" class="graph-message" data-testid="graph-message">
+          Loading repository graph…
+        </div>
+        <div class="graph-hint">Wheel to zoom · drag to pan · double-click a group to focus</div>
+      </section>
+
+      <aside class="sidebar">
+        <section class="summary-card">
+          <div>
+            <span>Project graph</span>
+            <strong id="project-counts" data-testid="project-counts">—</strong>
+          </div>
+          <div>
+            <span>Current view</span>
+            <strong id="view-counts" data-testid="view-counts">—</strong>
+          </div>
+          <p id="truncation-note"></p>
+        </section>
+
+        <section class="side-section view-section">
+          <div class="section-heading">
+            <h2>View model</h2>
+            <button id="reset-view-button" class="text-button" type="button">Reset</button>
+          </div>
+          <div class="control-grid">
+            <label>
+              <span>Group by</span>
+              <select id="group-by" data-testid="group-by">
+                <option value="semantic">Semantic role</option>
+                <option value="directory">Top-level directory</option>
+                <option value="language">Language</option>
+              </select>
+            </label>
+            <label>
+              <span>Color by</span>
+              <select id="color-by" data-testid="color-by">
+                <option value="kind">Node kind</option>
+                <option value="semantic">Semantic role</option>
+                <option value="language">Language</option>
+              </select>
+            </label>
+            <label>
+              <span>Relationships</span>
+              <select id="relation-mode" data-testid="relation-mode">
+                <option value="aggregate">Between groups</option>
+                <option value="selected">Selected node</option>
+                <option value="all">All visible</option>
+                <option value="none">None</option>
+              </select>
+            </label>
+            <label>
+              <span>Labels</span>
+              <select id="label-mode" data-testid="label-mode">
+                <option value="auto">Auto by zoom</option>
+                <option value="key">Key nodes</option>
+                <option value="all">All nodes</option>
+                <option value="none">None</option>
+              </select>
+            </label>
+          </div>
+        </section>
+
+        <section class="side-section distribution-section">
+          <div class="section-heading">
+            <h2>Distribution</h2>
+            <span id="group-count" class="section-count"></span>
+          </div>
+          <div id="distribution" data-testid="group-distribution"></div>
+        </section>
+
+        <section class="side-section legend-section">
+          <div class="section-heading">
+            <h2>Node kinds</h2>
+            <button id="show-all-button" class="text-button" type="button">Show all</button>
+          </div>
+          <div id="legend" class="legend" data-testid="kind-legend"></div>
+        </section>
+
+        <section class="side-section edge-filter-section">
+          <div class="section-heading">
+            <h2>Relationship kinds</h2>
+            <button id="show-all-edges-button" class="text-button" type="button">Show all</button>
+          </div>
+          <div id="edge-legend" class="legend" data-testid="edge-legend"></div>
+        </section>
+
+        <section class="side-section inspector-section">
+          <div class="section-heading">
+            <h2>Inspector</h2>
+            <span id="selection-kind" class="kind-pill" hidden></span>
+          </div>
+          <div id="inspector" data-testid="node-inspector">
+            <p class="empty-state">Select a node to see its exact CodeGraph identity and relationships.</p>
+          </div>
+        </section>
+      </aside>
+    </main>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/src/ui/assets/styles.css
+++ b/src/ui/assets/styles.css
@@ -1,0 +1,532 @@
+:root {
+  --bg: #07100e;
+  --panel: #0c1714;
+  --panel-raised: #11211c;
+  --line: #21342e;
+  --line-strong: #315048;
+  --muted: #7f9a91;
+  --text: #e6f1ed;
+  --accent: #6ee7b7;
+  --accent-strong: #34d399;
+  --warning: #fbbf24;
+  --danger: #fb7185;
+  --shadow: 0 22px 60px rgba(0, 0, 0, 0.32);
+}
+
+* { box-sizing: border-box; }
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background:
+    radial-gradient(circle at 28% 12%, rgba(52, 211, 153, 0.07), transparent 30rem),
+    var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  overflow: hidden;
+}
+
+button,
+input,
+select { font: inherit; }
+
+button { color: inherit; }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.topbar {
+  height: 68px;
+  display: grid;
+  grid-template-columns: minmax(190px, 0.7fr) minmax(320px, 1.5fr) minmax(180px, 0.7fr);
+  align-items: center;
+  gap: 24px;
+  padding: 0 22px;
+  background: rgba(7, 16, 14, 0.92);
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(18px);
+  position: relative;
+  z-index: 10;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.brand-mark {
+  width: 30px;
+  height: 30px;
+  border: 1px solid rgba(110, 231, 183, 0.6);
+  border-radius: 9px;
+  background:
+    radial-gradient(circle at 28% 30%, var(--accent), transparent 3px),
+    radial-gradient(circle at 72% 68%, var(--accent-strong), transparent 3px),
+    linear-gradient(135deg, transparent 45%, rgba(110, 231, 183, 0.8) 46% 53%, transparent 54%);
+  box-shadow: inset 0 0 18px rgba(110, 231, 183, 0.12);
+  flex: 0 0 auto;
+}
+
+.brand strong,
+.brand span { display: block; white-space: nowrap; }
+.brand strong { font-size: 14px; letter-spacing: 0.08em; text-transform: uppercase; }
+.brand span { margin-top: 2px; color: var(--muted); font-size: 11px; letter-spacing: 0.05em; }
+
+.search-shell {
+  position: relative;
+  width: min(680px, 100%);
+  justify-self: center;
+}
+
+#search {
+  width: 100%;
+  height: 40px;
+  color: var(--text);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  padding: 0 14px 0 38px;
+  outline: none;
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.search-shell::before {
+  content: "";
+  position: absolute;
+  z-index: 1;
+  left: 15px;
+  top: 13px;
+  width: 10px;
+  height: 10px;
+  border: 1.5px solid var(--muted);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.search-shell::after {
+  content: "";
+  position: absolute;
+  z-index: 1;
+  left: 25px;
+  top: 24px;
+  width: 6px;
+  height: 1.5px;
+  background: var(--muted);
+  transform: rotate(45deg);
+  pointer-events: none;
+}
+
+#search:focus {
+  border-color: rgba(110, 231, 183, 0.7);
+  box-shadow: 0 0 0 3px rgba(52, 211, 153, 0.09);
+}
+
+.search-results {
+  position: absolute;
+  top: 46px;
+  left: 0;
+  right: 0;
+  max-height: min(460px, 70vh);
+  overflow: auto;
+  padding: 7px;
+  background: rgba(12, 23, 20, 0.99);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+}
+
+.search-result {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  border: 0;
+  border-radius: 8px;
+  padding: 9px 10px;
+  text-align: left;
+  background: transparent;
+  cursor: pointer;
+}
+
+.search-result:hover,
+.search-result:focus-visible { background: var(--panel-raised); outline: none; }
+
+.search-result-dot,
+.legend-dot {
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--kind-color, #94a3b8);
+  box-shadow: 0 0 10px rgba(148, 163, 184, 0.3);
+}
+
+.kind-file { --kind-color: #6ee7b7; }
+.kind-module { --kind-color: #2dd4bf; }
+.kind-namespace { --kind-color: #14b8a6; }
+.kind-section { --kind-color: #fbbf24; }
+.kind-class { --kind-color: #60a5fa; }
+.kind-struct { --kind-color: #38bdf8; }
+.kind-interface { --kind-color: #818cf8; }
+.kind-trait { --kind-color: #a78bfa; }
+.kind-protocol { --kind-color: #c084fc; }
+.kind-function { --kind-color: #f472b6; }
+.kind-method { --kind-color: #fb7185; }
+.kind-component { --kind-color: #f97316; }
+.kind-route { --kind-color: #fb923c; }
+.kind-property { --kind-color: #a3e635; }
+.kind-field { --kind-color: #84cc16; }
+.kind-variable { --kind-color: #d9f99d; }
+.kind-constant { --kind-color: #fde047; }
+.kind-enum { --kind-color: #facc15; }
+.kind-enum_member { --kind-color: #eab308; }
+.kind-type_alias { --kind-color: #22d3ee; }
+.kind-parameter { --kind-color: #94a3b8; }
+.kind-import { --kind-color: #64748b; }
+.kind-export { --kind-color: #cbd5e1; }
+.palette-0 { --kind-color: #6ee7b7; }
+.palette-1 { --kind-color: #60a5fa; }
+.palette-2 { --kind-color: #fbbf24; }
+.palette-3 { --kind-color: #f472b6; }
+.palette-4 { --kind-color: #a78bfa; }
+.palette-5 { --kind-color: #22d3ee; }
+.palette-6 { --kind-color: #fb923c; }
+.palette-7 { --kind-color: #a3e635; }
+.palette-8 { --kind-color: #fb7185; }
+.palette-9 { --kind-color: #2dd4bf; }
+.palette-10 { --kind-color: #c084fc; }
+.palette-11 { --kind-color: #cbd5e1; }
+
+.search-result-copy { min-width: 0; }
+.search-result-copy strong,
+.search-result-copy small { display: block; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.search-result-copy strong { font-size: 13px; }
+.search-result-copy small { margin-top: 3px; color: var(--muted); font-size: 11px; }
+
+.toolbar { justify-self: end; display: flex; align-items: center; gap: 10px; }
+.toolbar button {
+  height: 34px;
+  padding: 0 13px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--panel);
+  cursor: pointer;
+}
+.toolbar button:hover { border-color: rgba(110, 231, 183, 0.5); }
+
+.badge,
+.kind-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 8px;
+  color: var(--accent);
+  background: rgba(52, 211, 153, 0.08);
+  border: 1px solid rgba(52, 211, 153, 0.2);
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.kind-pill { color: var(--kind-color, var(--accent)); }
+.kind-pill[hidden] { display: none; }
+
+.workspace {
+  height: calc(100% - 68px);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 370px;
+}
+
+.graph-panel {
+  position: relative;
+  min-width: 0;
+  overflow: hidden;
+  background:
+    linear-gradient(rgba(110, 231, 183, 0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(110, 231, 183, 0.022) 1px, transparent 1px);
+  background-size: 42px 42px;
+}
+
+.canvas-heading {
+  position: absolute;
+  z-index: 2;
+  top: 16px;
+  left: 18px;
+  right: 18px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  pointer-events: none;
+}
+
+.canvas-heading span,
+.canvas-heading strong { display: block; }
+#canvas-eyebrow { color: var(--accent); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; }
+#canvas-title { margin-top: 4px; font-size: 15px; letter-spacing: 0.01em; }
+.canvas-metrics { display: flex; gap: 7px; }
+.canvas-metrics span {
+  padding: 5px 8px;
+  color: var(--muted);
+  background: rgba(7, 16, 14, 0.72);
+  border: 1px solid rgba(33, 52, 46, 0.8);
+  border-radius: 999px;
+  font-size: 10px;
+}
+
+#graph { display: block; width: 100%; height: 100%; cursor: grab; touch-action: none; }
+#graph.panning { cursor: grabbing; }
+#arrow path { fill: rgba(126, 156, 146, 0.58); }
+#aggregate-arrow path { fill: rgba(110, 231, 183, 0.5); }
+
+.group-box {
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+  cursor: zoom-in;
+}
+.group-header { pointer-events: none; }
+.group-title {
+  fill: #e8f4f0;
+  font-size: 13px;
+  font-weight: 700;
+  paint-order: stroke;
+  stroke: rgba(7, 16, 14, 0.9);
+  stroke-width: 3px;
+}
+.group-meta {
+  fill: #91aaa2;
+  font-size: 9px;
+  paint-order: stroke;
+  stroke: rgba(7, 16, 14, 0.9);
+  stroke-width: 2px;
+}
+
+.aggregate-edge {
+  fill: none;
+  stroke: rgba(110, 231, 183, 0.3);
+  marker-end: url("#aggregate-arrow");
+  pointer-events: none;
+  vector-effect: non-scaling-stroke;
+}
+
+.exact-edge {
+  stroke: rgba(126, 156, 146, 0.2);
+  stroke-width: 0.8;
+  marker-end: url("#arrow");
+  pointer-events: none;
+  vector-effect: non-scaling-stroke;
+}
+.exact-edge.is-selected-edge { stroke: rgba(96, 165, 250, 0.72); stroke-width: 1.6; }
+
+.node { cursor: pointer; outline: none; pointer-events: bounding-box; }
+.node circle {
+  fill: var(--node-color, var(--kind-color, #94a3b8));
+  stroke: rgba(255, 255, 255, 0.38);
+  stroke-width: 0.7;
+  vector-effect: non-scaling-stroke;
+}
+.node-label {
+  display: none;
+  fill: #e5f2ed;
+  font-size: 9px;
+  paint-order: stroke;
+  stroke: rgba(7, 16, 14, 0.96);
+  stroke-width: 3px;
+  stroke-linejoin: round;
+  pointer-events: auto;
+  user-select: none;
+}
+.node.show-label .node-label,
+.node:hover .node-label,
+.node:focus-visible .node-label,
+.node.is-selected .node-label { display: block; }
+.node:hover circle,
+.node:focus-visible circle,
+.node.is-selected circle {
+  stroke: #fff;
+  stroke-width: 2;
+  filter: drop-shadow(0 0 7px var(--node-color, var(--kind-color, #94a3b8)));
+}
+
+.graph-message {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  transform: translate(-50%, -50%);
+  min-width: 220px;
+  padding: 13px 16px;
+  text-align: center;
+  color: var(--muted);
+  background: rgba(12, 23, 20, 0.92);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+}
+.graph-message[hidden] { display: none; }
+.graph-message.error { color: #fecdd3; border-color: rgba(251, 113, 133, 0.45); }
+
+.graph-hint {
+  position: absolute;
+  left: 16px;
+  bottom: 14px;
+  padding: 7px 10px;
+  color: var(--muted);
+  background: rgba(7, 16, 14, 0.74);
+  border: 1px solid rgba(33, 52, 46, 0.8);
+  border-radius: 8px;
+  font-size: 10px;
+  letter-spacing: 0.03em;
+  pointer-events: none;
+}
+
+.sidebar {
+  min-height: 0;
+  overflow-y: auto;
+  background: rgba(12, 23, 20, 0.97);
+  border-left: 1px solid var(--line);
+  box-shadow: -18px 0 50px rgba(0, 0, 0, 0.14);
+}
+
+.summary-card {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  padding: 14px;
+  background: rgba(12, 23, 20, 0.98);
+  border-bottom: 1px solid var(--line);
+}
+.summary-card > div {
+  padding: 10px 11px;
+  background: rgba(17, 33, 28, 0.78);
+  border: 1px solid rgba(33, 52, 46, 0.9);
+  border-radius: 10px;
+}
+.summary-card span,
+.summary-card strong { display: block; }
+.summary-card span { color: var(--muted); font-size: 9px; letter-spacing: 0.06em; text-transform: uppercase; }
+.summary-card strong { margin-top: 6px; font-size: 12px; font-variant-numeric: tabular-nums; }
+#truncation-note { grid-column: 1 / -1; margin: 0; color: var(--warning); font-size: 10px; line-height: 1.4; }
+
+.side-section { padding: 14px; border-bottom: 1px solid var(--line); }
+.section-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 10px; }
+.section-heading h2 { margin: 0; color: #a8bdb6; font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; }
+.section-count { color: var(--muted); font-size: 10px; }
+.text-button { padding: 0; color: var(--accent); background: transparent; border: 0; font-size: 10px; cursor: pointer; }
+
+.control-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 9px; }
+.control-grid label > span { display: block; margin: 0 0 5px; color: var(--muted); font-size: 9px; letter-spacing: 0.04em; text-transform: uppercase; }
+.control-grid select {
+  width: 100%;
+  height: 32px;
+  padding: 0 26px 0 8px;
+  color: var(--text);
+  background: var(--panel-raised);
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  outline: none;
+}
+.control-grid select:focus { border-color: rgba(110, 231, 183, 0.55); }
+
+.distribution-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 4px 9px; margin: 0 0 8px; }
+.distribution-copy { display: flex; justify-content: space-between; min-width: 0; gap: 8px; }
+.distribution-copy strong { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-size: 10px; font-weight: 600; }
+.distribution-copy span,
+.distribution-row > span { color: var(--muted); font-size: 9px; font-variant-numeric: tabular-nums; }
+.distribution-row progress {
+  grid-column: 1 / -1;
+  width: 100%;
+  height: 4px;
+  appearance: none;
+  border: 0;
+  border-radius: 999px;
+  overflow: hidden;
+  background: var(--panel-raised);
+}
+.distribution-row progress::-webkit-progress-bar { background: var(--panel-raised); }
+.distribution-row progress::-webkit-progress-value { background: var(--bar-color, var(--accent)); }
+.distribution-row progress::-moz-progress-bar { background: var(--bar-color, var(--accent)); }
+
+.legend { display: grid; grid-template-columns: 1fr 1fr; gap: 3px 7px; }
+.legend-item {
+  display: grid;
+  grid-template-columns: 13px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  padding: 4px 5px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.legend-item:hover { background: var(--panel-raised); }
+.legend-item input { position: absolute; opacity: 0; pointer-events: none; }
+.legend-item.is-hidden { opacity: 0.32; }
+.legend-label,
+.legend-count { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-size: 9px; }
+.legend-count { color: var(--muted); font-variant-numeric: tabular-nums; }
+.edge-filter-section .legend-dot { border-radius: 2px; }
+
+.empty-state { margin: 3px 0 0; color: var(--muted); font-size: 11px; line-height: 1.55; }
+.node-title { margin: 0 0 7px; overflow-wrap: anywhere; font-size: 15px; line-height: 1.25; }
+.node-path {
+  margin: 0 0 13px;
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+.detail-grid {
+  display: grid;
+  grid-template-columns: 65px minmax(0, 1fr);
+  gap: 6px 9px;
+  padding: 10px 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  font-size: 10px;
+}
+.detail-grid dt { color: var(--muted); }
+.detail-grid dd { margin: 0; overflow-wrap: anywhere; }
+.relation-heading { margin: 14px 0 6px; color: #a8bdb6; font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; }
+.neighbor-list { display: flex; flex-direction: column; gap: 4px; }
+.neighbor-button {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  width: 100%;
+  padding: 7px 8px;
+  color: var(--text);
+  text-align: left;
+  background: var(--panel-raised);
+  border: 1px solid transparent;
+  border-radius: 7px;
+  cursor: pointer;
+}
+.neighbor-button:hover { border-color: var(--line-strong); }
+.neighbor-button span:first-child { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-size: 10px; }
+.neighbor-button span:last-child { color: var(--muted); font-size: 8px; text-transform: uppercase; }
+.truncated-note { margin: 10px 0 0; color: var(--warning); font-size: 9px; line-height: 1.45; }
+
+@media (max-width: 980px) {
+  .topbar { grid-template-columns: auto minmax(220px, 1fr); }
+  .toolbar { display: none; }
+  .workspace { grid-template-columns: minmax(0, 1fr) 310px; }
+  .canvas-heading { display: none; }
+}

--- a/src/ui/topology-server.ts
+++ b/src/ui/topology-server.ts
@@ -1,0 +1,288 @@
+import * as fs from 'fs';
+import * as http from 'http';
+import * as path from 'path';
+import { AddressInfo } from 'net';
+import {
+  EDGE_KINDS,
+  GraphStats,
+  NODE_KINDS,
+  NodeKind,
+  SearchOptions,
+  SearchResult,
+  TopologyNeighborhood,
+  TopologySnapshot,
+  TopologySnapshotOptions,
+} from '../types';
+
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PORT = 7474;
+const DEFAULT_NODE_LIMIT = 800;
+const MAX_NODE_LIMIT = 2000;
+const MAX_SEARCH_LIMIT = 50;
+const MAX_NEIGHBOR_EDGES = 1000;
+
+const STATIC_FILES = new Map<string, { file: string; contentType: string }>([
+  ['/', { file: 'index.html', contentType: 'text/html; charset=utf-8' }],
+  ['/index.html', { file: 'index.html', contentType: 'text/html; charset=utf-8' }],
+  ['/app.js', { file: 'app.js', contentType: 'text/javascript; charset=utf-8' }],
+  ['/styles.css', { file: 'styles.css', contentType: 'text/css; charset=utf-8' }],
+  ['/favicon.ico', { file: 'favicon.svg', contentType: 'image/svg+xml' }],
+  ['/favicon.svg', { file: 'favicon.svg', contentType: 'image/svg+xml' }],
+]);
+
+const SECURITY_HEADERS: Readonly<Record<string, string>> = {
+  'Content-Security-Policy': [
+    "default-src 'self'",
+    "script-src 'self'",
+    "style-src 'self'",
+    "img-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'none'",
+    "frame-ancestors 'none'",
+  ].join('; '),
+  'Referrer-Policy': 'no-referrer',
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+};
+
+/**
+ * The topology server intentionally depends on this read-only structural
+ * interface instead of the concrete CodeGraph class. It cannot index, sync,
+ * watch, or mutate a project.
+ */
+export interface TopologyGraphReader {
+  getTopologySnapshot(options?: TopologySnapshotOptions): TopologySnapshot;
+  getStats(): GraphStats;
+  searchNodes(query: string, options?: SearchOptions): SearchResult[];
+  getTopologyNeighborhood(nodeId: string, limit?: number): TopologyNeighborhood | null;
+}
+
+export interface TopologyServerOptions {
+  /** Bind address. Defaults to loopback. */
+  host?: string;
+  /** TCP port. Use 0 to request an ephemeral port in tests. */
+  port?: number;
+  /** Default and maximum node count returned by `/api/graph`. */
+  nodeLimit?: number;
+}
+
+export interface TopologyServer {
+  readonly host: string;
+  readonly port: number;
+  readonly url: string;
+  close(): Promise<void>;
+}
+
+function clampInteger(value: number, fallback: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, Math.trunc(value)));
+}
+
+function queryInteger(
+  raw: string | null,
+  fallback: number,
+  min: number,
+  max: number
+): number {
+  if (raw === null || raw.trim() === '') return fallback;
+  return clampInteger(Number(raw), fallback, min, max);
+}
+
+function parseKinds(raw: string | null): NodeKind[] | undefined {
+  if (raw === null || raw.trim() === '') return undefined;
+  const allowed = new Set<NodeKind>(NODE_KINDS);
+  const kinds = [...new Set(raw.split(',').map((part) => part.trim()))];
+  if (kinds.some((kind) => !allowed.has(kind as NodeKind))) {
+    throw new HttpError(400, 'Unknown node kind');
+  }
+  return kinds as NodeKind[];
+}
+
+class HttpError extends Error {
+  constructor(
+    readonly status: number,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+function writeHeaders(
+  response: http.ServerResponse,
+  status: number,
+  contentType: string,
+  contentLength?: number
+): void {
+  response.statusCode = status;
+  response.setHeader('Content-Type', contentType);
+  response.setHeader('Cache-Control', 'no-store');
+  for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+    response.setHeader(name, value);
+  }
+  if (contentLength !== undefined) {
+    response.setHeader('Content-Length', contentLength);
+  }
+}
+
+function sendJson(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  status: number,
+  value: unknown
+): void {
+  const body = Buffer.from(JSON.stringify(value));
+  writeHeaders(response, status, 'application/json; charset=utf-8', body.length);
+  response.end(request.method === 'HEAD' ? undefined : body);
+}
+
+function sendText(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  status: number,
+  value: string
+): void {
+  const body = Buffer.from(value);
+  writeHeaders(response, status, 'text/plain; charset=utf-8', body.length);
+  response.end(request.method === 'HEAD' ? undefined : body);
+}
+
+function createRequestHandler(
+  graph: TopologyGraphReader,
+  nodeLimit: number
+): http.RequestListener {
+  const assetsDir = path.join(__dirname, 'assets');
+
+  return (request, response) => {
+    void (async () => {
+      try {
+        if (request.method !== 'GET' && request.method !== 'HEAD') {
+          response.setHeader('Allow', 'GET, HEAD');
+          throw new HttpError(405, 'Method not allowed');
+        }
+
+        const url = new URL(request.url ?? '/', `http://${request.headers.host ?? 'localhost'}`);
+
+        if (url.pathname === '/api/stats') {
+          sendJson(request, response, 200, graph.getStats());
+          return;
+        }
+
+        if (url.pathname === '/api/contract') {
+          sendJson(request, response, 200, {
+            nodeKinds: NODE_KINDS,
+            edgeKinds: EDGE_KINDS,
+            readOnly: true,
+          });
+          return;
+        }
+
+        if (url.pathname === '/api/graph') {
+          const limit = queryInteger(url.searchParams.get('limit'), nodeLimit, 1, nodeLimit);
+          const kinds = parseKinds(url.searchParams.get('kinds'));
+          sendJson(request, response, 200, graph.getTopologySnapshot({ limit, kinds }));
+          return;
+        }
+
+        if (url.pathname === '/api/search') {
+          const query = (url.searchParams.get('q') ?? '').trim();
+          if (query.length < 1 || query.length > 200) {
+            throw new HttpError(400, 'Search query must contain 1 to 200 characters');
+          }
+          const limit = queryInteger(
+            url.searchParams.get('limit'),
+            20,
+            1,
+            MAX_SEARCH_LIMIT
+          );
+          const results = graph.searchNodes(query, { limit });
+          sendJson(request, response, 200, {
+            results: results.map((result) => ({
+              node: result.node,
+              score: result.score,
+              highlights: result.highlights,
+            })),
+          });
+          return;
+        }
+
+        if (url.pathname === '/api/node') {
+          const id = url.searchParams.get('id') ?? '';
+          if (id.length < 1 || id.length > 2048) {
+            throw new HttpError(400, 'Node id must contain 1 to 2048 characters');
+          }
+          const neighborhood = graph.getTopologyNeighborhood(id, MAX_NEIGHBOR_EDGES);
+          if (!neighborhood) throw new HttpError(404, 'Node not found');
+          sendJson(request, response, 200, neighborhood);
+          return;
+        }
+
+        const staticAsset = STATIC_FILES.get(url.pathname);
+        if (staticAsset) {
+          const body = fs.readFileSync(path.join(assetsDir, staticAsset.file));
+          writeHeaders(response, 200, staticAsset.contentType, body.length);
+          response.end(request.method === 'HEAD' ? undefined : body);
+          return;
+        }
+
+        sendText(request, response, 404, 'Not found');
+      } catch (error) {
+        if (response.headersSent) {
+          response.destroy();
+          return;
+        }
+        const status = error instanceof HttpError ? error.status : 500;
+        const message = error instanceof HttpError ? error.message : 'Internal server error';
+        sendJson(request, response, status, { error: message });
+      }
+    })();
+  };
+}
+
+/**
+ * Start the bundled, read-only CodeGraph topology UI service.
+ */
+export async function startTopologyServer(
+  graph: TopologyGraphReader,
+  options: TopologyServerOptions = {}
+): Promise<TopologyServer> {
+  const host = options.host?.trim() || DEFAULT_HOST;
+  const port = clampInteger(options.port ?? DEFAULT_PORT, DEFAULT_PORT, 0, 65535);
+  const nodeLimit = clampInteger(
+    options.nodeLimit ?? DEFAULT_NODE_LIMIT,
+    DEFAULT_NODE_LIMIT,
+    1,
+    MAX_NODE_LIMIT
+  );
+  const server = http.createServer(createRequestHandler(graph, nodeLimit));
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error): void => reject(error);
+    server.once('error', onError);
+    server.listen(port, host, () => {
+      server.off('error', onError);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Topology server did not bind to a TCP address');
+  }
+  const actualPort = (address as AddressInfo).port;
+  const displayHost = host.includes(':') ? `[${host}]` : host;
+
+  return {
+    host,
+    port: actualPort,
+    url: `http://${displayHost}:${actualPort}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
+  };
+}


### PR DESCRIPTION
## Summary

This adds a repository-local knowledge layer and a bundled, read-only topology atlas on top of CodeGraph's existing graph:

- index Markdown headings as `section` nodes without changing or replacing any existing code extraction
- resolve local Markdown links and conservative inline-code symbol mentions into exact persisted `references` edges
- expose bounded, exact induced graph snapshots and exact node neighborhoods
- add `codegraph ui [path]` with bundled offline assets, loopback-only defaults, semantic/directory/language grouping, progressive labels, node/edge filters, visual-only group aggregation, and a precise inspector

## Why

Repository knowledge is split between source and local documents. Agents and humans need to move from architecture/runbooks to concrete symbols while retaining the original CodeGraph identity and relationship truth. Existing node IDs, qualified names, edge endpoints, edge kinds, and code extraction paths remain unchanged; document nodes are appended and UI aggregation is presentation-only.

## Related work

- #361 also indexes Markdown. This PR intentionally uses a smaller V1 surface (headings, local links, unambiguous symbol mentions) and combines it with the topology API/UI. I am happy to rebase the UI on #361, split the PR, or reuse its richer extractor if maintainers prefer.
- #1198 adds a self-contained `codegraph view`. This PR uses a loopback read-only service instead, so search and the inspector query the full SQLite graph while the browser renders a bounded snapshot. The atlas emphasizes macro distribution before node-level inspection.

## User impact

```bash
cd your-project
codegraph init
codegraph ui --limit 1200
# open http://127.0.0.1:7474
```

No CDN, external document fetch, or runtime network dependency is introduced. External URLs stay as source text and are not crawled.

## Validation

- `npm run build`
- 606/606 existing extraction tests
- 618/618 extraction + Markdown + wire-contract + topology tests
- 98/100 security, watcher, and CLI tests (2 existing platform skips)
- WSL Rust kernel: 15/15 tests
- real-browser validation on Graphify: 10,717 nodes / 25,441 edges; grouping, filtering, zoom labels, search, direct selection, and exact inspector relationships; 0 console errors/warnings and localhost-only requests

Design notes are included under `docs/design/repository-documents-v1.md` and `docs/design/repository-topology-ui-v1.md`.
