### PR TITLE
fix(resolution): resolve Python module members through aliased imports

### DIFF
--- a/__tests__/resolution.test.ts
+++ b/__tests__/resolution.test.ts
@@ -1243,6 +1243,57 @@ def external_caller():
       expect(externalCalls).toHaveLength(0);
     });
 
+    it('resolves Python module-attribute calls after `from pkg import module as alias` (#899)', async () => {
+      // #578 fixed the unaliased form; the aliased one still dropped its edge.
+      // resolvePythonModuleMember joined `imp.source` with `imp.localName` to
+      // name the submodule, but under `from pkg import module as alias`
+      // `localName` is the alias — so it looked for `pkg.alias`, which names no
+      // module, and the member never resolved. The two names coincide only when
+      // the import is unaliased, which is why the unaliased case passed on a
+      // scratch project while real trees (which alias) kept reporting no callers.
+      fs.mkdirSync(path.join(tempDir, 'pkg'));
+      fs.writeFileSync(path.join(tempDir, 'pkg', '__init__.py'), '');
+      fs.writeFileSync(
+        path.join(tempDir, 'pkg', 'module.py'),
+        'def func():\n    return 1\n'
+      );
+      fs.writeFileSync(
+        path.join(tempDir, 'main.py'),
+        `from pkg import module as mod_alias
+import os as operating_system
+
+
+def caller():
+    return mod_alias.func()
+
+
+def external_caller():
+    return operating_system.getcwd()
+`
+      );
+
+      cg = await CodeGraph.init(tempDir, { index: true });
+
+      const caller = cg.getNodesByKind('function').filter((n) => n.name === 'caller')[0];
+      expect(caller).toBeDefined();
+      const calls = cg.getOutgoingEdges(caller!.id).filter((e) => e.kind === 'calls');
+      expect(calls).toHaveLength(1);
+      const target = cg.getNode(calls[0]!.target);
+      expect(target?.name).toBe('func');
+      expect(target?.filePath.replace(/\\/g, '/')).toBe('pkg/module.py');
+
+      // An aliased *stdlib* module must still produce no edge — resolution only
+      // matches real in-repo module files, alias or not.
+      const externalCaller = cg
+        .getNodesByKind('function')
+        .filter((n) => n.name === 'external_caller')[0];
+      expect(externalCaller).toBeDefined();
+      const externalCalls = cg
+        .getOutgoingEdges(externalCaller!.id)
+        .filter((e) => e.kind === 'calls');
+      expect(externalCalls).toHaveLength(0);
+    });
+
     it('attaches Go methods to their receiver type across files (#583, cross-file half)', async () => {
       // In Go a type's methods are commonly declared in a different file from the
       // `type` declaration (`type Box` in box.go, `func (b *Box) Get()` in

--- a/src/resolution/import-resolver.ts
+++ b/src/resolution/import-resolver.ts
@@ -1607,11 +1607,19 @@ function resolvePythonModuleMember(
     // `import mod` / `import numpy as np` bind the module at `source` itself;
     // `from . import certs` / `from pkg import mod` bind a SUBMODULE whose
     // dotted path is the source joined with the imported name.
+    //
+    // The submodule is named by `exportedName`, not `localName`: under
+    // `from pkg import mod as alias`, `localName` is the alias and joining it
+    // yields `pkg.alias`, which names no module, so the lookup below misses and
+    // the call edge is dropped. They coincide only when the import is unaliased,
+    // which is why unaliased forms resolved and aliased ones did not (#899).
+    const moduleName =
+      imp.exportedName && imp.exportedName !== '*' ? imp.exportedName : imp.localName;
     const modulePath = imp.isNamespace
       ? imp.source
       : imp.source.endsWith('.')
-        ? imp.source + imp.localName
-        : imp.source + '.' + imp.localName;
+        ? imp.source + moduleName
+        : imp.source + '.' + moduleName;
 
     // resolveImportPath only maps RELATIVE dotted paths (`.mod`, `..pkg.mod`); an
     // ABSOLUTE package path (`pkg.module` from `from pkg import module`, or a bare
@@ -1725,9 +1733,13 @@ function resolveModuleImportToFile(
       modulePath = imp.source;
     } else if (ref.language === 'python') {
       // `from . import certs` — the imported NAME is a submodule of the source.
+      // Use `exportedName`, not `localName`: under `from pkg import mod as alias`
+      // the latter is the alias, and `pkg.alias` names no module (#899).
+      const moduleName =
+        imp.exportedName && imp.exportedName !== '*' ? imp.exportedName : imp.localName;
       modulePath = imp.source.endsWith('.')
-        ? imp.source + imp.localName
-        : imp.source + '.' + imp.localName;
+        ? imp.source + moduleName
+        : imp.source + '.' + moduleName;
     } else {
       // A named TS/JS import binds a symbol, not a module — leave it alone.
       continue;


### PR DESCRIPTION
## Summary

Python calls and imports through an aliased module (`from pkg import module as alias`) produce no `calls` edge and no file→file `imports` edge. `codegraph callers` on such a target returns nothing.

## Problem

`resolvePythonModuleMember` and `resolveModuleImportToFile` name the target submodule by joining the import source with `imp.localName`. Under `from pkg import module as alias`, `localName` is the alias, so the lookup asks for `pkg.alias` — which names no module. The member never resolves and the edge is dropped.

`localName` and `exportedName` coincide only when the import is unaliased. That is why the unaliased form resolves and the aliased one silently does not, and why this reproduces in real trees but not in minimal repros — small repros rarely alias.

Reported in #899 as still failing after #578 / #715; this appears to be the remaining cause.

## Reproduction

```
pkg/__init__.py      (empty)
pkg/module.py        def func(): return 1
main.py              from pkg import module as mod_alias

                     def caller():
                         return mod_alias.func()
```

`caller` has no outgoing `calls` edge, and `codegraph callers func` reports none. Dropping `as mod_alias` makes both appear.

## Fix

Both sites use `exportedName` (the real submodule), falling back to `localName` when it is absent or `*`. The `import x as y` namespace branch is untouched — it binds the module at `source` itself and returns before this path.

## Tests

Added `resolves Python module-attribute calls after \`from pkg import module as alias\` (#899)` in `__tests__/resolution.test.ts`, beside the existing #578 unaliased case. It asserts the call resolves to the submodule function, and that an aliased stdlib module (`import os as operating_system`) still creates no edge.

The test earns its place: with the fix reverted it is the only failure in that file (1 failed / 176 passed); with the fix, 177/177.

## Validation

- `npx vitest run __tests__/resolution.test.ts` — 177/177
- `npx vitest run __tests__/arkts-resolution.test.ts __tests__/cfml-inheritance-resolution.test.ts __tests__/php-property-receiver-resolution.test.ts __tests__/same-name-disambiguation.test.ts` — 38/38
- `npm run build` — clean
- `npm test` — the failing-test set is byte-identical to unmodified `main` (55 failures, all in CLI / MCP-daemon / version-affordance suites, pre-existing on this machine); passing count goes 2468 → 2469, which is the added test. No new failures, none removed.

Measured on a 991-file Python project that imports modules under aliases throughout: a target with 6 call sites across 5 enclosing functions went from 0 callers to 5; another went 2 → 4; +824 edges index-wide. Unaliased and class-based resolution unchanged.

Scope is Python only — both sites are language-gated. The Go (#388) and Ruby (#1110) caller gaps have different root causes.
