### PR TITLE
diag(extraction): log when the git-based scan falls back to a filesystem walk

### DIFF
--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -1074,7 +1074,21 @@ function getGitVisibleFiles(rootDir: string): Set<string> | null {
     // Git, but still wanted in the graph.)
     for (const f of collectIncludedFilesForRoot(rootDir)) visible.add(f);
     return visible;
-  } catch {
+  } catch (error) {
+    // Any failure here (git missing, a `git rev-parse`/`ls-files` timeout or
+    // buffer overrun under load, an unreadable repo, etc.) silently sent every
+    // caller to the `scanDirectoryWalk` filesystem-walk fallback with zero
+    // signal that the fast, fully git-delegated path was skipped — making a
+    // report like "the index walked into a nested-.gitignore-excluded
+    // directory" nearly untriageable, since there was no way to tell which of
+    // the two independent ignore implementations actually ran. Log it (gated
+    // by the project's existing CODEGRAPH_DEBUG convention, see logDebug) so a
+    // future report at this scale can confirm or rule out the fallback path
+    // in one step instead of re-instrumenting the source to find out.
+    logDebug('git-based file listing unavailable — falling back to filesystem walk', {
+      rootDir,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return null;
   }
 }


### PR DESCRIPTION
## What

Adds one `logDebug()` call in `getGitVisibleFiles()`'s outer `catch` block, naming the exception before falling back to the independent `scanDirectoryWalk()` filesystem-walk path. Zero behavior change — purely diagnostic, gated by the project's existing `CODEGRAPH_DEBUG` convention (same as every other `logDebug()` call in this file).

## Why

`getGitVisibleFiles()` currently silently returns `null` on **any** exception (git missing, a `rev-parse`/`ls-files` timeout or buffer overrun under load, an unreadable repo, etc.), sending every caller to `scanDirectoryWalk()` with no signal that the fast, fully git-delegated path was skipped.

That makes a report like #1567 (a real ~63x file-count blowup where `git check-ignore -v` proves git itself correctly excludes a nested-`.gitignore`'d `node_modules` tree, yet `codegraph init` walked into it anyway) hard to triage after the fact: both `getGitVisibleFiles()` and `scanDirectoryWalk()` independently implement nested-`.gitignore` handling and both look correct to me on inspection, but there is currently no way to tell which one actually ran for a given `index`/`init`/`sync` on the reporting host. This PR closes that specific observability gap.

## What this is NOT

This is **not** a fix for #1567's regression itself. I traced both scanning implementations and could not identify a concrete defect in either through static reading, and I could not reproduce the reported blowup in two synthetic fixtures (up to 63 nested `.gitignore` files / 960 excluded files / `.bin` symlinks) run against the actual `v1.5.0` binary — see the issue for full detail on both the confirmed root-cause evidence and the inconclusive reproduction attempts. I'm offering this small, safe, unambiguously-correct diagnostic improvement now rather than guessing at a behavioral fix I can't prove addresses the real trigger.

## Testing

- `npx tsc --noEmit -p .` — clean, no new errors.
- No behavior change on any success path; only the previously-silent `catch` branch gains a log call using the existing `logDebug(message, context)` signature already used elsewhere in this same file (e.g. `'Skipping unresolvable directory'`).

## Related

- Reproduction + evidence: #1567
