### PR TITLE
feat: framework-level route & reference extraction

### DIFF
--- a/__tests__/frameworks.test.ts
+++ b/__tests__/frameworks.test.ts
@@ -232,11 +232,11 @@ describe('expressResolver.extract', () => {
     expect(references[0].referenceName).toBe('listUsers');
   });
 
-  it('extracts route with router.post and middleware chain', () => {
+  it('extracts route with router.post', () => {
     const src = `router.post('/items', auth, createItem);\n`;
     const { nodes, references } = expressResolver.extract!('items.ts', src);
     expect(nodes[0].name).toBe('POST /items');
-    // Multiple handlers: prefer the LAST one (convention: middleware first, handler last)
+    // Multiple handlers: prefer the LAST one (convention: middleware comes first, handler last)
     expect(references[0].referenceName).toBe('createItem');
   });
 

--- a/src/resolution/frameworks/express.ts
+++ b/src/resolution/frameworks/express.ts
@@ -4,48 +4,14 @@
  * Handles Express and general Node.js patterns.
  */
 
-import { Node } from '../../types';
-import { FrameworkResolver, UnresolvedRef, ResolvedRef, ResolutionContext } from '../types';
-import { stripCommentsForRegex } from '../strip-comments';
+import type { Node } from '../../types';
+import type { FrameworkResolver, UnresolvedRef, ResolvedRef, ResolutionContext } from '../types';
 
 function extractTailIdent(expr: string): string | null {
   const cleaned = expr.replace(/\s+/g, '').replace(/\(\)$/, '');
   const m = cleaned.match(/(?:\.|^)([A-Za-z_][A-Za-z0-9_]*)$/);
   return m ? m[1]! : null;
 }
-
-/**
- * Index of the delimiter matching the one at `open`, skipping string/template
- * literals so a `)` or `}` inside a string doesn't throw off the balance.
- */
-function matchDelim(s: string, open: number, oc: string, cc: string): number {
-  let depth = 0;
-  for (let i = open; i < s.length; i++) {
-    const ch = s[i];
-    if (ch === '"' || ch === "'" || ch === '`') {
-      const q = ch;
-      i++;
-      while (i < s.length && s[i] !== q) { if (s[i] === '\\') i++; i++; }
-      continue;
-    }
-    if (ch === oc) depth++;
-    else if (ch === cc) { depth--; if (depth === 0) return i; }
-  }
-  return -1;
-}
-
-// Express res/req methods + common JS builtins — calls to these inside a handler
-// body are framework/noise, not the business flow we want to surface as route edges.
-const RESERVED_CALLS = new Set([
-  'json', 'jsonp', 'send', 'sendStatus', 'sendFile', 'status', 'end', 'redirect',
-  'render', 'set', 'get', 'header', 'type', 'format', 'attachment', 'download',
-  'cookie', 'clearCookie', 'append', 'location', 'vary', 'links', 'accepts', 'is',
-  'next', 'then', 'catch', 'finally', 'resolve', 'reject', 'all', 'race',
-  'map', 'filter', 'forEach', 'reduce', 'find', 'push', 'pop', 'slice', 'splice',
-  'includes', 'keys', 'values', 'entries', 'assign', 'parse', 'stringify',
-  'log', 'error', 'warn', 'info', 'String', 'Number', 'Boolean', 'Array', 'Object',
-  'Date', 'Math', 'JSON', 'Promise', 'require', 'fail', 'redirect',
-]);
 
 export const expressResolver: FrameworkResolver = {
   name: 'express',
@@ -136,18 +102,14 @@ export const expressResolver: FrameworkResolver = {
     const nodes: Node[] = [];
     const references: UnresolvedRef[] = [];
     const now = Date.now();
-    const lang = detectLanguage(filePath);
-    const safe = stripCommentsForRegex(content, lang);
-    // Match the route head up to the first arg: (app|router).METHOD('/path',
-    // (NOT the whole call — handlers are often inline arrows whose `)`/`{}` the
-    // old single-regex couldn't span, so inline-handler routes connected to nothing.)
-    const head = /\b(app|router)\.(get|post|put|patch|delete|all|use)\s*\(\s*['"]([^'"]+)['"]\s*,/g;
+    // Capture: (app|router).METHOD('/path', handler-expr)
+    const regex = /\b(app|router)\.(get|post|put|patch|delete|all|use)\s*\(\s*['"]([^'"]+)['"]\s*,\s*([^)]+)\)/g;
     let match: RegExpExecArray | null;
-    while ((match = head.exec(safe)) !== null) {
-      const method = match[2]!;
-      const routePath = match[3]!;
+    while ((match = regex.exec(content)) !== null) {
+      const [, _obj, method, routePath, handlers] = match;
+      if (!method || !routePath || !handlers) continue;
       if (method === 'use' && !routePath.startsWith('/')) continue;
-      const line = safe.slice(0, match.index).split('\n').length;
+      const line = content.slice(0, match.index).split('\n').length;
       const routeNode: Node = {
         id: `route:${filePath}:${line}:${method.toUpperCase()}:${routePath}`,
         kind: 'route',
@@ -158,63 +120,24 @@ export const expressResolver: FrameworkResolver = {
         endLine: line,
         startColumn: 0,
         endColumn: match[0].length,
-        language: lang,
+        language: detectLanguage(filePath),
         updatedAt: now,
       };
       nodes.push(routeNode);
-
-      // The full argument list = balanced parens from the route call's open paren.
-      const openParen = safe.indexOf('(', match.index);
-      const closeParen = openParen >= 0 ? matchDelim(safe, openParen, '(', ')') : -1;
-      const args = closeParen > openParen ? safe.slice(openParen + 1, closeParen) : '';
-      const arrowAt = args.indexOf('=>');
-
-      if (arrowAt >= 0) {
-        // Inline arrow handler (`router.post('/x', async (req,res) => {…})`). The
-        // arrow is anonymous, so its body — the actual request→service flow — would
-        // be lost. Attribute the body's calls to the route node as `calls` edges so
-        // `trace(route, service)` connects. Body = balanced `{…}` after `=>`, or the
-        // single-expression tail for `=> expr` arrows.
-        const afterArrow = args.slice(arrowAt + 2);
-        const braceAt = afterArrow.indexOf('{');
-        let body = afterArrow;
-        if (braceAt >= 0 && afterArrow.slice(0, braceAt).trim() === '') {
-          const end = matchDelim(afterArrow, braceAt, '{', '}');
-          if (end > braceAt) body = afterArrow.slice(braceAt + 1, end);
-        }
-        const callRe = /\b([A-Za-z_$][\w$]*)\s*\(/g;
-        const seen = new Set<string>();
-        let cm: RegExpExecArray | null;
-        while ((cm = callRe.exec(body)) !== null) {
-          const name = cm[1]!;
-          if (seen.has(name) || RESERVED_CALLS.has(name)) continue;
-          seen.add(name);
-          references.push({
-            fromNodeId: routeNode.id,
-            referenceName: name,
-            referenceKind: 'calls',
-            line,
-            column: 0,
-            filePath,
-            language: lang,
-          });
-        }
-      } else {
-        // Named handler: the LAST comma-separated arg (earlier ones are middleware).
-        const parts = args.split(',').map((s) => s.trim()).filter(Boolean);
-        const last = parts[parts.length - 1];
-        const handlerName = last ? extractTailIdent(last) : null;
-        if (handlerName) {
-          references.push({
-            fromNodeId: routeNode.id,
-            referenceName: handlerName,
-            referenceKind: 'references',
-            line,
-            column: 0,
-            filePath,
-            language: lang,
-          });
-        }
+      // Last comma-separated arg is the handler; intermediate args are middleware
+      const handlerParts = handlers.split(',').map((s) => s.trim()).filter(Boolean);
+      const last = handlerParts[handlerParts.length - 1];
+      const handlerName = last ? extractTailIdent(last) : null;
+      if (handlerName) {
+        references.push({
+          fromNodeId: routeNode.id,
+          referenceName: handlerName,
+          referenceKind: 'references',
+          line,
+          column: 0,
+          filePath,
+          language: detectLanguage(filePath),
+        });
       }
     }
     return { nodes, references };

--- a/src/resolution/frameworks/express.ts
+++ b/src/resolution/frameworks/express.ts
@@ -6,12 +6,46 @@
 
 import type { Node } from '../../types';
 import type { FrameworkResolver, UnresolvedRef, ResolvedRef, ResolutionContext } from '../types';
+import { stripCommentsForRegex } from '../strip-comments';
 
 function extractTailIdent(expr: string): string | null {
   const cleaned = expr.replace(/\s+/g, '').replace(/\(\)$/, '');
   const m = cleaned.match(/(?:\.|^)([A-Za-z_][A-Za-z0-9_]*)$/);
   return m ? m[1]! : null;
 }
+
+/**
+ * Index of the delimiter matching the one at `open`, skipping string/template
+ * literals so a `)` or `}` inside a string doesn't throw off the balance.
+ */
+function matchDelim(s: string, open: number, oc: string, cc: string): number {
+  let depth = 0;
+  for (let i = open; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      const q = ch;
+      i++;
+      while (i < s.length && s[i] !== q) { if (s[i] === '\\') i++; i++; }
+      continue;
+    }
+    if (ch === oc) depth++;
+    else if (ch === cc) { depth--; if (depth === 0) return i; }
+  }
+  return -1;
+}
+
+// Express res/req methods + common JS builtins — calls to these inside a handler
+// body are framework/noise, not the business flow we want to surface as route edges.
+const RESERVED_CALLS = new Set([
+  'json', 'jsonp', 'send', 'sendStatus', 'sendFile', 'status', 'end', 'redirect',
+  'render', 'set', 'get', 'header', 'type', 'format', 'attachment', 'download',
+  'cookie', 'clearCookie', 'append', 'location', 'vary', 'links', 'accepts', 'is',
+  'next', 'then', 'catch', 'finally', 'resolve', 'reject', 'all', 'race',
+  'map', 'filter', 'forEach', 'reduce', 'find', 'push', 'pop', 'slice', 'splice',
+  'includes', 'keys', 'values', 'entries', 'assign', 'parse', 'stringify',
+  'log', 'error', 'warn', 'info', 'String', 'Number', 'Boolean', 'Array', 'Object',
+  'Date', 'Math', 'JSON', 'Promise', 'require', 'fail', 'redirect',
+]);
 
 export const expressResolver: FrameworkResolver = {
   name: 'express',
@@ -102,14 +136,16 @@ export const expressResolver: FrameworkResolver = {
     const nodes: Node[] = [];
     const references: UnresolvedRef[] = [];
     const now = Date.now();
+    const lang = detectLanguage(filePath);
+    const safe = stripCommentsForRegex(content, lang);
     // Capture: (app|router).METHOD('/path', handler-expr)
-    const regex = /\b(app|router)\.(get|post|put|patch|delete|all|use)\s*\(\s*['"]([^'"]+)['"]\s*,\s*([^)]+)\)/g;
+    const head = /\b(app|router)\.(get|post|put|patch|delete|all|use)\s*\(\s*['"]([^'"]+)['"]\s*,/g;
     let match: RegExpExecArray | null;
-    while ((match = regex.exec(content)) !== null) {
-      const [, _obj, method, routePath, handlers] = match;
-      if (!method || !routePath || !handlers) continue;
+    while ((match = head.exec(safe)) !== null) {
+      const method = match[2]!;
+      const routePath = match[3]!;
       if (method === 'use' && !routePath.startsWith('/')) continue;
-      const line = content.slice(0, match.index).split('\n').length;
+      const line = safe.slice(0, match.index).split('\n').length;
       const routeNode: Node = {
         id: `route:${filePath}:${line}:${method.toUpperCase()}:${routePath}`,
         kind: 'route',
@@ -120,24 +156,63 @@ export const expressResolver: FrameworkResolver = {
         endLine: line,
         startColumn: 0,
         endColumn: match[0].length,
-        language: detectLanguage(filePath),
+        language: lang,
         updatedAt: now,
       };
       nodes.push(routeNode);
-      // Last comma-separated arg is the handler; intermediate args are middleware
-      const handlerParts = handlers.split(',').map((s) => s.trim()).filter(Boolean);
-      const last = handlerParts[handlerParts.length - 1];
-      const handlerName = last ? extractTailIdent(last) : null;
-      if (handlerName) {
-        references.push({
-          fromNodeId: routeNode.id,
-          referenceName: handlerName,
-          referenceKind: 'references',
-          line,
-          column: 0,
-          filePath,
-          language: detectLanguage(filePath),
-        });
+
+      // The full argument list = balanced parens from the route call's open paren.
+      const openParen = safe.indexOf('(', match.index);
+      const closeParen = openParen >= 0 ? matchDelim(safe, openParen, '(', ')') : -1;
+      const args = closeParen > openParen ? safe.slice(openParen + 1, closeParen) : '';
+      const arrowAt = args.indexOf('=>');
+
+      if (arrowAt >= 0) {
+        // Inline arrow handler (`router.post('/x', async (req,res) => {…})`). The
+        // arrow is anonymous, so its body — the actual request→service flow — would
+        // be lost. Attribute the body's calls to the route node as `calls` edges so
+        // `trace(route, service)` connects. Body = balanced `{…}` after `=>`, or the
+        // single-expression tail for `=> expr` arrows.
+        const afterArrow = args.slice(arrowAt + 2);
+        const braceAt = afterArrow.indexOf('{');
+        let body = afterArrow;
+        if (braceAt >= 0 && afterArrow.slice(0, braceAt).trim() === '') {
+          const end = matchDelim(afterArrow, braceAt, '{', '}');
+          if (end > braceAt) body = afterArrow.slice(braceAt + 1, end);
+        }
+        const callRe = /\b([A-Za-z_$][\w$]*)\s*\(/g;
+        const seen = new Set<string>();
+        let cm: RegExpExecArray | null;
+        while ((cm = callRe.exec(body)) !== null) {
+          const name = cm[1]!;
+          if (seen.has(name) || RESERVED_CALLS.has(name)) continue;
+          seen.add(name);
+          references.push({
+            fromNodeId: routeNode.id,
+            referenceName: name,
+            referenceKind: 'calls',
+            line,
+            column: 0,
+            filePath,
+            language: lang,
+          });
+        }
+      } else {
+        // Named handler: the LAST comma-separated arg (earlier ones are middleware).
+        const parts = args.split(',').map((s) => s.trim()).filter(Boolean);
+        const last = parts[parts.length - 1];
+        const handlerName = last ? extractTailIdent(last) : null;
+        if (handlerName) {
+          references.push({
+            fromNodeId: routeNode.id,
+            referenceName: handlerName,
+            referenceKind: 'references',
+            line,
+            column: 0,
+            filePath,
+            language: lang,
+          });
+        }
       }
     }
     return { nodes, references };

--- a/src/resolution/frameworks/python.ts
+++ b/src/resolution/frameworks/python.ts
@@ -4,8 +4,8 @@
  * Handles Django, Flask, and FastAPI patterns.
  */
 
-import { Node } from '../../types';
-import { FrameworkResolver, UnresolvedRef, ResolutionContext, FrameworkExtractionResult } from '../types';
+import type { Node } from '../../types';
+import type { FrameworkResolver, UnresolvedRef, ResolutionContext, FrameworkExtractionResult } from '../types';
 import { stripCommentsForRegex } from '../strip-comments';
 
 export const djangoResolver: FrameworkResolver = {
@@ -35,27 +35,7 @@ export const djangoResolver: FrameworkResolver = {
       const result = resolveByNameAndKind(ref.referenceName, CLASS_KINDS, FORM_DIRS, context);
       if (result) return { original: ref, targetNodeId: result, confidence: 0.8, resolvedBy: 'framework' };
     }
-    // ORM dynamic dispatch: QuerySet._fetch_all (and siblings) call
-    // `self._iterable_class(self)` — a runtime dispatch to the iterable class
-    // (default ModelIterable) whose __iter__ runs the SQL compiler. Static
-    // parsing can't resolve an attribute-as-callable, so it leaves an unresolved
-    // `_iterable_class` ref and a hole in the QuerySet→compiler chain. Bridge it
-    // to ModelIterable.__iter__ so the flow actually exists in the graph.
-    if (ref.referenceName === '_iterable_class') {
-      const target = resolveModelIterableIter(context);
-      if (target) return { original: ref, targetNodeId: target, confidence: 0.7, resolvedBy: 'framework' };
-    }
     return null;
-  },
-
-  // Let two ref shapes past resolveOne's "no possible match" pre-filter so they
-  // reach resolution: the ORM dynamic-dispatch `_iterable_class` (a QuerySet
-  // attribute, not a declared symbol), and a Django `include('app.urls')` module
-  // path — a dotted module name with no symbol/import to match, which resolution
-  // (resolvePythonAbsoluteModule) then maps to its `urls.py` file so the included
-  // URLconf records a dependency on the root urlconf.
-  claimsReference(name) {
-    return name === '_iterable_class' || name.endsWith('.urls');
   },
 
   extract(filePath, content) {
@@ -67,8 +47,7 @@ export const djangoResolver: FrameworkResolver = {
     const safe = stripCommentsForRegex(content, 'python');
 
     // path('url', handler, name=...) / re_path(r'...', handler) / url(r'...', handler)
-    // Capture groups: 1=function name, 2=url string, 3=handler expr
-    // Handler expr may contain one balanced () pair (e.g. View.as_view(), include('x.y'))
+    // Capture groups: 1=function name, 2=url string, 3=handler expression.
     const routeRegex = /\b(path|re_path|url)\s*\(\s*r?['"]([^'"]+)['"]\s*,\s*([\w.]+(?:\s*\([^)]*\))?)/g;
 
     let match: RegExpExecArray | null;
@@ -106,53 +85,9 @@ export const djangoResolver: FrameworkResolver = {
       }
     }
 
-    // DRF router registration: `router.register(r'articles', ArticleViewSet)` →
-    // route → the ViewSet class (the core CRUD endpoints, which path()/url() miss).
-    // The STRING first arg separates this from `admin.site.register(Model, Admin)`
-    // (whose first arg is a model class, not a string); the View/ViewSet suffix on
-    // the 2nd arg keeps it to DRF viewsets.
-    const routerRegex = /\.register\s*\(\s*r?['"]([^'"]+)['"]\s*,\s*([\w.]+)/g;
-    while ((match = routerRegex.exec(safe)) !== null) {
-      const prefix = match[1]!.replace(/^\^|\/?\$$/g, '');
-      const viewset = match[2]!.split('.').pop()!;
-      if (!/View(Set)?$/.test(viewset)) continue;
-      const line = safe.slice(0, match.index).split('\n').length;
-      const routeNode: Node = {
-        id: `route:${filePath}:${line}:VIEWSET:${prefix}`,
-        kind: 'route',
-        name: `VIEWSET /${prefix}`,
-        qualifiedName: `${filePath}::route:${prefix}`,
-        filePath, startLine: line, endLine: line, startColumn: 0, endColumn: match[0].length,
-        language: 'python', updatedAt: now,
-      };
-      nodes.push(routeNode);
-      references.push({
-        fromNodeId: routeNode.id,
-        referenceName: viewset,
-        referenceKind: 'references',
-        line, column: 0, filePath, language: 'python',
-      });
-    }
-
     return { nodes, references };
   },
 };
-
-/**
- * Find ModelIterable.__iter__ — the default iterable QuerySet invokes via
- * `self._iterable_class(self)`. Its __iter__ statically calls the SQL compiler,
- * so linking the dynamic dispatch here closes the QuerySet→SQL call chain.
- * (Over-approximates to the default iterable; .values()/.values_list() swap in
- * other BaseIterable subclasses, but ModelIterable is the canonical path.)
- */
-function resolveModelIterableIter(context: ResolutionContext): string | null {
-  const cls = context.getNodesByName('ModelIterable').find((n) => n.kind === 'class');
-  if (!cls) return null;
-  const iter = context.getNodesByName('__iter__').find(
-    (n) => n.filePath === cls.filePath && n.startLine >= cls.startLine && n.startLine <= cls.endLine
-  );
-  return iter ? iter.id : null;
-}
 
 /**
  * Parse a Django URL handler expression and return the symbol/module to link.

--- a/src/resolution/frameworks/python.ts
+++ b/src/resolution/frameworks/python.ts
@@ -35,7 +35,27 @@ export const djangoResolver: FrameworkResolver = {
       const result = resolveByNameAndKind(ref.referenceName, CLASS_KINDS, FORM_DIRS, context);
       if (result) return { original: ref, targetNodeId: result, confidence: 0.8, resolvedBy: 'framework' };
     }
+    // ORM dynamic dispatch: QuerySet._fetch_all (and siblings) call
+    // `self._iterable_class(self)` — a runtime dispatch to the iterable class
+    // (default ModelIterable) whose __iter__ runs the SQL compiler. Static
+    // parsing can't resolve an attribute-as-callable, so it leaves an unresolved
+    // `_iterable_class` ref and a hole in the QuerySet→compiler chain. Bridge it
+    // to ModelIterable.__iter__ so the flow actually exists in the graph.
+    if (ref.referenceName === '_iterable_class') {
+      const target = resolveModelIterableIter(context);
+      if (target) return { original: ref, targetNodeId: target, confidence: 0.7, resolvedBy: 'framework' };
+    }
     return null;
+  },
+
+  // Let two ref shapes past resolveOne's "no possible match" pre-filter so they
+  // reach resolution: the ORM dynamic-dispatch `_iterable_class` (a QuerySet
+  // attribute, not a declared symbol), and a Django `include('app.urls')` module
+  // path — a dotted module name with no symbol/import to match, which resolution
+  // (resolvePythonAbsoluteModule) then maps to its `urls.py` file so the included
+  // URLconf records a dependency on the root urlconf.
+  claimsReference(name) {
+    return name === '_iterable_class' || name.endsWith('.urls');
   },
 
   extract(filePath, content) {
@@ -85,9 +105,53 @@ export const djangoResolver: FrameworkResolver = {
       }
     }
 
+    // DRF router registration: `router.register(r'articles', ArticleViewSet)` →
+    // route → the ViewSet class (the core CRUD endpoints, which path()/url() miss).
+    // The STRING first arg separates this from `admin.site.register(Model, Admin)`
+    // (whose first arg is a model class, not a string); the View/ViewSet suffix on
+    // the 2nd arg keeps it to DRF viewsets.
+    const routerRegex = /\.register\s*\(\s*r?['"]([^'"]+)['"]\s*,\s*([\w.]+)/g;
+    while ((match = routerRegex.exec(safe)) !== null) {
+      const prefix = match[1]!.replace(/^\^|\/?\$$/g, '');
+      const viewset = match[2]!.split('.').pop()!;
+      if (!/View(Set)?$/.test(viewset)) continue;
+      const line = safe.slice(0, match.index).split('\n').length;
+      const routeNode: Node = {
+        id: `route:${filePath}:${line}:VIEWSET:${prefix}`,
+        kind: 'route',
+        name: `VIEWSET /${prefix}`,
+        qualifiedName: `${filePath}::route:${prefix}`,
+        filePath, startLine: line, endLine: line, startColumn: 0, endColumn: match[0].length,
+        language: 'python', updatedAt: now,
+      };
+      nodes.push(routeNode);
+      references.push({
+        fromNodeId: routeNode.id,
+        referenceName: viewset,
+        referenceKind: 'references',
+        line, column: 0, filePath, language: 'python',
+      });
+    }
+
     return { nodes, references };
   },
 };
+
+/**
+ * Find ModelIterable.__iter__ — the default iterable QuerySet invokes via
+ * `self._iterable_class(self)`. Its __iter__ statically calls the SQL compiler,
+ * so linking the dynamic dispatch here closes the QuerySet→SQL call chain.
+ * (Over-approximates to the default iterable; .values()/.values_list() swap in
+ * other BaseIterable subclasses, but ModelIterable is the canonical path.)
+ */
+function resolveModelIterableIter(context: ResolutionContext): string | null {
+  const cls = context.getNodesByName('ModelIterable').find((n) => n.kind === 'class');
+  if (!cls) return null;
+  const iter = context.getNodesByName('__iter__').find(
+    (n) => n.filePath === cls.filePath && n.startLine >= cls.startLine && n.startLine <= cls.endLine
+  );
+  return iter ? iter.id : null;
+}
 
 /**
  * Parse a Django URL handler expression and return the symbol/module to link.


### PR DESCRIPTION
## What changed
All framework resolvers now expose `FrameworkResolver.extract()` returning route/endpoint nodes + reference edges. The orchestrator passes detected-framework names to each `extractFromSource` call so framework-specific regex extractors only run on relevant files.

## Commits
- 1d6d8c9 feat(resolution): replace extractNodes with extract() returning nodes and references
- dca86f6 feat(resolution): add getApplicableFrameworks helper for per-language dispatch
- 571beab feat(django): emit route nodes and route->view references in extract()
- 1a09053 fix(django): restore include(), ORM dispatch, and DRF router extraction
- 16eb713 feat(flask,fastapi): emit route nodes and route->handler references
- a483c28 feat(express): emit route nodes and route->handler references
- 8ed2c30 fix(express): restore balanced-paren and arrow-handler extraction

## Test evidence
- `npm run build` passes (tsc + copy-assets)
- `npm test` passes: 2,530 pass / 175 skip (160 test files)
- `__tests__/frameworks.test.ts` pass (113 tests)
- `__tests__/frameworks-integration.test.ts` pass (23 tests)
- No dangling `extractNodes` references remain in `src/` or `__tests__/`

## Checklist
- [x] Step 1: FrameworkResolver.extract interface with ProjectNode + GraphReference
- [x] Step 2: detectFrameworks wired into extraction orchestrator
- [x] Step 3: Batch any per-file regex extraction
- [x] Step 4: Remove dead / superseded regex code
- [x] Step 5: Verify against existing integration tests
- [x] README: Framework-aware Routes table updated with new frameworks
