### PR TITLE
feat(config): add codegraph.json "deprioritize" for ranking-only path down-weighting (#982)

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,9 +666,7 @@ Sometimes a directory shouldn't leave the index — you still want to find thing
 in it — it just shouldn't *outrank* your real code. A `scripts/` or
 `optional-skills/` tree whose helpers use generic names (`usage`, `status`,
 `run`) can win on an exact name match and crowd out the product code that
-actually answers the query. CodeGraph already de-prioritizes `example/`,
-`sample/`, `fixture/`, `benchmark/` and `demo/` this way; `deprioritize` extends
-that list to the trees only your project knows about:
+actually answers the query. Name those trees under `deprioritize`:
 
 ```json
 {
@@ -678,7 +676,11 @@ that list to the trees only your project knows about:
 
 This is the ranking counterpart to `exclude`: those paths stay indexed and
 findable — searching for them directly still works — they just stop winning
-against first-party code.
+against first-party code. It applies to `query` / `search` and to `explore`'s
+ranking. It is *not* a filter: unlike the built-in `example/`, `sample/`,
+`fixture/`, `benchmark/` and `demo/` handling — which also drops those files
+from some result sets outright — `deprioritize` only ever changes rank. Reach
+for `exclude` when you want something gone.
 
 ### Custom file extensions
 

--- a/README.md
+++ b/README.md
@@ -662,6 +662,24 @@ CodeGraph discovers those files off disk, overriding `.gitignore`, on index,
 sync, and watch. An explicit `exclude` still wins, and built-in skips
 (`node_modules`, `dist`, `.git`) are never re-included.
 
+Sometimes a directory shouldn't leave the index — you still want to find things
+in it — it just shouldn't *outrank* your real code. A `scripts/` or
+`optional-skills/` tree whose helpers use generic names (`usage`, `status`,
+`run`) can win on an exact name match and crowd out the product code that
+actually answers the query. CodeGraph already de-prioritizes `example/`,
+`sample/`, `fixture/`, `benchmark/` and `demo/` this way; `deprioritize` extends
+that list to the trees only your project knows about:
+
+```json
+{
+  "deprioritize": ["optional-skills/", "scripts/"]
+}
+```
+
+This is the ranking counterpart to `exclude`: those paths stay indexed and
+findable — searching for them directly still works — they just stop winning
+against first-party code.
+
 ### Custom file extensions
 
 If your project uses a non-standard extension for a [supported

--- a/__tests__/deprioritize-config.test.ts
+++ b/__tests__/deprioritize-config.test.ts
@@ -23,6 +23,7 @@ import * as os from 'os';
 import { CodeGraph } from '../src';
 import { initGrammars, loadAllGrammars } from '../src/extraction/grammars';
 import { loadDeprioritizePatterns } from '../src/project-config';
+import { scorePathRelevance } from '../src/search/query-utils';
 
 const QUERY = 'desktop status bar context window usage';
 
@@ -162,6 +163,7 @@ describe('#982 minimal repro — ranking with and without deprioritize', () => {
     // This is the status quo the issue reports, and the shape the corpus-frequency
     // discount cannot fix (only two symbols are named `usage` here, so it is rare).
     const results = baseCg.searchNodes(QUERY, { limit: 20 });
+    expect(results.length).toBeGreaterThanOrEqual(2);
     expect(results.slice(0, 2).every(isHelper)).toBe(true);
   });
 
@@ -184,8 +186,74 @@ describe('#982 minimal repro — ranking with and without deprioritize', () => {
     // gateway/ and packages/ are not named, so their scores must not move.
     const score = (cg: CodeGraph, file: string): number | undefined =>
       cg.searchNodes('slugify', { limit: 20 }).find((r) => r.node.filePath.includes(file))?.score;
-    expect(score(cfgCg, 'packages/core/util/strings.ts')).toBe(
-      score(baseCg, 'packages/core/util/strings.ts')
-    );
+    const baseline = score(baseCg, 'packages/core/util/strings.ts');
+    expect(baseline).toBeDefined();
+    expect(score(cfgCg, 'packages/core/util/strings.ts')).toBe(baseline);
+  });
+
+  it('a query that genuinely targets the tree still ranks it, competitor present', () => {
+    // The "discount, don't erase" edge case #982 calls out. `bodyfat_calc` lives
+    // only in the de-prioritized tree; a query naming it must still find it
+    // first, even with product code competing for the same terms.
+    const results = cfgCg.searchNodes('bodyfat calc usage', { limit: 20 });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].node.filePath).toContain('optional-skills/bodyfat');
+  });
+
+  it('explore ranking honours the setting, not just search', () => {
+    // #982's reproduction rows B/C/D are all `codegraph explore`. Explore ranks
+    // through its own path scorer as well as through searchNodes, so a
+    // search-only fix would leave the reported surface unchanged.
+    const matcher = (cfgCg as unknown as { queries: { getDeprioritizedPathMatcher(): ((p: string) => boolean) | undefined } })
+      .queries.getDeprioritizedPathMatcher();
+    expect(matcher).toBeDefined();
+    expect(matcher!('optional-skills/bodyfat/scripts/bodyfat_calc.ts')).toBe(true);
+    expect(matcher!('apps/desktop/statusbar/StatusBar.ts')).toBe(false);
+  });
+
+  it('picks up a config written after the project was opened', async () => {
+    // wireLayers runs once per open, so a matcher captured there would freeze
+    // at open time — and the MCP server keeps one CodeGraph per root alive for
+    // its whole lifetime, which would make an edited config look like a no-op.
+    const late = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-deprio-late-'));
+    writeRepro(late);
+    const cg = CodeGraph.initSync(late);
+    try {
+      await cg.indexAll();
+      const before = cg.searchNodes(QUERY, { limit: 20 });
+      expect(before.length).toBeGreaterThanOrEqual(2);
+      expect(before.slice(0, 2).every(isHelper)).toBe(true);
+
+      fs.writeFileSync(
+        path.join(late, 'codegraph.json'),
+        JSON.stringify({ deprioritize: ['optional-skills/'] })
+      );
+      const after = cg.searchNodes(QUERY, { limit: 20 });
+      const firstHelper = after.findIndex(isHelper);
+      const firstProduct = after.findIndex((r) => r.node.filePath.includes('apps/desktop'));
+      expect(firstProduct).toBeGreaterThanOrEqual(0);
+      expect(firstHelper === -1 || firstProduct < firstHelper).toBe(true);
+    } finally {
+      cg.destroy();
+      fs.rmSync(late, { recursive: true, force: true });
+    }
+  }, 180_000);
+});
+
+describe('scorePathRelevance — the two deliberate asymmetries (#982)', () => {
+  it('docks a path that is both test-like and de-prioritized only once', () => {
+    const both = 'example/a/foo.ts';
+    const asTestOnly = scorePathRelevance(both, 'foo');
+    const asBoth = scorePathRelevance(both, 'foo', undefined, true);
+    expect(asBoth).toBe(asTestOnly);
+  });
+
+  it('does not waive the user penalty for a test-y query, unlike the built-ins', () => {
+    // The built-in classification is inferred, so a test-y query waives it. A
+    // `deprioritize` pattern is a standing statement by the project, so it
+    // stands. Asserted so the difference is a decision, not an accident.
+    const builtIn = scorePathRelevance('example/a/foo.ts', 'foo test');
+    const userDeclared = scorePathRelevance('optional-skills/a/foo.ts', 'foo test', undefined, true);
+    expect(userDeclared).toBe(builtIn - 15);
   });
 });

--- a/__tests__/deprioritize-config.test.ts
+++ b/__tests__/deprioritize-config.test.ts
@@ -23,7 +23,8 @@ import * as os from 'os';
 import { CodeGraph } from '../src';
 import { initGrammars, loadAllGrammars } from '../src/extraction/grammars';
 import { loadDeprioritizePatterns } from '../src/project-config';
-import { scorePathRelevance } from '../src/search/query-utils';
+import { nameMatchBonus, scorePathRelevance } from '../src/search/query-utils';
+import { DEPRIORITIZED_NAME_BONUS_SCALE } from '../src/db/queries';
 
 const QUERY = 'desktop status bar context window usage';
 
@@ -255,5 +256,25 @@ describe('scorePathRelevance — the two deliberate asymmetries (#982)', () => {
     const builtIn = scorePathRelevance('example/a/foo.ts', 'foo test');
     const userDeclared = scorePathRelevance('optional-skills/a/foo.ts', 'foo test', undefined, true);
     expect(userDeclared).toBe(builtIn - 15);
+  });
+});
+
+describe('the name-bonus damping constant is derived, not picked (#982)', () => {
+  it('keeps a damped exact match above the prefix arm, so it cannot lose to one', () => {
+    // A de-prioritized node keeps `80 * SCALE` of the whole-query exact bonus
+    // and also takes the -15 path penalty. The prefix arm tops out below 40, so
+    // `80 * SCALE - 15 > 40` is what guarantees the exact match still wins —
+    // "discount, don't erase" stated as arithmetic instead of taste.
+    expect(nameMatchBonus('child', 'child')).toBe(80);
+    expect(nameMatchBonus('children', 'child')).toBeLessThan(40);
+    expect(80 * DEPRIORITIZED_NAME_BONUS_SCALE - 15).toBeGreaterThan(40);
+  });
+
+  it('would fail at the originally proposed 0.25, which is why it moved', () => {
+    // Measured on a 62k-node django index with `deprioritize: ["tests/"]`: at
+    // 0.25 the exact-name queries `child`, `parent` and `method` lost rank 1 to
+    // the prefix matches `children`, `all_parents` and `method_decorator`.
+    // Asserted so nobody lowers the constant back without meeting the bound.
+    expect(80 * 0.25 - 15).toBeLessThan(40);
   });
 });

--- a/__tests__/deprioritize-config.test.ts
+++ b/__tests__/deprioritize-config.test.ts
@@ -1,0 +1,191 @@
+/**
+ * `codegraph.json` → `deprioritize` — user-extensible ranking de-prioritization (#982).
+ *
+ * `matchesNonProductionDir` hardcodes example/sample/fixture/benchmark/demo, so a
+ * peripheral tree only the project knows about — `optional-skills/`, `scripts/` —
+ * gets no de-prioritization. When helpers in such a tree carry generic symbol
+ * names, an exact name match hands them a large bonus and they crowd out the
+ * product code that actually answers the query.
+ *
+ * This is the *ranking* half of #982, deliberately distinct from the corpus-
+ * frequency discount: that one keys on a name being COMMON, and is near-inert on
+ * #982's own 8-file repro where only two symbols are named `usage`. The fixture
+ * here IS that repro, which is the point — the two levers cover different shapes.
+ *
+ * It is also distinct from `exclude`, which is a recall lever. De-prioritized
+ * paths stay indexed and findable; they just stop winning. Locked below.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { CodeGraph } from '../src';
+import { initGrammars, loadAllGrammars } from '../src/extraction/grammars';
+import { loadDeprioritizePatterns } from '../src/project-config';
+
+const QUERY = 'desktop status bar context window usage';
+
+/** #982's minimal reproduction layout. */
+function writeRepro(root: string): void {
+  const mk = (rel: string, content: string) => {
+    const p = path.join(root, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, content);
+  };
+
+  // Product code. No symbol here is literally named `usage`.
+  mk(
+    'apps/desktop/statusbar/StatusBar.ts',
+    [
+      'export class DesktopStatusBar {',
+      '  render(): string { return this.refresh(); }',
+      '  refresh(): string { return "status bar"; }',
+      '  mount(): void {}',
+      '}',
+    ].join('\n')
+  );
+  mk(
+    'apps/desktop/statusbar/StatusBarController.ts',
+    [
+      "import { DesktopStatusBar } from './StatusBar';",
+      'export class StatusBarController {',
+      '  constructor(private readonly bar: DesktopStatusBar) {}',
+      '  show(): string { return this.bar.render(); }',
+      '}',
+    ].join('\n')
+  );
+  mk(
+    'apps/desktop/context/ContextWindowMeter.ts',
+    [
+      'export class ContextWindowMeter {',
+      '  read(): number { return this.recompute(); }',
+      '  recompute(): number { return estimateTokens("context window"); }',
+      '}',
+      'export function estimateTokens(text: string): number { return text.length; }',
+    ].join('\n')
+  );
+  mk(
+    'apps/desktop/context/format.ts',
+    'export function formatTokens(n: number): string { return `${n} tokens`; }\n'
+  );
+  mk('gateway/server/server.ts', 'export function startServer(): void {}\n');
+  mk('packages/core/util/strings.ts', 'export function slugify(s: string): string { return s; }\n');
+
+  // The peripheral tree: two standalone helpers, each with a module-level `usage`.
+  for (const skill of ['bodyfat', 'nutrition']) {
+    mk(
+      `optional-skills/${skill}/scripts/${skill}_calc.ts`,
+      ['export function usage(): void {', `  console.log("usage: ${skill}_calc [options]");`, '}'].join('\n')
+    );
+  }
+}
+
+const isHelper = (r: { node: { name: string; filePath: string } }): boolean =>
+  r.node.name.toLowerCase() === 'usage' && r.node.filePath.includes('optional-skills');
+
+describe('codegraph.json deprioritize — parsing', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-deprio-cfg-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const write = (config: unknown): string => {
+    const sub = fs.mkdtempSync(path.join(dir, 'p-'));
+    fs.writeFileSync(path.join(sub, 'codegraph.json'), JSON.stringify(config));
+    return sub;
+  };
+
+  it('defaults to empty with no config file', () => {
+    const sub = fs.mkdtempSync(path.join(dir, 'none-'));
+    expect(loadDeprioritizePatterns(sub)).toEqual([]);
+  });
+
+  it('keeps gitignore-style patterns verbatim, trimmed', () => {
+    const sub = write({ deprioritize: ['optional-skills/', '  tools/gen  ', 'vendor/**'] });
+    expect(loadDeprioritizePatterns(sub)).toEqual(['optional-skills/', 'tools/gen', 'vendor/**']);
+  });
+
+  it('warns-and-skips a non-array value instead of throwing', () => {
+    const sub = write({ deprioritize: 'optional-skills/' });
+    expect(loadDeprioritizePatterns(sub)).toEqual([]);
+  });
+
+  it('drops blank and non-string entries, keeping the rest', () => {
+    const sub = write({ deprioritize: ['optional-skills/', '', 42, '   ', 'scripts/'] });
+    expect(loadDeprioritizePatterns(sub)).toEqual(['optional-skills/', 'scripts/']);
+  });
+
+  it('does not disturb the other config keys', () => {
+    const sub = write({ deprioritize: ['optional-skills/'], exclude: ['static/'] });
+    expect(loadDeprioritizePatterns(sub)).toEqual(['optional-skills/']);
+  });
+});
+
+describe('#982 minimal repro — ranking with and without deprioritize', () => {
+  let baseDir: string;
+  let cfgDir: string;
+  let baseCg: CodeGraph;
+  let cfgCg: CodeGraph;
+
+  beforeAll(async () => {
+    await initGrammars();
+    await loadAllGrammars();
+
+    baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-deprio-base-'));
+    writeRepro(baseDir);
+    baseCg = CodeGraph.initSync(baseDir);
+    await baseCg.indexAll();
+
+    cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-deprio-on-'));
+    writeRepro(cfgDir);
+    fs.writeFileSync(
+      path.join(cfgDir, 'codegraph.json'),
+      JSON.stringify({ deprioritize: ['optional-skills/'] }, null, 2)
+    );
+    cfgCg = CodeGraph.initSync(cfgDir);
+    await cfgCg.indexAll();
+  }, 180_000);
+
+  afterAll(() => {
+    baseCg?.destroy();
+    cfgCg?.destroy();
+    for (const d of [baseDir, cfgDir]) if (d) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  it('control: without the config the usage() helpers still take the top ranks', () => {
+    // This is the status quo the issue reports, and the shape the corpus-frequency
+    // discount cannot fix (only two symbols are named `usage` here, so it is rare).
+    const results = baseCg.searchNodes(QUERY, { limit: 20 });
+    expect(results.slice(0, 2).every(isHelper)).toBe(true);
+  });
+
+  it('with deprioritize, product code outranks the peripheral helpers', () => {
+    const results = cfgCg.searchNodes(QUERY, { limit: 20 });
+    const firstHelper = results.findIndex(isHelper);
+    const firstProduct = results.findIndex((r) => r.node.filePath.includes('apps/desktop'));
+    expect(firstProduct).toBeGreaterThanOrEqual(0);
+    expect(firstHelper === -1 || firstProduct < firstHelper).toBe(true);
+  });
+
+  it('is a ranking lever, not exclude: the helpers stay indexed and findable', () => {
+    // The whole point of keeping this distinct from `exclude` — recall is intact.
+    expect(cfgCg.getNodesByName('usage').length).toBe(2);
+    const direct = cfgCg.searchNodes('usage', { limit: 20 });
+    expect(direct.some(isHelper)).toBe(true);
+  });
+
+  it('leaves paths outside the patterns alone', () => {
+    // gateway/ and packages/ are not named, so their scores must not move.
+    const score = (cg: CodeGraph, file: string): number | undefined =>
+      cg.searchNodes('slugify', { limit: 20 }).find((r) => r.node.filePath.includes(file))?.score;
+    expect(score(cfgCg, 'packages/core/util/strings.ts')).toBe(
+      score(baseCg, 'packages/core/util/strings.ts')
+    );
+  });
+});

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -187,6 +187,7 @@ export { LOW_CONFIDENCE_MARKER } from './markers';
 export class ContextBuilder {
   private projectRoot: string;
   private queries: QueryBuilder;
+
   private traverser: GraphTraverser;
 
   constructor(
@@ -197,6 +198,21 @@ export class ContextBuilder {
     this.projectRoot = projectRoot;
     this.queries = queries;
     this.traverser = traverser;
+  }
+
+  /**
+   * Whether the project's `codegraph.json` `deprioritize` patterns cover this
+   * path (#982). Explore ranks through its own path scorer as well as through
+   * `searchNodes`, so the lever has to be applied here too or the setting would
+   * only half-work — and explore is the surface #982 actually reports on.
+   *
+   * Only the -15 relevance penalty is shared. Explore's hard `continue` filters
+   * and its non-production budget cap are deliberately NOT joined: those REMOVE
+   * content, and `deprioritize` is a ranking lever by definition — `exclude` is
+   * the lever for taking things out of reach.
+   */
+  private isDeprioritized(filePath: string): boolean {
+    return this.queries.getDeprioritizedPathMatcher()?.(filePath) ?? false;
   }
 
   /**
@@ -805,7 +821,12 @@ export class ContextBuilder {
           if (searchIdSet.has(r.node.id)) continue;
           if (isTestFile(r.node.filePath) && !isTestQuery) continue;
 
-          const pathScore = scorePathRelevance(r.node.filePath, query);
+          const pathScore = scorePathRelevance(
+            r.node.filePath,
+            query,
+            undefined,
+            this.isDeprioritized(r.node.filePath),
+          );
           const brevityBonus = Math.max(0, 6 - (name.length - titleCased.length) / 4);
           termCandidates.push({ node: r.node, score: 8 + brevityBonus + pathScore });
         }
@@ -892,7 +913,12 @@ export class ContextBuilder {
         const compoundResults: SearchResult[] = [];
         for (const [, entry] of compoundTermMap) {
           if (entry.terms.size >= 2) {
-            const pathScore = scorePathRelevance(entry.node.filePath, query);
+            const pathScore = scorePathRelevance(
+              entry.node.filePath,
+              query,
+              undefined,
+              this.isDeprioritized(entry.node.filePath),
+            );
             const brevityBonus = Math.max(0, 6 - entry.node.name.length / 8);
             compoundResults.push({
               node: entry.node,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -19,13 +19,6 @@ import {
 } from '../types';
 import { safeJsonParse } from '../utils';
 import { kindBonus, nameMatchBonus, scorePathRelevance } from '../search/query-utils';
-
-/**
- * How much of the exact-name bonus a `deprioritize`d path keeps (#982). Damped
- * rather than zeroed: a query that genuinely targets that tree must still rank
- * it, the same "discount, don't erase" rule the path penalty follows.
- */
-const DEPRIORITIZED_NAME_BONUS_SCALE = 0.25;
 import { parseQuery, boundedEditDistance } from '../search/query-parser';
 import { isGeneratedFile } from '../extraction/generated-detection';
 import { splitIdentifierSegments } from '../search/identifier-segments';
@@ -56,6 +49,13 @@ function isLowValueFile(filePath: string): boolean {
 }
 
 const SQLITE_PARAM_CHUNK_SIZE = 500;
+
+/**
+ * How much of the exact-name bonus a `deprioritize`d path keeps (#982). Damped
+ * rather than zeroed: a query that genuinely targets that tree must still rank
+ * it, the same "discount, don't erase" rule the path penalty follows.
+ */
+const DEPRIORITIZED_NAME_BONUS_SCALE = 0.25;
 
 /**
  * Database row types (snake_case from SQLite)
@@ -336,6 +336,11 @@ export class QueryBuilder {
    */
   setDeprioritizedPathMatcher(matcher: ((filePath: string) => boolean) | undefined): void {
     this.isDeprioritizedPath = matcher;
+  }
+
+  /** The `deprioritize` predicate (#982), so other rankers apply the same lever. */
+  getDeprioritizedPathMatcher(): ((filePath: string) => boolean) | undefined {
+    return this.isDeprioritizedPath;
   }
 
   // ===========================================================================
@@ -1268,18 +1273,14 @@ export class QueryBuilder {
         // on #982's repro, a `usage()` helper sat at 74.8 vs 51.2 for the top
         // product symbol — -15 lands at 59.8, still ahead). Damped, not zeroed,
         // so the tree stays findable when it genuinely is what you asked for.
+        // Evaluated once and reused: the predicate stats the config file.
         const deprioritized = this.isDeprioritizedPath?.(r.node.filePath) ?? false;
         const nameBonus = nameMatchBonus(r.node.name, scoringQuery);
         return {
           ...r,
           score: r.score
             + kindBonus(r.node.kind)
-            + scorePathRelevance(
-              r.node.filePath,
-              scoringQuery,
-              this.projectNameTokens,
-              this.isDeprioritizedPath,
-            )
+            + scorePathRelevance(r.node.filePath, scoringQuery, this.projectNameTokens, deprioritized)
             + (deprioritized ? Math.round(nameBonus * DEPRIORITIZED_NAME_BONUS_SCALE) : nameBonus),
         };
       });

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -19,6 +19,13 @@ import {
 } from '../types';
 import { safeJsonParse } from '../utils';
 import { kindBonus, nameMatchBonus, scorePathRelevance } from '../search/query-utils';
+
+/**
+ * How much of the exact-name bonus a `deprioritize`d path keeps (#982). Damped
+ * rather than zeroed: a query that genuinely targets that tree must still rank
+ * it, the same "discount, don't erase" rule the path penalty follows.
+ */
+const DEPRIORITIZED_NAME_BONUS_SCALE = 0.25;
 import { parseQuery, boundedEditDistance } from '../search/query-parser';
 import { isGeneratedFile } from '../extraction/generated-detection';
 import { splitIdentifierSegments } from '../search/identifier-segments';
@@ -196,6 +203,7 @@ export class QueryBuilder {
   // whole project, not a symbol, so it carries no discriminative signal (#720).
   // Set once by the CodeGraph instance; empty by default (no down-weighting).
   private projectNameTokens: Set<string> = new Set();
+  private isDeprioritizedPath: ((filePath: string) => boolean) | undefined;
 
   // Node cache for frequently accessed nodes (LRU-style, max 1000 entries)
   private nodeCache: Map<string, Node> = new Map();
@@ -318,6 +326,16 @@ export class QueryBuilder {
   /** The normalized project-name tokens (#720); empty if none were derived. */
   getProjectNameTokens(): Set<string> {
     return this.projectNameTokens;
+  }
+
+  /**
+   * Set the predicate that marks a path as de-prioritized by the project's
+   * `codegraph.json` `deprioritize` patterns (#982). Ranking-only: those paths
+   * stay indexed and findable, they just stop outranking first-party code.
+   * Called once when the project opens; undefined disables the lever.
+   */
+  setDeprioritizedPathMatcher(matcher: ((filePath: string) => boolean) | undefined): void {
+    this.isDeprioritizedPath = matcher;
   }
 
   // ===========================================================================
@@ -1243,13 +1261,28 @@ export class QueryBuilder {
     // Apply multi-signal scoring
     if (results.length > 0 && (text || query)) {
       const scoringQuery = text || query;
-      results = results.map(r => ({
-        ...r,
-        score: r.score
-          + kindBonus(r.node.kind)
-          + scorePathRelevance(r.node.filePath, scoringQuery, this.projectNameTokens)
-          + nameMatchBonus(r.node.name, scoringQuery),
-      }));
+      results = results.map(r => {
+        // A path the project de-prioritized is saying its symbol NAMES are not
+        // the answer, so the exact-name bonus has to be damped too. The -15 path
+        // penalty alone cannot do it: the bonus is additive and larger (measured
+        // on #982's repro, a `usage()` helper sat at 74.8 vs 51.2 for the top
+        // product symbol — -15 lands at 59.8, still ahead). Damped, not zeroed,
+        // so the tree stays findable when it genuinely is what you asked for.
+        const deprioritized = this.isDeprioritizedPath?.(r.node.filePath) ?? false;
+        const nameBonus = nameMatchBonus(r.node.name, scoringQuery);
+        return {
+          ...r,
+          score: r.score
+            + kindBonus(r.node.kind)
+            + scorePathRelevance(
+              r.node.filePath,
+              scoringQuery,
+              this.projectNameTokens,
+              this.isDeprioritizedPath,
+            )
+            + (deprioritized ? Math.round(nameBonus * DEPRIORITIZED_NAME_BONUS_SCALE) : nameBonus),
+        };
+      });
       results.sort((a, b) => b.score - a.score);
       // Trim to requested limit after rescoring
       if (results.length > limit) {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -54,8 +54,18 @@ const SQLITE_PARAM_CHUNK_SIZE = 500;
  * How much of the exact-name bonus a `deprioritize`d path keeps (#982). Damped
  * rather than zeroed: a query that genuinely targets that tree must still rank
  * it, the same "discount, don't erase" rule the path penalty follows.
+ *
+ * Derived rather than picked. `nameMatchBonus`'s prefix arm tops out below
+ * `10 + 30 = 40`, and a de-prioritized node also takes the -15 path penalty, so
+ * `80 * SCALE - 15 > 40` is what stops a damped WHOLE-QUERY exact match from
+ * losing to a mere prefix match. 0.75 clears it (45). Measured on a 62k-node
+ * django index: at 0.25 that invariant breaks in practice — `child`, `parent`
+ * and `method` lose rank 1 to `children`, `all_parents` and `method_decorator`
+ * — while crowd-out removal is almost flat between 0.75 and 0.5 (39 vs 40 of 88
+ * peripheral top-10 slots cleared), so a deeper discount buys little and costs
+ * the invariant. Pinned by a test.
  */
-const DEPRIORITIZED_NAME_BONUS_SCALE = 0.25;
+export const DEPRIORITIZED_NAME_BONUS_SCALE = 0.75;
 
 /**
  * Database row types (snake_case from SQLite)

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,8 @@ import { FileWatcher, WatchOptions, PendingFile, LockUnavailableError } from './
 import { EXTRACTION_VERSION } from './extraction/extraction-version';
 import { getCodeGraphDir } from './directory';
 import { deriveProjectNameTokens } from './search/query-utils';
+import ignore from 'ignore';
+import { loadDeprioritizePatterns } from './project-config';
 import { CodeGraphPackageVersion } from './mcp/version';
 import { segmentLookupVariants, splitIdentifierSegments } from './search/identifier-segments';
 import { createYielder } from './resolution/cooperative-yield';
@@ -183,6 +185,24 @@ export class CodeGraph {
     // the whole repo, not a symbol, so it has no discriminative value (#720).
     try {
       this.queries.setProjectNameTokens(deriveProjectNameTokens(this.projectRoot));
+    } catch {
+      // Best-effort: ranking still works without it.
+    }
+    // Down-weight the peripheral trees the project named in `codegraph.json`
+    // `deprioritize` — indexed and findable, but never outranking real code
+    // (#982). Ranking-only, so a bad pattern costs relevance, never recall.
+    try {
+      const patterns = loadDeprioritizePatterns(this.projectRoot);
+      if (patterns.length > 0) {
+        const matcher = ignore().add(patterns);
+        this.queries.setDeprioritizedPathMatcher((filePath: string) => {
+          const rel = path.isAbsolute(filePath)
+            ? path.relative(this.projectRoot, filePath)
+            : filePath;
+          if (!rel || rel.startsWith('..')) return false;
+          return matcher.ignores(rel.split(path.sep).join('/'));
+        });
+      }
     } catch {
       // Best-effort: ranking still works without it.
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,21 +191,36 @@ export class CodeGraph {
     // Down-weight the peripheral trees the project named in `codegraph.json`
     // `deprioritize` — indexed and findable, but never outranking real code
     // (#982). Ranking-only, so a bad pattern costs relevance, never recall.
-    try {
-      const patterns = loadDeprioritizePatterns(this.projectRoot);
-      if (patterns.length > 0) {
-        const matcher = ignore().add(patterns);
-        this.queries.setDeprioritizedPathMatcher((filePath: string) => {
-          const rel = path.isAbsolute(filePath)
-            ? path.relative(this.projectRoot, filePath)
-            : filePath;
-          if (!rel || rel.startsWith('..')) return false;
-          return matcher.ignores(rel.split(path.sep).join('/'));
-        });
+    //
+    // Read LAZILY, not once here: `wireLayers` runs from the constructor and
+    // from `reopenIfReplaced`, so a matcher built here would freeze at whatever
+    // the config said when the project opened. The MCP server caches one
+    // CodeGraph per root for its whole lifetime, so editing `codegraph.json`
+    // would appear to do nothing until the process restarted — `exclude` and
+    // `include` do not behave that way. `loadDeprioritizePatterns` is
+    // mtime-cached, so this costs one `stat`; the compiled matcher is memoized
+    // on the pattern array's identity, which the cache keeps stable.
+    let cachedPatterns: string[] | undefined;
+    let cachedMatcher: ReturnType<typeof ignore> | undefined;
+    this.queries.setDeprioritizedPathMatcher((filePath: string): boolean => {
+      try {
+        const patterns = loadDeprioritizePatterns(this.projectRoot);
+        if (patterns.length === 0) return false;
+        if (patterns !== cachedPatterns) {
+          cachedPatterns = patterns;
+          cachedMatcher = ignore().add(patterns);
+        }
+        const rel = path.isAbsolute(filePath)
+          ? path.relative(this.projectRoot, filePath)
+          : filePath;
+        if (!rel || rel.startsWith('..')) return false;
+        return cachedMatcher!.ignores(rel.split(path.sep).join('/'));
+      } catch {
+        // Ranking must never take the search down with it.
+        return false;
       }
-    } catch {
-      // Best-effort: ranking still works without it.
-    }
+    });
+
     this.orchestrator = new ExtractionOrchestrator(this.projectRoot, this.queries);
     this.resolver = createResolver(this.projectRoot, this.queries);
     this.graphManager = new GraphQueryManager(this.queries);

--- a/src/project-config.ts
+++ b/src/project-config.ts
@@ -67,6 +67,21 @@ export interface ProjectConfig {
    * wins. Absent/empty (the default) forces nothing in.
    */
   include?: string[];
+  /**
+   * Gitignore-style patterns for paths that should still be INDEXED and
+   * findable, but must not outrank first-party code in search ranking (#982).
+   *
+   * The ranking counterpart to `exclude`: `exclude` is a recall lever (the
+   * content leaves the index entirely), this is a relevance lever (the content
+   * stays, it just stops winning). It generalizes the built-in
+   * example/sample/fixture/benchmark de-prioritization to trees only the
+   * project knows about — an `optional-skills/` or `scripts/` directory whose
+   * helpers share generic symbol names with real code. Matched against
+   * project-root-relative paths, so `"optional-skills/"`, a recursive glob, or
+   * `"tools/gen"` all work. Absent/empty (the default) de-prioritizes nothing
+   * beyond the built-ins.
+   */
+  deprioritize?: string[];
 }
 
 /** Parsed, validated view of a project's `codegraph.json`. */
@@ -74,6 +89,7 @@ interface ParsedConfig {
   extensions: Record<string, Language>;
   includeIgnored: string[];
   exclude: string[];
+  deprioritize: string[];
   include: string[];
 }
 
@@ -97,6 +113,7 @@ const EMPTY_CONFIG: ParsedConfig = Object.freeze({
   includeIgnored: Object.freeze([]) as unknown as string[],
   exclude: Object.freeze([]) as unknown as string[],
   include: Object.freeze([]) as unknown as string[],
+  deprioritize: Object.freeze([]) as unknown as string[],
 });
 
 /**
@@ -149,15 +166,17 @@ function parseConfig(file: string): ParsedConfig {
   const includeIgnored = extractIncludeIgnored(parsed, file);
   const exclude = extractExclude(parsed, file);
   const include = extractInclude(parsed, file);
+  const deprioritize = extractPatternList(parsed, file, 'deprioritize');
   if (
     extensions === EMPTY_EXTENSIONS &&
     includeIgnored.length === 0 &&
     exclude.length === 0 &&
-    include.length === 0
+    include.length === 0 &&
+    deprioritize.length === 0
   ) {
     return EMPTY_CONFIG;
   }
-  return { extensions, includeIgnored, exclude, include };
+  return { extensions, includeIgnored, exclude, include, deprioritize };
 }
 
 /**
@@ -203,6 +222,29 @@ function extractIncludeIgnored(parsed: object, file: string): string[] {
   for (const entry of raw) {
     if (typeof entry !== 'string' || !entry.trim()) {
       logWarn(`Ignoring an "includeIgnored" entry in ${PROJECT_CONFIG_FILENAME}: every pattern must be a non-empty string`, { file });
+      continue;
+    }
+    out.push(entry.trim());
+  }
+  return out;
+}
+
+/**
+ * Validate a gitignore-style pattern list under `key`. A non-array value or a
+ * non-string/blank entry warns-and-skips; never throws. Patterns are kept
+ * verbatim (trimmed) so they match exactly as a `.gitignore` line would.
+ */
+function extractPatternList(parsed: object, file: string, key: 'deprioritize'): string[] {
+  const raw = (parsed as ProjectConfig)[key];
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) {
+    logWarn(`Ignoring "${key}" in ${PROJECT_CONFIG_FILENAME}: must be an array of gitignore-style patterns`, { file });
+    return [];
+  }
+  const out: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== 'string' || !entry.trim()) {
+      logWarn(`Ignoring a "${key}" entry in ${PROJECT_CONFIG_FILENAME}: every pattern must be a non-empty string`, { file });
       continue;
     }
     out.push(entry.trim());
@@ -323,6 +365,17 @@ export function loadIncludeIgnoredPatterns(rootDir: string): string[] {
  */
 export function loadExcludePatterns(rootDir: string): string[] {
   return loadParsedConfig(rootDir).exclude;
+}
+
+/**
+ * Load the validated `deprioritize` patterns for a project, mtime-cached.
+ *
+ * These name indexed paths that must not outrank first-party code (#982) — the
+ * ranking counterpart to `exclude`. An empty result — the zero-config default —
+ * de-prioritizes nothing beyond the built-in example/fixture/benchmark dirs.
+ */
+export function loadDeprioritizePatterns(rootDir: string): string[] {
+  return loadParsedConfig(rootDir).deprioritize;
 }
 
 /**

--- a/src/search/query-utils.ts
+++ b/src/search/query-utils.ts
@@ -222,6 +222,7 @@ export function scorePathRelevance(
   filePath: string,
   query: string,
   projectNameTokens?: Set<string>,
+  isDeprioritizedPath?: (filePath: string) => boolean,
 ): number {
   const pathLower = filePath.toLowerCase();
   const fileName = path.basename(filePath).toLowerCase();
@@ -264,10 +265,15 @@ export function scorePathRelevance(
     else if (subtokens.some((t) => pathLower.includes(t))) score += 3;
   }
 
-  // Deprioritize test files unless the query is explicitly about tests
+  // Deprioritize test files unless the query is explicitly about tests. The
+  // project's own `deprioritize` patterns (#982) land in the same penalty: a
+  // peripheral tree the project named is off-target for the same reason a
+  // fixture dir is. Applied ONCE — a path that is both must not be docked twice.
   const queryLower = query.toLowerCase();
   const isTestQuery = queryLower.includes('test') || queryLower.includes('spec');
-  if (!isTestQuery && isTestFile(filePath)) {
+  const offTarget =
+    (!isTestQuery && isTestFile(filePath)) || (isDeprioritizedPath?.(filePath) ?? false);
+  if (offTarget) {
     score -= 15;
   }
 

--- a/src/search/query-utils.ts
+++ b/src/search/query-utils.ts
@@ -222,7 +222,7 @@ export function scorePathRelevance(
   filePath: string,
   query: string,
   projectNameTokens?: Set<string>,
-  isDeprioritizedPath?: (filePath: string) => boolean,
+  isDeprioritized?: boolean,
 ): number {
   const pathLower = filePath.toLowerCase();
   const fileName = path.basename(filePath).toLowerCase();
@@ -265,14 +265,18 @@ export function scorePathRelevance(
     else if (subtokens.some((t) => pathLower.includes(t))) score += 3;
   }
 
-  // Deprioritize test files unless the query is explicitly about tests. The
-  // project's own `deprioritize` patterns (#982) land in the same penalty: a
-  // peripheral tree the project named is off-target for the same reason a
-  // fixture dir is. Applied ONCE — a path that is both must not be docked twice.
+  // Deprioritize test files unless the query is explicitly about tests, and
+  // apply the same -15 to a path the project declared peripheral (#982).
+  //
+  // Two deliberate asymmetries, both pinned by tests:
+  //  - the built-in test/fixture penalty is waived for a test-y query, because
+  //    the tool inferred that classification; a `deprioritize` pattern is a
+  //    standing statement by the project, so it is NOT waived. The name-bonus
+  //    damping at the call site is what keeps such a tree findable.
+  //  - a path that is both is docked ONCE, not twice.
   const queryLower = query.toLowerCase();
   const isTestQuery = queryLower.includes('test') || queryLower.includes('spec');
-  const offTarget =
-    (!isTestQuery && isTestFile(filePath)) || (isDeprioritizedPath?.(filePath) ?? false);
+  const offTarget = (!isTestQuery && isTestFile(filePath)) || isDeprioritized === true;
   if (offTarget) {
     score -= 15;
   }


### PR DESCRIPTION
The **ranking** half of #982, kept deliberately separate from the corpus-frequency discount in #1462 — the issue asks for the two to stay distinct because they have different semantics, and measuring confirmed they cover different shapes.

## Why a second lever

`matchesNonProductionDir` hardcodes `example/sample/fixture/benchmark/demo`, so a peripheral tree only the project knows about — `optional-skills/`, `scripts/`, a generator's output dir — gets no de-prioritization at all. When helpers there carry generic symbol names (`usage`, `status`, `run`), an exact name match hands them a large bonus and they crowd out the product code that answers the query.

```json
{
  "deprioritize": ["optional-skills/", "scripts/"]
}
```

Gitignore-style patterns, matched against project-root-relative paths — same contract as `exclude`, `include`, `includeIgnored`, and validated by the same warn-and-skip rules (a non-array value or a blank/non-string entry is dropped with a warning, never thrown).

**This is a relevance lever, not a recall lever.** `exclude` takes content out of the index; `deprioritize` leaves it fully indexed and findable and only stops it from winning. There's a test pinning exactly that — after de-prioritizing, `getNodesByName('usage')` still returns both helpers and a direct search for `usage` still surfaces them.

## The part I got wrong first, and what the measurement showed

My first cut only added the patterns to the existing **−15** path penalty, matching the built-in non-production dirs. **It did not fix the issue's repro**, and the numbers say why:

| | `usage()` helper | top product symbol |
|---|---|---|
| baseline | **74.8** | 51.2 |
| −15 path penalty only | **59.8** | 51.2 |

The path penalty is additive, and the signal it has to counter — the exact-name bonus — is additive and *larger*. No magnitude of a hand-tuned additive penalty fixes that shape robustly; it just moves the threshold.

So the lever now also targets the mechanism directly: **a path the project de-prioritized is saying its symbol names are not the answer**, so the exact-name bonus is damped there as well (`0.75×` — derived below; it started as a guessed `0.25×`). Damped rather than zeroed, so the tree still ranks when it genuinely *is* what you asked for — the same "discount, don't erase" rule as the path penalty.

Worth flagging as a finding regardless of this PR: **the built-in `example/`/`fixture/` de-prioritization has the same weakness.** A `usage()` inside a hardcoded `examples/` dir would out-rank product code today for exactly the same reason. This PR fixes it for user-declared paths; say the word and I'll extend the damping to the built-in set in a follow-up (I left it out to keep the diff to one behaviour).

## Relationship to #1462

Complementary, not overlapping — this is the point of keeping them distinct:

| | keys on | fixes #982's 8-file repro? |
|---|---|---|
| #1462 corpus-frequency discount | the **name** being common across the corpus | **No** — only 2 symbols are named `usage` there, so the name is rare and IDF is ~0.8, near-inert by design |
| this PR | the **path** being one the project declared peripheral | **Yes** — that repro is the fixture here |

Neither subsumes the other. They're on independent branches off `main` and touch `scorePathRelevance`'s signature in the same region, so whichever lands second needs a trivial rebase — happy to do that in either order.

## Two defects a review pass caught, now fixed

Both were real, both are pinned by new tests.

**1. The setting needed a process restart to take effect.** The matcher was built once in `wireLayers()`, which runs only from the constructor and `reopenIfReplaced()`. `src/mcp/tools.ts` keeps one `CodeGraph` per project root alive for the whole server lifetime — so a user editing `codegraph.json`, re-indexing, and seeing nothing change would reasonably conclude the feature was broken. `exclude` and `include` don't behave that way. The predicate now reads `loadDeprioritizePatterns()` per call (mtime-cached — one `stat`) and memoizes the compiled matcher on the pattern array's identity. There's a test that writes the config *after* opening the project; I confirmed it fails against the old code.

**2. `explore` only half-honoured the setting — and explore is the surface this issue reports on.** Both `scorePathRelevance` call sites in `src/context/index.ts` passed two arguments, so the lever never reached them; explore improved only incidentally, via the two sub-searches that route through `searchNodes`. Rows **B, C and D of #982's own reproduction table are all `codegraph explore`**, so shipping it search-only would have missed the reported case. Both sites now pass it.

What I deliberately did **not** join: explore's hard early-`continue` filters and its non-production budget cap. Those *remove* content from the result set, and `deprioritize` is a ranking lever by definition — `exclude` is the lever for putting something out of reach. Mixing the two would collapse the distinction the issue asks us to preserve.

The README claim was also overstated — it said this "extends" the built-in `example/`/`fixture/` list, when the built-ins get five mechanisms and this gets one. Narrowed to state exactly what it does.

Smaller items from the same pass: `scorePathRelevance` now takes a boolean rather than a predicate (the caller had already evaluated it, and it was being invoked twice per result); the predicate body is exception-guarded so a malformed path can never take a search down with it; the misplaced module const moved out from between two imports; and two test assertions that could pass vacuously on an empty result set were tightened.

## Tests

`__tests__/deprioritize-config.test.ts`, 16 tests:

- **parsing** — default empty with no config; patterns kept verbatim and trimmed; non-array warns-and-skips; blank/non-string entries dropped while the rest survive; other config keys undisturbed
- **ranking** — a *control* asserting that without the config the helpers still take the top two ranks (the reported status quo), then that with the config product code outranks them
- **recall preserved** — the helpers stay indexed and directly findable
- **no collateral** — `packages/core/util/strings.ts`, which no pattern names, scores identically with and without the config
- **config written after open** — fails on the eager implementation, verified
- **explore** — the matcher is reachable from the context builder and classifies both trees correctly
- **a query that genuinely targets the tree** — `bodyfat calc usage` still ranks the de-prioritized helper first with product code competing, which is #982's "discount, don't erase" edge case
- **the damping constant is derived** — `80 × SCALE − 15` must stay above the prefix arm's ceiling; one of the two tests fails at the originally proposed 0.25
- **the two deliberate asymmetries** — a path that is both test-like and de-prioritized is docked once, not twice; and the user penalty is *not* waived by a test-y query the way the inferred built-in one is (a standing project declaration outranks a heuristic — asserted so it reads as a decision, not an accident)

Regression suites, all green: `context-ranking`, `explore-corroboration-ranking`, `explore-nl-stopword-collision`, `explore-result-count`, `explore-blast-radius`, `explore-output-budget`, `context`, `symbol-lookup`, `same-name-disambiguation`, `field-name-retrieval`, `search-query-parser`, `exclude-config`, `include-config`, `include-ignored-config`, `is-test-file` — **165 passed**. `tsc --noEmit` clean. README documents the key alongside `exclude`/`include`.

## The A/B this repo gates on — now run, and what it did and didn't show

`CLAUDE.md` requires a scorer change to be A/B'd with `scripts/agent-eval/*`, ≥2 runs/arm. That gate was the honest blocker on this PR, so it is now run: **`ab-new-vs-baseline.sh`** (both arms codegraph-on — the only harness that isolates a retrieval change) plus **`run-all.sh`** for the with/without pass bar. sonnet / high, RUNS=2, baseline ref = this branch's merge-base (`572d22b`), target = a 62k-node django index carrying a `codegraph.json` the baseline build simply doesn't understand.

**Headline: the agent-level A/B is a null result. The deterministic evidence is real and is what this section actually offers.** Details below, including the two attempts that measured nothing.

### Deterministic probes — the lever does what it claims, on a real corpus

django, 62,080 nodes, `deprioritize: ["tests/"]` (that tree is **68.4%** of all nodes — a fair stand-in for a project whose peripheral tree dwarfs its product code).

40 queries, auto-generated from the 20 symbol names most concentrated in `tests/` that *also* exist in first-party code — i.e. exactly the crowd-out condition, not queries chosen to flatter the change:

| | peripheral slots in top-10 (40 queries) | queries improved | queries made worse |
|---|---|---|---|
| config absent | 88 | — | — |
| `deprioritize: ["tests/"]` | **49** | 15 | **0** |

Instrument control: same build, same index, config present but with a pattern that matches nothing (`no-such-tree/`) → **0 of 40 queries changed, byte-identical rankings**. So the deltas above are the lever, not run-to-run anything.

A concrete one — `setup handling during request processing`, top 10, **6 peripheral slots → 1**:

| rank | off | on |
|---|---|---|
| 4 | `setUp@django/test/utils.py` | `setUp@django/test/utils.py` |
| 5–9 | five more copies of `setUp@tests/admin_inlines/tests.py` | `request@django/test/client.py` ×4, `setup@docs/_ext/djangodocs.py` |
| 10 | `setUp@tests/admin_inlines/tests.py` | `setUp@tests/admin_inlines/tests.py` |

`codegraph_explore` moves too, which matters because explore is the surface #982 reports on. With a core-dev-shaped config (`["django/contrib/", "tests/"]`), `where is urlpatterns configured at startup` returns **5 files, 3 of them `django/contrib/**` URL modules** on the baseline; with the lever, **3 files, 1 peripheral** — `django/conf/__init__.py` and `django/core/management/commands/listurls.py` take the freed budget, and the response drops 24.7k → 23.2k chars.

And the case that should *not* improve, stated plainly: `how does the test runner set up the database before running tests` — a query that genuinely targets the de-prioritized tree — still returns it (5 of 7 files, alongside `django/test/runner.py`). That is "discount, don't erase" working, not a miss.

### `0.25×` → `0.75×`: the number you asked me not to guess, now derived

You asked me to set these two numbers rather than guess. One of them turned out to be measurable, so I stopped guessing it and pushed the change.

Sweeping the damping constant on the same 40 queries, plus a recall check on 15 symbol names that exist *only* inside the de-prioritized tree (an on-target query for those has no first-party alternative, so the tree should still win):

| scale | peripheral slots cleared (of 88) | on-target names still at rank 1 (of 15) |
|---|---|---|
| 1.0 (path penalty only) | 14 | 15 |
| 0.75 | **39** | **15** |
| 0.5 | 40 | 15 |
| 0.25 (originally proposed) | 56 | **10** |
| 0.1 | 68 | 9 |
| 0 (erase) | 74 | 9 |

Two things fall out:

1. **`1.0` — the −15 path penalty alone — clears 14 of 88.** That is the quantified version of the "additive penalty can't beat an additive, larger bonus" argument above, on a real corpus rather than the fixture.
2. **`0.25` breaks the PR's own rule.** The names that lose rank 1 there lose it *to prefix matches*: `child` → `children@django/test/utils.py`, `parent` → `all_parents@django/db/models/options.py`, `method` → `method_decorator@django/utils/decorators.py`. That is indefensible ranking behaviour regardless of this feature.

There's a bound that predicts it: `nameMatchBonus`'s prefix arm tops out below `10 + 30 = 40`, and a de-prioritized node also takes the −15 path penalty, so **`80 × SCALE − 15 > 40`** is what keeps a damped whole-query exact match ahead of a mere prefix match at any corpus shape. `0.75` clears it (45); `0.25` doesn't (5). And since 0.75 and 0.5 clear virtually the same crowd-out (39 vs 40 of 88), the deeper discount was buying almost nothing.

So the constant is now **0.75, derived**, with two tests pinning the bound — one of them fails at the old 0.25, so it can't drift back silently. The other number, the **−15** path penalty, I left alone: it's shared with the built-ins and changing it would move behaviour this PR doesn't own.

### Agent A/B — null result, reported as such

`ab-new-vs-baseline.sh`, django + `["django/contrib/", "tests/"]`, question chosen *after* verifying with the probe above that it actually surfaces the de-prioritized tree (`where are urlpatterns configured at startup…`), RUNS=2 per arm, on the shipped `0.75` build:

| | new (this PR) | baseline (`572d22b`) |
|---|---|---|
| duration | 43s [40–46] | 42s [42–43] |
| codegraph calls | 3 | 3 [2–3] |
| Read / Grep | 0 / 0 | 0 / 0 |
| retrieval residual | 23.6k tok [21.8–25.4k] | 17.5k tok [15.0–20.0k] |

Control repo (excalidraw, **no** `codegraph.json` → the lever is inert by construction, so any gap is pure variance): duration 38s [35–41] vs 41s [37–45], residual 31.5k [31.1–31.9k] vs 24.4k [17.8–30.9k]. **That control puts the noise floor at roughly ±7k tokens of residual and ±5s of duration at n=2 — as large as every gap in the table above.** An earlier pass of the same question on the interim `0.25` build even came out the other way (38s [33–43] vs 47s [45–49], residual 15.5k vs 21.6k). Two runs of the same question disagreeing on direction is the definition of a null result, and I'd rather say so than quote the favourable half.

Pass bar (`run-all.sh`, with vs without codegraph, same question, 2 invocations): with = 3–4 tool calls, **0–1 Read, 0 Grep**, 2 explore calls, 39s/55s; without = 6–8 tool calls, **4–5 Read**, 2–3 Bash, 40s/41s. The Read/Grep half of the bar is met comfortably; the "faster than without" half is a wash on this question (39 vs 40, then 55 vs 41). That measures codegraph as a whole, not this lever.

### Two measurements I threw away, and why

Both are the same trap, and it's worth writing down: **"the instrument didn't see it" is not "it isn't there."**

1. **First attempt: both arms made 0 codegraph calls.** Given a flow question with Read/Bash available, the agent solved it by `grep` and `Read` in both arms — 8 tool calls, no explore. Any difference between those arms is about grep, not about ranking. Both arms then got an identical instruction to use `codegraph_explore` and not shell out; from then on every run is 2–3 explore calls and 0 Grep.
2. **Second attempt: the question never surfaced the de-prioritized tree at all.** "How does Django turn a URL into a view" returns handler and resolver files in both arms — no `tests/`, no `contrib/`. The lever had nothing to act on, so the arms differed only by noise (new looked *worse*: 88% vs 96% allocation efficiency). Discarded, and the question replaced with one the deterministic probe had already shown to be contaminated in the baseline.

### Where that leaves the merge decision

The gate is procedurally satisfied — `ab-new-vs-baseline.sh` and `run-all.sh`, ≥2 runs/arm, isolated arms, disclosed methodology. But I'm not going to claim the agent-level win it was designed to detect: at n=2 on one repo the arms are inside the control's noise. What the measurement *did* buy is concrete: it caught that my own damping constant broke the "discount, don't erase" invariant, and replaced it with a derived one.

If a null agent A/B is disqualifying for a ranking lever that is off by default, say so and I'll close this. If the deterministic evidence is enough — the effect is user-opt-in, zero-diff when the key is absent, and provably no-op when the patterns match nothing — then the remaining decision is just whether you want the same damping extended to the built-in `example/`/`fixture/` set, which has the identical weakness.

Two small things I've deliberately left for the merge moment rather than doing now: a **rebase** onto current `main`, and the **CHANGELOG** entry (adding it to this branch's stale `[Unreleased]` section is a guaranteed conflict — I checked). Both are one command each once you tell me this is going in; I kept the head at the exact tree the numbers above were measured on.
