### PR TITLE
docs: stop presenting codegraph ui as a released command

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,16 +127,6 @@ codegraph init
 
 Auto-sync is enabled by default. CodeGraph watches the project and updates the graph on every file change — while your agent edits code, or you add, modify, or delete files. **The index is never stale, and there is nothing to re-run.**
 
-### 5. See what your agent sees
-
-```bash
-codegraph ui
-```
-
-Opens the graph in your browser at `http://127.0.0.1:4747` — callers on the left, the symbol's
-source in the middle, what it calls on the right. See
-[Read your graph in the browser](#read-your-graph-in-the-browser).
-
 ### Uninstall
 
 Changed your mind? One command removes CodeGraph from every agent it configured **and** the CLI itself — every install it finds (standalone bundle, npm global package, launcher link), shown to you before anything is deleted:
@@ -325,15 +315,13 @@ The handful of cases where manual `codegraph sync` makes sense: the watcher is d
 
 ## Read your graph in the browser
 
-`codegraph ui` opens a viewer for a project you have already indexed. It is the same graph
-your agent reads, on screen: pick a symbol and you see **who calls it on the left**, its
-**verbatim source in the middle**, and **what it calls on the right — each one drawn level
-with the line that calls it**.
+> **Not in the latest release.** `codegraph ui` is on `main` and will ship in the
+> next release. It is **not** a command in v1.6.0 — the published CLI will not
+> recognize it. See [#1666](https://github.com/colbymchenry/codegraph/issues/1666).
 
-```bash
-codegraph init          # once per project, if you haven't already
-codegraph ui            # opens http://127.0.0.1:4747 in your browser
-```
+A local viewer for a project you have already indexed is coming: pick a symbol and
+you see **who calls it on the left**, its **verbatim source in the middle**, and
+**what it calls on the right — each one drawn level with the line that calls it**.
 
 <img src="https://raw.githubusercontent.com/colbymchenry/codegraph/main/assets/codegraph-ui-symbol-view.png?v=1" alt="The CodeGraph viewer: callers on the left, the symbol's source in the middle with a marker on every calling line, and the symbols it calls on the right, each level with its call site" width="100%">
 
@@ -355,20 +343,12 @@ What you get on that screen:
 - **Keep a walk.** Press **Save trail** on the trail bar, name it, and the path is kept — listed on the empty screen and on Entry points, above the suggestions, and reopened at the symbol you left with the whole walk restored. Steps are remembered by what they are, not where they sat, so a saved trail survives editing the code it describes; when something does move it says which step moved, which was renamed away, and how much of the walk still opens. Trails are plain JSON under `.codegraph/ui/trails/` (git already ignores it), and **Export** hands you the file if you would rather commit one.
 - **It keeps up.** Save a file and a banner appears within about a third of a second saying the index hasn't caught up yet — and the screen switches to the file's current source rather than a body sliced at lines it no longer has. When something re-indexes, whatever is on screen refetches itself and says "Index updated · reloaded". A symbol that moved because you added a line above it is followed, not lost. Nothing polls: the viewer watches, and if it loses touch with the server it retries a few times and then says so instead of hammering it.
 
-Options: `--port <n>` to pin a port (without it the viewer takes 4747, or the next free one),
-`--no-open` to just print the URL for a headless box or an SSH session, and
-`CODEGRAPH_BROWSER=<command>` to choose the browser (`CODEGRAPH_BROWSER=none` never opens one).
-`codegraph web` is an alias for the same command.
-
 **Privacy:** the viewer listens on `127.0.0.1` only, so nothing on your network can reach it,
 and requests claiming to come from any other host are refused. It opens an index that already
 exists, never creates one, and never changes your graph or a line of your code. The one thing
-it writes is a trail you asked it to save, into `.codegraph/ui/trails/`; `codegraph ui
---read-only` refuses even that. **It sends nothing anywhere**: no code, no paths, no analytics.
-There is no account and no cloud in this feature at all.
-
-The viewer reads an index that already exists — it never creates one — so `codegraph init` has
-to have run first. `codegraph ui /path/to/project` points it at a project you indexed elsewhere.
+it writes is a trail you asked it to save, into `.codegraph/ui/trails/`. **It sends nothing
+anywhere**: no code, no paths, no analytics. There is no account and no cloud in this feature
+at all.
 
 ---
 
@@ -589,7 +569,6 @@ codegraph uninit [path]           # Remove CodeGraph from a project (--force to 
 codegraph index [path]            # Full index (--force to re-index, --quiet for less output)
 codegraph sync [path]             # Incremental update
 codegraph status [path]           # Show statistics
-codegraph ui [path]               # Open the browser viewer for an indexed project (alias: web; --port, --no-open, --read-only)
 codegraph unlock [path]           # Remove a stale lock file that's blocking indexing
 codegraph query <search>          # Search symbols (--kind, --limit, --json)
 codegraph explore <query>         # Relevant symbols' source + call paths in one shot (same output as the codegraph_explore MCP tool)

--- a/site/src/content/docs/getting-started/next-steps.md
+++ b/site/src/content/docs/getting-started/next-steps.md
@@ -14,7 +14,7 @@ You've got CodeGraph installed and a graph built. Here's where to go next.
 ## Put it to work
 
 - [Indexing a Project](/codegraph/guides/indexing/) — full index, incremental sync, and the file watcher.
-- [Reading Your Graph in the Browser](/codegraph/guides/viewer/) — `codegraph ui`: callers, source and callees on one screen.
+- [Reading Your Graph in the Browser](/codegraph/guides/viewer/) — `codegraph ui` (next release, not in v1.6.0): callers, source and callees on one screen.
 - [Framework Routes](/codegraph/guides/framework-routes/) — link URL patterns to their handlers.
 - [Affected Tests in CI](/codegraph/guides/affected-tests/) — run only the tests a change touches.
 

--- a/site/src/content/docs/guides/viewer.md
+++ b/site/src/content/docs/guides/viewer.md
@@ -3,11 +3,15 @@ title: Reading Your Graph in the Browser
 description: codegraph ui opens a local viewer for an indexed project — callers, source, and callees on one screen.
 ---
 
+:::caution
+`codegraph ui` is **not** in the latest release (v1.6.0). The published CLI does not have this command. It is on `main` and will ship in the next release. See [issue #1666](https://github.com/colbymchenry/codegraph/issues/1666).
+:::
+
 `codegraph ui` opens a viewer for a project you have already indexed. It is the same graph your agent reads, on screen.
 
 ```bash
 codegraph init          # once per project, if you haven't already
-codegraph ui            # opens http://127.0.0.1:4747 in your browser
+codegraph ui            # opens http://127.0.0.1:4747 in your browser (next release / main)
 ```
 
 ![The CodeGraph viewer: callers on the left, the symbol's source in the middle with a marker on every calling line, and the symbols it calls on the right, each level with its call site](https://raw.githubusercontent.com/colbymchenry/codegraph/main/assets/codegraph-ui-symbol-view.png?v=1)

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -12,7 +12,6 @@ codegraph uninit [path]           # Remove CodeGraph from a project (--force to 
 codegraph index [path]            # Full re-index from scratch (--force, --quiet, --verbose)
 codegraph sync [path]             # Incremental update (--quiet)
 codegraph status [path]           # Show statistics (--json)
-codegraph ui [path]               # Open the browser viewer for an indexed project (alias: web; --port, --no-open)
 codegraph unlock [path]           # Remove a stale lock file that's blocking indexing
 codegraph query <search>          # Search symbols (--kind, --limit, --json)
 codegraph explore <query>         # Relevant symbols' source + call paths in one shot (same output as the codegraph_explore MCP tool)
@@ -52,6 +51,10 @@ codegraph impact AuthMiddleware --depth 3
 Traces import dependencies transitively to find which test files are affected by changed source files. See [Affected Tests in CI](/codegraph/guides/affected-tests/) for options and a CI example.
 
 ## ui
+
+:::caution
+`codegraph ui` is **not** in the latest release (v1.6.0). The published CLI does not have this command. It is on `main` and will ship in the next release. See [issue #1666](https://github.com/colbymchenry/codegraph/issues/1666).
+:::
 
 `codegraph ui` opens the [browser viewer](/codegraph/guides/viewer/) for a project you have already indexed: callers on the left, the symbol's source in the middle, and what it calls on the right at the height of the line that calls it.
 


### PR DESCRIPTION
## Summary

The `codegraph ui` viewer is a really excellent feature — callers, source, and callees on one screen is exactly the kind of thing that makes the graph readable for humans, not just agents. I ran into this while using CodeGraph: the README told me to run `codegraph ui`, but the latest release (v1.6.0) does not have that command.

#1666 already calls this out, and you noted it should not have shown up in the README yet. I still think the README itself should say so, so the next person who follows the getting-started steps is not sent to a command that is not on the published CLI.

This PR:
- Removes the copy-paste `codegraph ui` step from the README and drops it from the released CLI list
- Adds a short note that the viewer is on `main` / the next release, not v1.6.0
- Adds the same caution on the published viewer / CLI docs

If a release that actually ships `codegraph ui` lands first and this PR is still open, please close it — the warnings would then be wrong.

Related to #1666