### PR TITLE
feat(search): surface camelCase symbols via segment vocab (#1520)

### DIFF
--- a/__tests__/search-segment-supplement.test.ts
+++ b/__tests__/search-segment-supplement.test.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CodeGraph } from '../src/index';
+
+/**
+ * #1520: FTS unicode61 keeps camelCase as one token. searchNodes must still
+ * surface sub-word hits via name_segment_vocab.
+ */
+describe('searchNodes camelCase segment supplement (#1520)', () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  });
+
+  it('finds getShippingMethodIdFromCheckout via query "checkout"', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-1520-seg-'));
+    fs.writeFileSync(
+      path.join(tmpDir, 'shipping.ts'),
+      [
+        'export function getShippingMethodIdFromCheckout(cartId: string): string {',
+        '  return cartId;',
+        '}',
+        'export function unrelatedHelper(): void {}',
+      ].join('\n'),
+    );
+
+    const cg = CodeGraph.initSync(tmpDir);
+    try {
+      await cg.indexAll();
+      const hits = cg.searchNodes('checkout', { limit: 20 });
+      const names = hits.map((h) => h.node.name);
+      expect(names).toContain('getShippingMethodIdFromCheckout');
+    } finally {
+      cg.close();
+    }
+  });
+});

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1223,6 +1223,18 @@ export class QueryBuilder {
       // results despite the DB having plenty of matches.
       : this.searchAllByFilters({ kinds, languages, limit: limit * 5 });
 
+    // FTS unicode61 keeps camelCase/PascalCase identifiers as opaque tokens,
+    // so a query like `checkout` misses `getShippingMethodIdFromCheckout`.
+    // name_segment_vocab already stores those sub-words at index time — merge
+    // them into the candidate set before falling through to LIKE (#1520).
+    if (text) {
+      results = this.supplementWithSegmentMatches(results, text, {
+        kinds,
+        languages,
+        limit: Math.max(limit * 5, 100),
+      });
+    }
+
     // If no FTS results, try LIKE-based substring search
     if (results.length === 0 && text.length >= 2) {
       results = this.searchNodesLike(text, { kinds, languages, limit, offset });
@@ -1394,6 +1406,58 @@ export class QueryBuilder {
         // exact-match fallbacks (dist 0) outrank dist-2 typos.
         results.push({ node: rowToNode(row), score: 1 / (1 + c.dist) });
         if (results.length >= limit) break;
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Merge camelCase/PascalCase sub-word hits from `name_segment_vocab` into an
+   * FTS candidate set. FTS5's default tokenizer does not split case boundaries,
+   * so queries like `checkout` otherwise miss `getShippingMethodIdFromCheckout`
+   * even though that segment was materialized at index time (#1520).
+   */
+  private supplementWithSegmentMatches(
+    results: SearchResult[],
+    text: string,
+    options: { kinds?: NodeKind[]; languages?: Language[]; limit: number },
+  ): SearchResult[] {
+    const { kinds, languages, limit } = options;
+    const terms = text
+      .replace(/::/g, ' ')
+      .replace(/['"*():^]/g, '')
+      .split(/\s+/)
+      .map((t) => t.toLowerCase())
+      .filter((t) => t.length >= 2)
+      .filter((t) => !/^(and|or|not|near)$/i.test(t));
+    if (terms.length === 0) return results;
+
+    const existingIds = new Set(results.map((r) => r.node.id));
+    const baseScore =
+      results.length > 0 ? Math.max(...results.map((r) => r.score)) : 1;
+    const perTerm = Math.max(20, Math.ceil(limit / Math.max(terms.length, 1)));
+
+    for (const term of terms) {
+      const names = this.getNamesForSegment(term, perTerm);
+      if (names.length === 0) continue;
+      const placeholders = names.map(() => '?').join(', ');
+      let sql = `SELECT * FROM nodes WHERE name IN (${placeholders})`;
+      const params: (string | number)[] = [...names];
+      if (kinds && kinds.length > 0) {
+        sql += ` AND kind IN (${kinds.map(() => '?').join(',')})`;
+        params.push(...kinds);
+      }
+      if (languages && languages.length > 0) {
+        sql += ` AND language IN (${languages.map(() => '?').join(',')})`;
+        params.push(...languages);
+      }
+      sql += ' LIMIT ?';
+      params.push(perTerm * 3);
+      const rows = this.db.prepare(sql).all(...params) as NodeRow[];
+      for (const row of rows) {
+        if (existingIds.has(row.id)) continue;
+        results.push({ node: rowToNode(row), score: baseScore });
+        existingIds.add(row.id);
       }
     }
     return results;


### PR DESCRIPTION
## Summary

Addresses the largest finding in #1520: camelCase / PascalCase identifiers are unreachable by sub-word FTS queries because `nodes_fts` uses the default `unicode61` tokenizer (no case-boundary splits).

`name_segment_vocab` already materializes those sub-words at index time for the prompt hook. This PR merges that vocabulary into `searchNodes` candidate generation so queries like `checkout` surface `getShippingMethodIdFromCheckout` without a custom FTS5 tokenizer or schema migration.

### Changes

- After FTS, call `supplementWithSegmentMatches()` to pull symbol names from `name_segment_vocab` for each query term and join them into the candidate set (still subject to kind/language filters and the existing rescoring path).
- Add a regression test that indexes a camelCase helper and asserts `searchNodes('checkout')` finds it.

Other #1520 items (persisted bm25 rank weights, dropping `id` from FTS, `--path` CLI, GROUP BY dedupe) are left for follow-ups; search already applies column-weighted `bm25(...)` in SQL and supports `path:` query filters.

### Test plan

- [x] `npx vitest run __tests__/search-segment-supplement.test.ts`
- [ ] CI
