### PR TITLE
fix(prompt-hook): cap the injection under Claude Code's 10k inline hook-output limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **The Map covers a multi-root project.** A React Native app's `ios/` beside its `src/` — or any second root holding a fifth of the code — is now on the picture, one level deeper, instead of the map silently drawing only the larger root.
 
+- **The Claude Code prompt hook's context now arrives inline.** The hook capped its injection at 16,000 characters, but Claude Code shows hook output inline only up to 10,000 and otherwise persists it to a file with a 2 KB preview, so on any repo where explore filled the cap the model saw a file path and the first 2 KB. The cap is now 9,000 characters, under the limit with room for the wrapper. (#1694)
+
 - Fixed a long-running `codegraph ui` session serving a symbol that a sync had already deleted. The viewer keeps one connection to your index open, and its in-memory lookup didn't notice when another process — your agent's sync, or `codegraph sync` — rewrote the file underneath it, so a symbol screen could keep showing a body with no callers while search correctly reported it had moved. Because a symbol's identity includes the line it starts on, this happened after almost any edit above it.
 
 ## [1.6.0] - 2026-08-26

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -1412,7 +1412,11 @@ program
             const text = result.content[0]?.text ?? '';
             if (!result.isError && text.trim()) {
               // Cap the injection so a large-repo explore can't flood the prompt.
-              const MAX = 16000;
+              // Claude Code shows hook stdout inline only up to 10,000 characters;
+              // above that it persists the output to a file and the model sees a
+              // 2 KB preview (#1694). 9,000 leaves room for the wrapper and the
+              // projectPath nudge lines below.
+              const MAX = 9000;
               const body = text.length > MAX ? `${text.slice(0, MAX)}\n…(truncated; call codegraph_explore for the rest)` : text;
               // For a front-loaded SUB-project, a follow-up explore needs its path.
               const more = plan.viaSubScan


### PR DESCRIPTION
Fixes #1694.

`codegraph prompt-hook` capped its `<codegraph_context>` injection at 16,000 characters. Claude Code shows hook stdout inline only up to 10,000 characters; above that it persists the output to `tool-results/hook-<id>-stdout.txt` and the model sees a 2 KB preview plus the path. So on any repo where explore filled the cap, the hook delivered a file reference instead of the context (measured in #1694: 9,871 characters inline, 10,031 persisted, on Claude Code 2.1.261).

## Change

- `MAX` 16000 → 9000 in `src/bin/codegraph.ts`, with a comment naming the host limit. 9,000 leaves ~1,000 characters for the `<codegraph_context>` wrapper and the `projectPath` nudge lines that are appended after the cap is applied.
- CHANGELOG entry under Unreleased › Fixes.

The existing "…(truncated; call codegraph_explore for the rest)" notice is unchanged, so a capped payload still tells the model where the rest is. The blast-radius list leads the explore output, so the part that survives the cap is the part the model acts on.

## Not in this PR

An env var to set the cap per host. Happy to add one if you want other hosts to be able to raise it.
