### PR TITLE
fix(swift): remove catastrophic backtracking in Vapor route regex

### DIFF
--- a/__tests__/frameworks.test.ts
+++ b/__tests__/frameworks.test.ts
@@ -1472,6 +1472,47 @@ func boot(routes: RoutesBuilder) throws {
     const { nodes } = vaporResolver.extract!('configure.swift', src);
     expect(nodes).toHaveLength(0);
   });
+
+  // A `.METHOD(...)` call with many comma-separated args and no `use:` used to
+  // make the route regex backtrack exponentially (60 args hung for minutes).
+  it('does not backtrack exponentially on a long arg list without use:', () => {
+    const args = Array.from({ length: 60 }, (_, i) => `arg${i}: value${i}`).join(', ');
+    const src = `app.get(${args})\n`;
+    const start = performance.now();
+    const { nodes } = vaporResolver.extract!('routes.swift', src);
+    const elapsed = performance.now() - start;
+    expect(nodes).toHaveLength(0);
+    expect(elapsed).toBeLessThan(250);
+  });
+
+  it('still parses every Vapor route shape after the arg-list rewrite', () => {
+    const src = `
+admin.get(use: self.list)
+app.get("users", use: listUsers)
+router.post("users", User.parameter, "edit", use: UserController.edit)
+app.patch(":id" ,  "meta" ,  use: update)
+app.get(
+  "multi",
+  "line",
+  use: multiLine
+)
+`;
+    const { nodes, references } = vaporResolver.extract!('routes.swift', src);
+    expect(nodes.map((n) => n.name)).toEqual([
+      'GET /',
+      'GET /users',
+      'POST /users/edit',
+      'PATCH /:id/meta',
+      'GET /multi/line',
+    ]);
+    expect(references.map((r) => r.referenceName)).toEqual([
+      'list',
+      'listUsers',
+      'edit',
+      'update',
+      'multiLine',
+    ]);
+  });
 });
 
 import { reactResolver } from '../src/resolution/frameworks/react';

--- a/src/resolution/frameworks/swift.ts
+++ b/src/resolution/frameworks/swift.ts
@@ -367,7 +367,17 @@ export const vaporResolver: FrameworkResolver = {
     // (`BlogUser.parameter`, `:id`, a path constant) so accept any comma-separated
     // args before `use:` — the label keeps only the string parts. `use:`
     // discriminates a real route from Environment.get("X")/req.parameters.get("X").
-    const routeRegex = /\b(\w+)\.(get|post|put|patch|delete|head|options)\s*\(\s*((?:[^,()]+,\s*)*)use:\s*([A-Za-z_][\w.]*)/g;
+    // Each arg repetition must end at a comma, and `,` is outside the char class,
+    // so the split is unique and matching stays linear. The earlier
+    // `(?:[^,()]+,\s*)*` was ambiguous — the trailing `\s*` and the next
+    // iteration's `[^,()]+` could both claim the same spaces — which backtracked
+    // exponentially on a long arg list that never reaches `use:`.
+    // The tail is `\s*` rather than a lazy `[^,()]*?` on purpose: both are
+    // linear, but the lazy form drops the "`use:` is preceded by a comma"
+    // requirement and widens the match set — `req.get(foo.use: bar)` would then
+    // be indexed as a route (groups `["req","get","foo.","bar"]`) where both
+    // this pattern and the original match nothing.
+    const routeRegex = /\b(\w+)\.(get|post|put|patch|delete|head|options)\s*\(\s*((?:[^,()]+,)*\s*)use:\s*([A-Za-z_][\w.]*)/g;
     let match: RegExpExecArray | null;
     while ((match = routeRegex.exec(safe)) !== null) {
       const [, receiver, method, segsStr, handlerExpr] = match;


### PR DESCRIPTION
Fixes #1544.

## Problem

`vaporResolver.extract` matches Vapor routes with

```js
/\b(\w+)\.(get|post|put|patch|delete|head|options)\s*\(\s*((?:[^,()]+,\s*)*)use:\s*([A-Za-z_][\w.]*)/g
```

The arg-list group `(?:[^,()]+,\s*)*` is ambiguous: the trailing `\s*` and the
next iteration's `[^,()]+` can both claim the same run of spaces, so there are
exponentially many ways to partition the same input. When a `.METHOD(...)` call
has many comma-separated labelled args and never reaches `use:` — exactly the
generated request-builder shape in the issue — the engine explores all of them
before failing.

## Measurements

`app.get(arg0: value0, arg1: value1, …)` with n args and no `use:`
(Node v24.14.0, macOS):

| n | input len | before | after |
|---|---|---|---|
| 16 | 243 | 2.6 ms | 0.005 ms |
| 20 | 307 | 40.3 ms | 0.003 ms |
| 24 | 371 | 647 ms | 0.004 ms |
| 30 | 467 | **41.7 s** | 0.004 ms |
| 60 | 947 | **no result after 120 s** | 0.005 ms |

Time roughly ×4 per +2 args before the fix. After the fix it is linear:
1000 args / 17,787 chars → 0.090 ms.

Since `index`, `sync` and the MCP connect-time catch-up sync all run this
resolver, one such file hangs the process indefinitely — which is what bricked
the reporter's MCP integration.

## Fix

Anchor every repetition at a comma:

```diff
-((?:[^,()]+,\s*)*)
+((?:[^,()]+,)*\s*)
```

`,` is excluded from the character class, so each repetition ends at the next
comma and the split is unique — there is nothing left to re-partition, and
matching is linear. The trailing `\s*` absorbs the whitespace after the final
comma, which the old pattern captured inside the group; whitespace after
non-final commas is absorbed by the following `[^,()]+`, so capture group 3 is
byte-for-byte identical.

## Why `\s*` and not the `[^,()]*?` tail from the issue

The issue suggests `(?:[^,()]+,)*[^,()]*?`, and that is the right idea — the
whole fix comes from it. Both versions kill the exponential blow-up by the same
mechanism: every repetition is forced to end at a comma, and `,` is excluded
from `[^,()]`, so there is exactly one way to split the arg list and nothing to
backtrack over. I only narrowed the tail by one notch, and I want to be explicit
about why in case you'd rather have the looser form.

`[^,()]*?` widens the match set: `use:` no longer has to be preceded by a comma,
so text that the old regex rejected starts matching. Two cases from my
equivalence run:

| input | old | `…,)*[^,()]*?` | `…,)*\s*` (this PR) |
|---|---|---|---|
| `app.get("a" use: h)` (missing comma, not valid Swift) | 0 matches | 1 match | 0 matches |
| `req.get(foo.use: bar)` | 0 matches | 1 match | 0 matches |

(With the lazy tail the second one is indexed as a route node with handler
reference `bar` — a false route in the graph, not just a wasted match.)

`\s*` instead corresponds exactly to what the old pattern's final `\s*` did —
"the whitespace after the last comma" — so the match set is unchanged rather
than merely a superset. That kept the equivalence check below a strict
comparison (identical `index` and identical capture groups) instead of "no
regressions on the routes we happen to test".

If you'd prefer the more permissive tail — e.g. you want a route with a missing
comma to still be indexed — say so and I'll swap it; the performance
characteristics are the same either way.

## Behaviour is unchanged

Old and new regex produce identical `index` + all four capture groups on:

- 18 hand-written Vapor shapes — no args (`admin.get(use: self.list)`),
  single/multiple path segments, `User.parameter`, `":id"`, dotted and
  `self.`-prefixed handlers, irregular whitespace, multi-line calls, several
  routes on one line, plus the non-route cases `Environment.get("X")`,
  `req.parameters.get("id")`, `app.get("a" use: h)` and
  `app.get("a", foo(bar), use: h)` (all 0 matches on both);
- 200,000 fuzzed inputs assembled from route-ish tokens.

## Tests

Two regression tests in `__tests__/frameworks.test.ts`:

1. **`does not backtrack exponentially on a long arg list without use:`** —
   60 args, no `use:`, asserts an explicit `< 250 ms` wall-clock bound. On the
   old regex this input never returns (>120 s); dialled down to 24 args so the
   old code can finish at all, it fails with
   `expected 668.119334 to be less than 250`. The committed 60-arg version
   finishes in 0.005 ms, ~50,000× under the bound, so it is not flaky.
2. **`still parses every Vapor route shape after the arg-list rewrite`** —
   asserts the 5 route names and 5 handler references for no-arg, single-arg,
   multi-arg + `X.parameter`, irregular-whitespace and multi-line calls, so a
   future ReDoS-style rewrite cannot silently break parsing.

`__tests__/frameworks.test.ts` 115/115 pass, the four Swift-related test files
162/162 pass, and `tsc --noEmit` is clean. The 54 pre-existing failures in the
full suite (`cli-*`, `mcp-*`, `index-command`, `status-json`, `*-watchdog` —
they exec the built `dist/` CLI) reproduce identically on an unmodified
`main`.
