### PR TITLE
fix(resolution): fuzzy matching skips a nested function the reference cannot reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 #### Symbols, tests and the viewer
 
+- **Fuzzy matching no longer lands on a closure it cannot reach.** A function nested inside another function is only callable from inside its container, and exact-name matching already filtered such candidates; the fuzzy fallback did not, so a builtin method call (`res.text()`, `items.push()`) whose only same-named project symbol was some file's closure resolved onto that closure at confidence 0.5. The fallback now applies the same reachability filter. On a 584-file repo that removed the 11 fuzzy edges onto nested functions and nothing else. Re-index after upgrading.
 - **Files under an `e2e/` directory count as tests.** Their calls no longer appear as production callers in Steps, dead-code and test badges.
 
 - **Production code under a `samples` or `examples` package path is no longer treated as test code.** A Kotlin or Java project whose package path runs through `com/google/samples/…` (Now in Android, for one) had nearly every file counted as a fixture, so the Map opened on `build-logic`, the entry points hid the app, and dead-code and test badges were wrong. Only the project layout above a `src/` folder decides now; the package path below it never does.

--- a/__tests__/fuzzy-lexical-reach.test.ts
+++ b/__tests__/fuzzy-lexical-reach.test.ts
@@ -1,0 +1,73 @@
+/**
+ * A function nested inside another function is only callable from inside its
+ * container. matchByExactName already filters candidates that way; matchFuzzy
+ * must too, or a call to a builtin method (`res.text()`) whose only same-named
+ * project symbol is some file's closure resolves onto that closure.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { CodeGraph } from '../src';
+
+describe('fuzzy matching respects lexical reachability of nested functions', () => {
+  let tempDir: string;
+  let cg: CodeGraph | null = null;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-fuzzy-reach-'));
+  });
+
+  afterEach(() => {
+    cg?.destroy();
+    cg = null;
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Windows can still hold the SQLite handle for a moment; the OS temp dir is swept anyway.
+    }
+  });
+
+  it('does not resolve a builtin method call onto another file\'s closure of the same name', async () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'seed.ts'),
+      [
+        'export function readSeedState(raw: string): string {',
+        '  function text(): string {',
+        '    return raw.trim();',
+        '  }',
+        '  return text();',
+        '}',
+        '',
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(tempDir, 'fetch.ts'),
+      [
+        'export async function readOkText(settled: { value: Response }): Promise<string> {',
+        '  // A chained receiver reaches the resolver as the bare method name.',
+        '  return settled.value.text();',
+        '}',
+        '',
+      ].join('\n')
+    );
+    cg = await CodeGraph.init(tempDir, { index: true });
+    cg.resolveReferences();
+
+    const closure = cg
+      .getNodesByKind('function')
+      .find((n) => n.name === 'text' && n.filePath === 'seed.ts');
+    const caller = cg.getNodesByKind('function').find((n) => n.name === 'readOkText');
+    expect(closure).toBeDefined();
+    expect(caller).toBeDefined();
+
+    const fromCaller = cg.getOutgoingEdges(caller!.id).filter((e) => e.kind === 'calls');
+    expect(fromCaller.map((e) => e.target)).not.toContain(closure!.id);
+
+    // The in-container call still resolves.
+    const container = cg.getNodesByKind('function').find((n) => n.name === 'readSeedState');
+    const inside = cg.getOutgoingEdges(container!.id).filter((e) => e.kind === 'calls');
+    expect(inside.map((e) => e.target)).toContain(closure!.id);
+  });
+});

--- a/src/resolution/name-matcher.ts
+++ b/src/resolution/name-matcher.ts
@@ -2412,7 +2412,10 @@ export function matchFuzzy(
 
   // Filter to callable kinds only (function, method, class)
   const callableKinds = new Set(['function', 'method', 'class']);
-  const callableCandidates = applyLanguageGate(candidates.filter((n) => callableKinds.has(n.kind)), ref);
+  const callableCandidates = applyLanguageGate(
+    candidates.filter((n) => callableKinds.has(n.kind) && isLexicallyReachable(n, ref, context)),
+    ref
+  );
 
   // Prefer same-language matches
   const sameLanguageCandidates = callableCandidates.filter(n => n.language === ref.language);


### PR DESCRIPTION
Fixes #1708.

## What

`matchFuzzy` now filters its callable candidates with the same `isLexicallyReachable` check `matchByExactName` applies (#1230): a `function` nested inside another function is a candidate only for references from inside that container.

## Why

When the only project symbol with a given name is a nested function, exact-match correctly declines, the ref falls through to fuzzy, and fuzzy adopted the closure as its "unique" candidate at confidence 0.5. Any builtin method call that reaches the resolver as a bare name (`settled.value.text()`, `items.push()`) hit whichever file happened to declare a closure of that name.

## Measured

Real TS repo, 584 files, same build with and without the change:

| | before | after |
| --- | --- | --- |
| edges | 41,378 | 41,367 |
| `resolvedBy: fuzzy` | 26 | 15 |
| fuzzy edges onto nested functions | 11 | 0 |

Nothing else moves. With #1679 (closure extraction) applied the same repo had 160 such edges, so that PR benefits from this one landing first.

## Tests

`__tests__/fuzzy-lexical-reach.test.ts`: two files, a nested `function text()` in one, a `settled.value.text()` call in the other; asserts no `calls` edge from the caller to the closure and that the in-container call still resolves. Fails on `main`, passes with the change.
