### PR TITLE
fix(erlang): don't count comments as arguments when computing arity

### DIFF
--- a/__tests__/erlang-arity-resolution.test.ts
+++ b/__tests__/erlang-arity-resolution.test.ts
@@ -120,6 +120,39 @@ go(Args) ->
     expect(edges.some((e) => e.sq === 'spawner::go/1' && e.tq.startsWith('multi::job'))).toBe(false);
   });
 
+  it('counts arity past comments written inside a parameter or argument list', async () => {
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'src', 'noted.erl'),
+      `-module(noted).
+-export([run/0, plain/2, spaced/2]).
+
+plain(X, Y) -> X + Y.
+
+spaced(X, % why this one is special
+       Y) ->
+    X * Y.
+
+run() ->
+    A = plain( % leading note
+        1, 2),
+    B = plain(1, % separating note
+              2),
+    C = spaced(1, 2),
+    D = erlang:spawn(noted, plain, [1, % note inside the MFA list
+                                    2]),
+    {A, B, C, D}.
+`
+    );
+    const edges = await callEdges(dir);
+    // A comment is a NAMED child, but it is not an argument: every call below
+    // is arity 2, and `spaced` is defined with arity 2.
+    expect(edges).toContainEqual({ sq: 'noted::run/0', tq: 'noted::plain/2' });
+    expect(edges).toContainEqual({ sq: 'noted::run/0', tq: 'noted::spaced/2' });
+    // Nothing resolved to a phantom arity the comments would have produced.
+    expect(edges.some((e) => /::(plain|spaced)\/[^2]$/.test(e.tq))).toBe(false);
+  });
+
   it('lands `fun mod:f/1` references on the written arity', async () => {
     fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
     fs.writeFileSync(

--- a/src/extraction/languages/erlang.ts
+++ b/src/extraction/languages/erlang.ts
@@ -1,5 +1,10 @@
 import type { Node as SyntaxNode } from 'web-tree-sitter';
-import { getNodeText, getChildByField, getPrecedingDocstring } from '../tree-sitter-helpers';
+import {
+  getNodeText,
+  getChildByField,
+  getPrecedingDocstring,
+  namedArgCount,
+} from '../tree-sitter-helpers';
 import type { LanguageExtractor, ExtractorContext } from '../tree-sitter-types';
 
 // Node names follow the vendored WhatsApp/tree-sitter-erlang grammar (0.19,
@@ -95,10 +100,9 @@ function moduleExports(node: SyntaxNode, source: string, filePath: string): Set<
   return result;
 }
 
-/** Argument count of a clause/sig: the `args` (expr_args) field's named-child count. */
+/** Argument count of a clause/sig: the `args` (expr_args) field's arguments. */
 function nodeArity(withArgs: SyntaxNode): number {
-  const args = getChildByField(withArgs, 'args');
-  return args ? args.namedChildCount : 0;
+  return namedArgCount(getChildByField(withArgs, 'args'));
 }
 
 /**

--- a/src/extraction/tree-sitter-helpers.ts
+++ b/src/extraction/tree-sitter-helpers.ts
@@ -90,6 +90,19 @@ function cleanCommentMarkers(comment: string): string {
 }
 
 /**
+ * Number of ARGUMENTS in an `args` node — its named children minus comments.
+ *
+ * tree-sitter reports `comment` as a NAMED child, so a comment written at the
+ * top level of a parameter or argument list (`f(A, % why\n B)`) inflates a
+ * plain `namedChildCount`. Anywhere that count is an arity — and arity is part
+ * of an Erlang function's identity (#1610) — the comment must not be counted.
+ */
+export function namedArgCount(argsNode: SyntaxNode | null | undefined): number {
+  if (!argsNode) return 0;
+  return argsNode.namedChildren.filter((c) => c.type !== 'comment').length;
+}
+
+/**
  * Get the docstring/comment preceding a node
  */
 export function getPrecedingDocstring(node: SyntaxNode, source: string): string | undefined {

--- a/src/extraction/tree-sitter.ts
+++ b/src/extraction/tree-sitter.ts
@@ -16,7 +16,13 @@ import {
   UnresolvedReference,
 } from '../types';
 import { getParser, detectLanguage, isLanguageSupported, isFileLevelOnlyLanguage } from './grammars';
-import { generateNodeId, getNodeText, getChildByField, getPrecedingDocstring } from './tree-sitter-helpers';
+import {
+  generateNodeId,
+  getNodeText,
+  getChildByField,
+  getPrecedingDocstring,
+  namedArgCount,
+} from './tree-sitter-helpers';
 import { FN_REF_SPECS, captureFnRefCandidates, type FnRefSpec, type FnRefCandidate } from './function-ref';
 import { isGeneratedFile } from './generated-detection';
 import type { LanguageExtractor, ExtractorContext } from './tree-sitter-types';
@@ -3805,8 +3811,7 @@ export class TreeSitterExtractor {
           }
           // Arity from the call site's own argument list — part of the callee's
           // identity, and what disambiguates `f/1` from `f/2` (#1610).
-          const callArgsNode = getChildByField(node, 'args');
-          const callArity = callArgsNode ? callArgsNode.namedChildCount : 0;
+          const callArity = namedArgCount(getChildByField(node, 'args'));
           this.unresolvedReferences.push({
             fromNodeId: callerId,
             referenceName: `${calleeName}/${callArity}`,
@@ -3873,7 +3878,7 @@ export class TreeSitterExtractor {
               // qualified matcher then resolves it only when the module
               // defines exactly one arity of that name.
               const mfaList = argExprs[i + 2];
-              const arityTail = mfaList?.type === 'list' ? `/${mfaList.namedChildCount}` : '';
+              const arityTail = mfaList?.type === 'list' ? `/${namedArgCount(mfaList)}` : '';
               this.unresolvedReferences.push({
                 fromNodeId: callerId,
                 referenceName: (isLocalModule ? erlAtom(f) : `${erlAtom(m)}::${erlAtom(f)}`) + arityTail,


### PR DESCRIPTION
Follow-up to #1615, rebased onto `main` now that it has landed.

Arity is computed with `namedChildCount`, but tree-sitter reports `comment` as a named child, so a comment at the top level of a parameter or argument list inflates it:

```erlang
plain( % a comment
    1, 2)          % counted as plain/3 — the edge is dropped

withdef(X, % a comment
        Y) -> ...  % indexed as withdef/3
```

Same for the MFA list in `spawn(?MODULE, f, [A, % note\n B])`. A comment nested one level deeper (inside `#state{...}`, a tuple, a list) is unaffected — only the top level of the list counts.

This surfaced with #1615: before it, arity took no part in resolution, so the miscount was harmless. Now arity is identity, so one extra unit silently drops the edge.

Small blast radius. Across cowboy, ranch, jsx, rebar3 and fast_xml only rebar3 is affected, losing two real edges (`rebar_compiler.erl:403`, `rebar_release_SUITE.erl:247`); re-indexing those five with this patch changes nothing else — no nodes added or removed, no edges removed, exactly those two edges restored.

The three counts now go through one `namedArgCount` helper so the invariant is stated once.

The new test in `erlang-arity-resolution.test.ts` covers the four shapes above. I checked it is not vacuous: on `main` without this patch it fails, and it passes with it. The full suite passes (3,053).

No CHANGELOG entry — #1615's entry already describes the user-visible behaviour, and the trigger here is rare; this just keeps that rare case from silently dropping edges.
