### PR TITLE
Add .gitattributes to mark grammars as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+codegraph-kernel/grammars linguist-generated


### PR DESCRIPTION
The project is currently incorrectly recognized as C project on GitHub. This PR fixes that by marking generated tree sitter grammars as generated. See GitHub docs: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

<img width="293" height="155" alt="Screenshot 2026-09-01 at 11 48 12 PM" src="https://github.com/user-attachments/assets/b5bd9281-8bdf-4ecc-b085-7b2dbd8055aa" />
