### PR TITLE
fix(mcp): reword explore guidance as advisory, not a quota

### DIFF
--- a/__tests__/explore-output-budget.test.ts
+++ b/__tests__/explore-output-budget.test.ts
@@ -6,7 +6,7 @@
  * grep+Read. These tests pin the per-tier budget shape so future tuning
  * doesn't silently drift the small-project case back into bloat.
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -198,7 +198,26 @@ describe('codegraph_explore output respects the adaptive budget', () => {
     const text = result.content?.[0]?.text ?? '';
     expect(text).not.toContain('### Additional relevant files');
     expect(text).not.toContain('Complete source code is included above');
-    expect(text).not.toContain('Explore budget:');
+    expect(text).not.toContain('advisory only, NOT a quota');
+  });
+
+  it('emits advisory-only exploration guidance on medium projects — never quota wording', async () => {
+    // Medium tier (500–4,999 files) turns the guidance note on. The synthetic
+    // project is tiny, so fake the stats to land in that tier — the note's
+    // WORDING is what this test pins. Regression guard: quota phrasing
+    // ("remaining calls" / "Synthesize once") must never come back — agents
+    // read it as a hard cap, stop exploring early, and fall back to grep+Read.
+    const spy = vi.spyOn(cg, 'getStats').mockReturnValue({ fileCount: 1000 } as ReturnType<CodeGraph['getStats']>);
+    try {
+      const result = await handler.execute('codegraph_explore', { query: 'Session method helper' });
+      const text = result.content?.[0]?.text ?? '';
+      expect(text).toContain('advisory only, NOT a quota');
+      expect(text).toContain('extra calls are never rejected or rate-limited');
+      expect(text).not.toContain('remaining calls');
+      expect(text).not.toContain('Synthesize once');
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('still includes the Relationships section — it is the cheapest structural signal', async () => {

--- a/__tests__/mcp-tool-annotations.test.ts
+++ b/__tests__/mcp-tool-annotations.test.ts
@@ -95,11 +95,12 @@ describe('Live tool surface keeps annotations with a project open (#1018)', () =
     expect(got.length).toBeGreaterThan(0);
     for (const tool of got) expectReadOnly(tool);
 
-    // explore's description is regenerated with a per-repo budget suffix via
-    // object spread; the annotation must survive that rewrite.
+    // explore's description is regenerated with a per-repo advisory-guidance
+    // suffix via object spread; the annotation must survive that rewrite.
     const explore = got.find((t) => t.name === 'codegraph_explore');
     expect(explore).toBeDefined();
-    expect(explore!.description).toMatch(/Budget: make at most/);
+    expect(explore!.description).toMatch(/advisory only, NOT a quota/);
+    expect(explore!.description).not.toMatch(/make at most/);
     expectReadOnly(explore!);
   });
 });

--- a/scripts/agent-eval/probe-suite-envelope.mjs
+++ b/scripts/agent-eval/probe-suite-envelope.mjs
@@ -85,7 +85,7 @@ try {
       epilogueCut: text.includes('omitted for size'),
       sectionCut: text.includes('output truncated to budget'),
       notShown: text.includes('Not shown above'),
-      budgetNote: text.includes('**Explore budget:'),
+      budgetNote: text.includes('advisory only, NOT a quota'),
     });
   }
 } finally {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -207,7 +207,10 @@ export interface ExploreOutputBudget {
   includeAdditionalFiles: boolean;
   /** Include the "Complete source code is included above…" reminder. */
   includeCompletenessSignal: boolean;
-  /** Include the explore-budget reminder at the end. */
+  /**
+   * Include the advisory exploration-guidance note at the end. Purely
+   * advisory — the server NEVER rejects or rate-limits extra explore calls.
+   */
   includeBudgetNote: boolean;
 }
 
@@ -1490,7 +1493,7 @@ export class ToolHandler {
         if (tool.name === 'codegraph_explore') {
           return {
             ...tool,
-            description: `${tool.description} Budget: make at most ${budget} calls for this project (${stats.fileCount.toLocaleString()} files indexed).`,
+            description: `${tool.description} Exploration guidance — advisory only, NOT a quota: ~${budget} focused calls usually cover this project (${stats.fileCount.toLocaleString()} files indexed), and extra calls are never rejected or rate-limited.`,
           };
         }
         return tool;
@@ -5687,13 +5690,17 @@ export class ToolHandler {
         ? ['', `> Some file sections were trimmed for size. For a specific symbol you still need, run another \`codegraph_explore\` (or \`codegraph_node\`) with its exact name — line-numbered source, cheaper and more complete than Read.`]
         : [];
 
-    // Explore budget note based on project size.
+    // Advisory exploration-guidance note based on project size. Deliberately
+    // phrased as guidance, NOT a quota: agents read "budget / remaining calls /
+    // Synthesize once" as a hard cap and stop exploring early, falling back to
+    // grep + Read (which costs more tokens). The server never rejects or
+    // rate-limits extra explore calls, and the note says so explicitly.
     let budgetBlock: string[] = [];
     if (budget.includeBudgetNote) {
       try {
         const stats = cg.getStats();
         const callBudget = getExploreBudget(stats.fileCount);
-        budgetBlock = ['', `> **Explore budget: ${callBudget} calls for this project (${stats.fileCount.toLocaleString()} files indexed).** Each call covers ~6 files; if your question spans more, spend your remaining calls on the uncovered area BEFORE falling back to Read — another explore is cheaper and more complete than reading those files. Synthesize once you've used ${callBudget}.`];
+        budgetBlock = ['', `> **Exploration guidance — advisory only, NOT a quota: this project (~${stats.fileCount.toLocaleString()} files indexed) is usually covered in ≈${callBudget} focused explore calls, and extra calls are never rejected or rate-limited. If the response above does not fully cover your question, run another codegraph_explore on the uncovered symbols — it is cheaper and more complete than Read. Only stop exploring when the response actually covers the flow you asked about.`];
       } catch {
         // Stats unavailable — skip budget note
       }


### PR DESCRIPTION
# PR Description — Reword the `codegraph_explore` budget note so agents read it as advisory, not a quota

---

## Summary

This PR fixes a wording problem in the `codegraph_explore` response footer. The server appends a note like
`Explore budget: 2 calls for this project (3,497 files indexed) … Synthesize once you've used 2` to every
response on mid-sized projects. My AI coding assistant read that as a hard quota, stopped calling `codegraph_explore`
after two invocations, and fell back to grep + Read — which cost more tokens and produced worse context than a
third explore would have. The note was meant as soft guidance; nothing in it said so. This PR rewords it to be
explicitly advisory ("NOT a quota", "extra calls are never rejected"), and updates the eval probe and tests that
pin the old wording.

## Background

`codegraph_explore` returns a bounded slice of source per call, tuned by project size
(`getExploreOutputBudget` / `getExploreBudget` in `src/mcp/tools.ts`, introduced in #185). On small-to-medium
repositories the intent is to keep a single response tight — under the host's inline tool-result ceiling so the
agent doesn't have to Read an externalized file back — and to steer the agent toward a few *focused* calls instead
of one sprawling query.

The steering takes the form of a footer note appended to every response when the project sits in the
500–4,999-file tier (3,497 files indexed for my project, so this tier is where I hit it). The original text:

> **Explore budget: 2 calls for this project (3,497 files indexed).** Each call covers ~6 files; if your
> question spans more, spend your remaining calls on the uncovered area BEFORE falling back to Read — another
> explore is cheaper and more complete than reading those files. Synthesize once you've used 2.

## Why it scared my AI assistant

The note is generated by the server at `src/mcp/tools.ts:5696` and is purely informational — the server never
enforces or rate-limits explore calls, and a third call always succeeds. But the wording reads like an enforced
budget, and that is exactly how my assistant treated it:

1. **The word "budget".** In a tooling context, "budget" implies a quota or ceiling. Combined with
   `spend your remaining calls`, the calls sound like a depleting allowance.
2. **The imperative close.** `Synthesize once you've used 2` is a direct order to wrap up after two calls.
   LLM agents tend to comply with imperative text in tool output as if it were a runtime constraint.
3. **No negation anywhere.** Nothing in the note says "advisory", "not enforced", or "extra calls will still
   work". An agent cannot tell soft guidance from a hard cap unless the text says so explicitly.
4. **The number contrast.** `2` next to `3,497 files indexed` reinforces the intuition that explore calls are
   expensive and rationed.
5. **It conflicted with my repo's working rules.** My AGENTS.md says code-understanding questions must start
   with `codegraph_explore` and use grep only as a supplement. When the budget note (stop after 2) and the
   rule (keep exploring) pointed in opposite directions, the assistant obeyed the one that looked like a system
   constraint — the tool's own quota-flavored text.

**What actually happened** (2026-08-19, reproducible): my assistant used two explores on my project, saw
`Explore budget: 2 calls`, assumed the allowance was spent, and switched the follow-up query to grep + Read —
reading whole files (`agent_api.c`, `wifi_service.c`, …) that one more explore would have returned more cheaply
and more completely. A third explore still succeeded, proving there was never any enforcement. The only reason
the assistant behaved that way is that the note did not say "this is a suggestion".

## Fix overview

- Reword the footer (`src/mcp/tools.ts:5696`): `Exploration guidance — advisory only, NOT a quota`;
  explicitly state "extra calls are never rejected or rate-limited"; replace the imperative
  `Synthesize once you've used N` with a conditional "only stop exploring when the response actually covers
  the flow you asked about".
- Optional hardening: only emit the note when the response was actually trimmed (so the guidance appears
  exactly when more calls are genuinely useful), and consider dropping the call count entirely.
- Update the pinned consumers of the old wording: `scripts/agent-eval/probe-suite-envelope.mjs:88` and
  `__tests__/explore-output-budget.test.ts` (including a new regression assertion that the tier-2 note
  contains "NOT a quota" and never reintroduces "remaining calls" / "Synthesize once").
- Regenerate `dist/mcp/tools.js` via `npm run build`.

## Tests

- `npm run build && npm test` (vitest: `explore-output-budget.test.ts`, `explore-allocation-e2e.test.ts`).
- Manual smoke: `codegraph.js serve --mcp --path <project>` on a 3,497-file project, confirm the footer
  carries the new advisory wording.