### PR TITLE
fix(resolution): remove catastrophic backtracking in the Vapor route regex

### DIFF
--- a/__tests__/frameworks.test.ts
+++ b/__tests__/frameworks.test.ts
@@ -1436,6 +1436,19 @@ describe('vaporResolver.extract', () => {
     expect(references[0].referenceName).toBe('listUsers');
   });
 
+  it('does not backtrack exponentially on a call that never reaches use: (#1544)', () => {
+    // `app.get(a, b, c, ... )` with no `use:` label: the route regex must fail
+    // fast. The previous pattern had `\s*` inside the repeated group, which
+    // overlapped `[^,()]+`, so each extra argument roughly quadrupled the work
+    // and a generated file could hang indexing for minutes.
+    const args = Array.from({ length: 40 }, (_, i) => `arg${i}, `).join('');
+    const src = `app.get(${args}x)\n`;
+    const started = Date.now();
+    const { nodes } = vaporResolver.extract!('routes.swift', src);
+    expect(Date.now() - started).toBeLessThan(1000);
+    expect(nodes).toEqual([]);
+  });
+
   it('extracts grouped RouteCollection routes with the group prefix and no path arg', () => {
     const src = `
 func boot(routes: RoutesBuilder) throws {

--- a/src/resolution/frameworks/swift.ts
+++ b/src/resolution/frameworks/swift.ts
@@ -367,7 +367,14 @@ export const vaporResolver: FrameworkResolver = {
     // (`BlogUser.parameter`, `:id`, a path constant) so accept any comma-separated
     // args before `use:` — the label keeps only the string parts. `use:`
     // discriminates a real route from Environment.get("X")/req.parameters.get("X").
-    const routeRegex = /\b(\w+)\.(get|post|put|patch|delete|head|options)\s*\(\s*((?:[^,()]+,\s*)*)use:\s*([A-Za-z_][\w.]*)/g;
+    // The `\s*` that used to sit inside the repeated group overlapped
+    // `[^,()]+` (which also matches whitespace), so every space after a comma
+    // could be consumed by either branch. On a call whose argument list never
+    // reaches `use:` that ambiguity backtracks exponentially — ~4x per extra
+    // argument, seconds by 28 — hanging index/sync/MCP on generated files.
+    // Keeping the group purely `<run>,` and matching the gap before `use:`
+    // once, outside the loop, leaves exactly one way to split the input.
+    const routeRegex = /\b(\w+)\.(get|post|put|patch|delete|head|options)\s*\(\s*((?:[^,()]+,)*)\s*use:\s*([A-Za-z_][\w.]*)/g;
     let match: RegExpExecArray | null;
     while ((match = routeRegex.exec(safe)) !== null) {
       const [, receiver, method, segsStr, handlerExpr] = match;


### PR DESCRIPTION
Fixes #1544.

## The bug

`src/resolution/frameworks/swift.ts` matched Vapor routes with:

```js
/\b(\w+)\.(get|post|...)\s*\(\s*((?:[^,()]+,\s*)*)use:\s*([A-Za-z_][\w.]*)/g
```

`[^,()]+` also matches whitespace, so each space after a comma can be consumed **either** by `\s*` on the current iteration **or** by `[^,()]+` on the next one. When the call never reaches `use:` the match fails, and the engine explores every possible split.

Measured on `app.get(arg0, arg1, … x)` with no `use:` label:

| arguments | ms |
|---|---|
| 16 | 1.7 |
| 20 | 23.8 |
| 24 | 379.7 |
| 28 | 6100.1 |

~4× per additional argument. At 40 arguments it does not finish — I aborted a run after 10 minutes. Any generated Swift file with a long argument list on a `.get`/`.post`/… call stalls index/sync/MCP indefinitely.

## The fix

Keep the repeated group to `<run>,` and match the gap before `use:` once, outside the loop:

```js
((?:[^,()]+,)*)\s*use:
```

`,` is excluded from the class, so each iteration is forced to span exactly one comma-delimited run — there is only one way to split the input, and the failure is linear. **2000 arguments now match in 0.2 ms**; the 40-argument case is 0.5 ms.

## Behaviour is unchanged

The capture group is only ever consumed by `segJoin`, which pulls `"quoted"` literals out of it via `/"([^"]*)"/g`. Moving whitespace outside the group therefore cannot change a route path. I diffed old vs new across the real call shapes and the receiver/method/path/handler are identical on every one:

```
same  app.get("users", use: list)                          -> GET /users -> list
same  app.get(use: index)                                  -> GET / -> index
same  app.get("users", ":id", use: UserController.show)    -> GET /users/:id -> UserController.show
same  routes.post("a","b", use: h)                         -> POST /a/b -> h
same  app.get( "x" ,  "y" ,  use:  self.handler )          -> GET /x/y -> self.handler
same  app.get("users", BlogUser.parameter, use: show)      -> GET /users -> show
same  req.parameters.get("id")                             -> no match
same  Environment.get("X")                                 -> no match
```

The last two matter: `use:` is what discriminates a route from `Environment.get(…)` / `req.parameters.get(…)`, and both still correctly fail to match.

## Tests

Added `does not backtrack exponentially on a call that never reaches use: (#1544)` to `__tests__/frameworks.test.ts` — 40 arguments, no `use:`, asserts it completes under 1s and extracts no routes. It passes in 0.5 ms with the fix; with the old regex restored it does not terminate, so the assertion fails.

`npm run build && npx vitest run` is green: **2902 passed, 178 skipped**, up from 2901 by exactly the new test.

Note for anyone reproducing locally: the suite needs `npm run build` first — 54 tests in 15 files fail without `dist/` because the CLI tests spawn `dist/bin/codegraph.js`.

The three sibling regexes in this file (`(?:\w+\s*,\s*)*` in the SwiftUI/UIKit patterns) are **not** affected — `\w` and `\s` are disjoint, so there is no ambiguity to backtrack on. I left them alone.