### PR TITLE
fix(resolution): resolve `.js` import specifiers to their TS source

### DIFF
--- a/__tests__/js-specifier-ts-resolution.test.ts
+++ b/__tests__/js-specifier-ts-resolution.test.ts
@@ -1,0 +1,107 @@
+/**
+ * `.js` specifiers naming an on-disk `.ts` source.
+ *
+ * `"moduleResolution": "NodeNext"` REQUIRES the emitted extension on relative
+ * imports (`./impl.js`), while the file on disk is `./impl.ts`.
+ * EXTENSION_RESOLUTION only ever APPENDS a suffix, so such a specifier was tried
+ * as `impl.js.ts`, `impl.js.tsx`, … then bare `impl.js` — never `impl.ts`.
+ * Import resolution returned null for EVERY relative import in the project and
+ * the resolver fell through to the name-matcher, which cannot cross a rename,
+ * so an aliased or default import reported a false 0 callers.
+ *
+ * Each fixture below imports under a DIFFERENT local name than the declaration,
+ * so the name-matcher cannot rescue the edge — the assertion isolates
+ * import-based resolution.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import CodeGraph from '../src/index';
+
+describe('.js specifiers resolve to their TS source', () => {
+  let cg: CodeGraph;
+  let dir: string;
+
+  afterEach(() => {
+    if (cg) cg.destroy();
+    if (dir && fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const callersOf = (name: string): string[] => {
+    const target = cg.getNodesByKind('function').find((n) => n.name === name);
+    expect(target, `fixture symbol ${name} was not indexed`).toBeDefined();
+    return cg.getCallers(target!.id).map((c) => c.node.name);
+  };
+
+  it('resolves a default import through a `.js` specifier', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-jsspec-'));
+    fs.writeFileSync(
+      path.join(dir, 'impl.ts'),
+      'export default function realImpl(): number { return 1; }\n'
+    );
+    fs.writeFileSync(
+      path.join(dir, 'consumer.ts'),
+      "import renamedLocally from './impl.js';\n" +
+        'export function consumerFn(): number { return renamedLocally(); }\n'
+    );
+
+    cg = CodeGraph.initSync(dir, { config: { include: ['**/*.ts'], exclude: [] } });
+    await cg.indexAll();
+
+    expect(callersOf('realImpl')).toContain('consumerFn');
+  });
+
+  it('resolves `.mjs` and `.cjs` specifiers to `.mts` and `.cts`', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-jsspec-esm-'));
+    fs.writeFileSync(
+      path.join(dir, 'esm.mts'),
+      'export default function esmImpl(): number { return 1; }\n'
+    );
+    fs.writeFileSync(
+      path.join(dir, 'cjs.cts'),
+      'export default function cjsImpl(): number { return 2; }\n'
+    );
+    fs.writeFileSync(
+      path.join(dir, 'consumer.ts'),
+      "import esmRenamed from './esm.mjs';\n" +
+        "import cjsRenamed from './cjs.cjs';\n" +
+        'export function consumerFn(): number { return esmRenamed() + cjsRenamed(); }\n'
+    );
+
+    cg = CodeGraph.initSync(dir, {
+      config: { include: ['**/*.ts', '**/*.mts', '**/*.cts'], exclude: [] },
+    });
+    await cg.indexAll();
+
+    expect(callersOf('esmImpl')).toContain('consumerFn');
+    expect(callersOf('cjsImpl')).toContain('consumerFn');
+  });
+
+  it('prefers a real emitted `.js` on disk over the rewritten `.ts`', async () => {
+    // Committed build output beside its source: `./emitted.js` names the JS
+    // file, which exists, so the rewrite must NOT steal the edge.
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-jsspec-literal-'));
+    fs.writeFileSync(
+      path.join(dir, 'emitted.js'),
+      'export default function fromJs() { return 1; }\n'
+    );
+    fs.writeFileSync(
+      path.join(dir, 'emitted.ts'),
+      'export default function fromTs(): number { return 1; }\n'
+    );
+    fs.writeFileSync(
+      path.join(dir, 'consumer.ts'),
+      "import renamedLocally from './emitted.js';\n" +
+        'export function consumerFn(): number { return renamedLocally(); }\n'
+    );
+
+    cg = CodeGraph.initSync(dir, {
+      config: { include: ['**/*.ts', '**/*.js'], exclude: [] },
+    });
+    await cg.indexAll();
+
+    expect(callersOf('fromJs')).toContain('consumerFn');
+    expect(callersOf('fromTs')).not.toContain('consumerFn');
+  });
+});

--- a/src/resolution/import-resolver.ts
+++ b/src/resolution/import-resolver.ts
@@ -377,6 +377,44 @@ function isExternalImport(
 }
 
 /**
+ * TypeScript's ESM/NodeNext rule: a relative specifier carries the EMITTED
+ * extension while the file on disk is the TS source — `import './x.js'`
+ * resolves to `x.ts`. `EXTENSION_RESOLUTION` only ever APPENDS a suffix, so a
+ * specifier that already ends in `.js` is tried as `x.js.ts`, `x.js.tsx`, …
+ * and then bare `x.js`, none of which exist in a TS project. Import resolution
+ * then returns null for EVERY relative import in the repo and the resolver
+ * falls through to the name-matcher, which cannot cross a rename — so an
+ * aliased or default export silently reports a false 0 callers.
+ *
+ * This is not an edge case: `"moduleResolution": "NodeNext"` REQUIRES the `.js`
+ * suffix, so an entire class of modern TS codebases resolves nothing (a 16k-file
+ * project measured 32,732 `.js` specifiers and 0 extensionless ones).
+ *
+ * Tried only AFTER the literal path, so a real emitted `.js` sitting on disk
+ * still wins and no currently-resolving import changes target.
+ */
+const TS_SOURCE_REWRITES: Array<[RegExp, string[]]> = [
+  [/\.js$/, ['.ts', '.tsx', '.d.ts']],
+  [/\.jsx$/, ['.tsx', '.jsx', '.d.ts']],
+  [/\.mjs$/, ['.mts', '.d.mts']],
+  [/\.cjs$/, ['.cts', '.d.cts']],
+];
+
+/** Languages whose specifiers may name emitted JS for an on-disk TS source. */
+const TS_SOURCE_LANGUAGES = new Set<string>(['typescript', 'tsx', 'arkts', 'svelte', 'vue', 'astro']);
+
+/** The TS source paths a JS-suffixed specifier may legally denote. */
+function tsSourceCandidates(candidatePath: string, language: Language): string[] {
+  if (!TS_SOURCE_LANGUAGES.has(language)) return [];
+  for (const [suffix, replacements] of TS_SOURCE_REWRITES) {
+    if (suffix.test(candidatePath)) {
+      return replacements.map((ext) => candidatePath.replace(suffix, ext));
+    }
+  }
+  return [];
+}
+
+/**
  * Resolve a relative import
  */
 function resolveRelativeImport(
@@ -423,6 +461,13 @@ function resolveRelativeImport(
     return relativePath;
   }
 
+  // `./x.js` naming the on-disk `./x.ts` (see TS_SOURCE_REWRITES).
+  for (const candidate of tsSourceCandidates(relativePath, language)) {
+    if (context.fileExists(candidate)) {
+      return candidate;
+    }
+  }
+
   return null;
 }
 
@@ -450,6 +495,9 @@ function resolveAliasedImport(
       if (context.fileExists(candidate)) return candidate;
     }
     if (context.fileExists(basePath)) return basePath;
+    for (const candidate of tsSourceCandidates(basePath, language)) {
+      if (context.fileExists(candidate)) return candidate;
+    }
     return null;
   };
 


### PR DESCRIPTION
Fixes the first of the two root causes behind #1482.

## The bug

`EXTENSION_RESOLUTION` only ever **appends** a suffix. So a NodeNext-style relative specifier is tried as:

```
./x.js  ->  x.js.ts   x.js.tsx   x.js.d.ts   ...   x.js
```

`x.ts` is never tried. `resolveRelativeImport` returns `null`.

That matters more than it looks, because `"moduleResolution": "NodeNext"` **requires** the emitted extension on relative imports. In such a project *no relative import resolves at all* — every reference falls through to Strategy 3, the name-matcher. Name-matching cannot cross a rename, so a default import or an aliased import silently reports **0 callers** with full confidence.

One 16k-file TypeScript project I measured has **32,732 `.js` specifiers and 0 extensionless ones**. For that repo, import-based resolution was effectively off.

## The fix

A small rewrite table, tried **only after the literal path**:

| specifier | candidates |
|---|---|
| `.js` | `.ts`, `.tsx`, `.d.ts` |
| `.jsx` | `.tsx`, `.jsx`, `.d.ts` |
| `.mjs` | `.mts`, `.d.mts` |
| `.cjs` | `.cts`, `.d.cts` |

Applied in `resolveRelativeImport` and in `resolveAliasedImport`'s `tryWithExt`, gated to TS-family languages.

Ordering is the safety property: a real emitted `.js` sitting on disk beside its source still wins, so **no currently-resolving import changes target**. There is a test for exactly that.

## Tests

`__tests__/js-specifier-ts-resolution.test.ts`, 3 cases:

1. default import through `./impl.js` — resolves to `impl.ts`
2. `.mjs` / `.cjs` -> `.mts` / `.cts`
3. `./emitted.js` where **both** `emitted.js` and `emitted.ts` exist — the real `.js` wins

Each fixture imports under a *different local name* than the declaration, so the name-matcher cannot rescue the edge; the assertion isolates import resolution.

On `main` cases 1 and 2 fail and case 3 passes; with the fix all three pass.

## Verification

- full suite on this branch: **2,533 passed, 0 failed, 175 skipped**
- the 175 skips are the `kernel-*-parity` files, expected without a native kernel build (`CODEGRAPH_KERNEL=0`)
- real-world: a 18.4k-file TS/polyglot repo re-indexed in 1m30s, edges **1,262,985 -> 1,268,309 (+5,324)**, and a `callers` query that previously returned nothing now returns both true call sites

## Not covered

I did not build the Rust kernel, so **the kernel path for this change is unvalidated**. Both changed functions live in the TS resolution layer above it, but you'll want to confirm that.

---

Companion PR for the second root cause (alias bindings) is independent of this one and can land in either order; both touch `import-resolver.ts` in different regions, so whichever lands second may need a trivial rebase.
