### PR TITLE
feat(fivem): bridge FiveM string-keyed dispatch — RegisterNetEvent/exports/lib.callback handlers become nodes, Trigger*Event/exports[…]/callback/NUI sites link to them

### DIFF
--- a/__tests__/fivem-dispatch-synthesizer.test.ts
+++ b/__tests__/fivem-dispatch-synthesizer.test.ts
@@ -1,0 +1,174 @@
+/**
+ * FiveM string-keyed dispatch bridge (Lua + JS resources).
+ *
+ * A FiveM pack is many resources (dirs with `fxmanifest.lua`) that call each other only by
+ * string: `TriggerServerEvent('res:evt')` → `RegisterNetEvent('res:evt', function … end)`,
+ * `exports['res']:Fn()` → `exports('Fn', function … end)`, `lib.callback.await('c')` →
+ * `lib.callback.register('c', …)`. Handlers are inline anonymous functions, so nothing is a
+ * node for them until `frameworks/fivem.ts` `extract()` makes one per registration site;
+ * `fivem-synthesizer.ts` then links every literal dispatch site to those nodes. Proves the
+ * precision gates: an unregistered key, a commented-out dispatch, and a computed key all
+ * contribute no edge, and a Lua project with no manifest contributes nothing at all.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { CodeGraph } from '../src';
+import { stripLuaComments } from '../src/resolution/frameworks/fivem';
+
+const write = (dir: string, rel: string, body: string): void => {
+  fs.mkdirSync(path.dirname(path.join(dir, rel)), { recursive: true });
+  fs.writeFileSync(path.join(dir, rel), body);
+};
+
+describe('fivem-dispatch synthesizer', () => {
+  let dir: string;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fivem-dispatch-')); });
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+  it('bridges events, exports and callbacks across resources; ignores unregistered, commented, computed keys', async () => {
+    write(dir, 'resources/[core]/qb-inventory/fxmanifest.lua', `fx_version 'cerulean'\ngame 'gta5'\nserver_script 'server/main.lua'\n`);
+    write(dir, 'resources/[core]/qb-inventory/server/main.lua', `local Inventory = {}
+
+RegisterNetEvent('qb-inventory:server:AddItem', function(item, amount)
+    Inventory[item] = (Inventory[item] or 0) + amount
+end)
+
+RegisterNetEvent('qb-inventory:server:RemoveItem', function(item, amount)
+    Inventory[item] = (Inventory[item] or 0) - amount
+end)
+
+exports('AddItem', function(src, item, amount)
+    TriggerEvent('qb-inventory:server:AddItem', item, amount)
+end)
+
+lib.callback.register('qb-inventory:getCount', function(source, item)
+    return Inventory[item] or 0
+end)
+`);
+    write(dir, 'resources/[core]/qb-shops/fxmanifest.lua', `fx_version 'cerulean'\ngame 'gta5'\nclient_script 'client/main.lua'\nserver_script 'server/main.lua'\n`);
+    write(dir, 'resources/[core]/qb-shops/client/main.lua', `local function BuyItem(item)
+    TriggerServerEvent('qb-inventory:server:AddItem', item, 1)     -- cross-resource event
+    -- TriggerServerEvent('qb-inventory:server:RemoveItem', item, 1)   commented out: no edge
+    local count = lib.callback.await('qb-inventory:getCount', false, item)
+    TriggerServerEvent('qb-shops:server:nothingRegistered', item)  -- no handler anywhere: no edge
+    return count
+end
+
+local function Refund(item)
+    local evt = 'qb-inventory:server:' .. 'RemoveItem'
+    TriggerServerEvent(evt, item, 1)                               -- computed key: no edge
+end
+`);
+    write(dir, 'resources/[core]/qb-shops/client/ui.js', `const socket = connect();
+socket.on('connect', () => { console.log('ui up'); });          // member .on: not FiveM, no node
+onNet('qb-shops:client:refresh', (item) => {
+  emitNet('qb-inventory:server:AddItem', item, 1);               // JS side, inside a JS handler
+});
+`);
+    write(dir, 'resources/[core]/qb-shops/client/nui.lua', `RegisterNUICallback('getStock', function(data, cb)
+    cb(lib.callback.await('qb-inventory:getCount', false, data.item))
+end)
+`);
+    write(dir, 'resources/[core]/qb-shops/html/app.js', `on('hook:destroyed', () => {});                              // browser code: never a FiveM handler
+function loadStock(item) {
+  return fetch(\`https://qb-shops/getStock\`, { body: JSON.stringify({ item }) });   // literal host
+}
+function loadStockOwn(item) {
+  return fetch(\`https://\${GetParentResourceName()}/getStock\`, { method: 'POST' });   // the usual form: own resource
+}
+async function loadStockLib(item) {
+  return fetchNui('getStock', { item });                                             // ox_lib helper
+}
+`);
+    write(dir, 'resources/[core]/qb-shops/server/main.lua', `local function Restock(src, item)
+    exports['qb-inventory']:AddItem(src, item, 10)                 -- cross-resource export
+    exports.qb_inventory:AddItem(src, item, 1)                     -- wrong resource name: no edge
+end
+`);
+
+    const cg = await CodeGraph.init(dir, { silent: true });
+    await cg.indexAll();
+    const db = (cg as any).db.db;
+
+    const handlers = db.prepare(`SELECT name, file_path fp, start_line sl FROM nodes WHERE id LIKE 'fivem:%' ORDER BY name`).all();
+    expect(handlers.map((h: any) => h.name)).toEqual([
+      'callback:qb-inventory:getCount',
+      'event:qb-inventory:server:AddItem',
+      'event:qb-inventory:server:RemoveItem',
+      'event:qb-shops:client:refresh',
+      'export:AddItem',
+      'nui:getStock',
+    ]);
+    expect(handlers.some((h: any) => h.name === 'event:hook:destroyed')).toBe(false);
+    expect(handlers.find((h: any) => h.name === 'event:qb-inventory:server:AddItem').sl).toBe(3);
+    const ends = db.prepare(`SELECT name, end_line el FROM nodes WHERE id LIKE 'fivem:%'`).all();
+    expect(ends.find((h: any) => h.name === 'event:qb-inventory:server:AddItem').el).toBe(5); // `end)` closes on line 5
+    expect(ends.find((h: any) => h.name === 'export:AddItem').el).toBe(13);
+    expect(ends.find((h: any) => h.name === 'event:qb-shops:client:refresh').el).toBe(5); // JS arrow body closes on line 5
+
+    const edges = db
+      .prepare(
+        `SELECT s.name source, t.name target, json_extract(e.metadata,'$.via') via, json_extract(e.metadata,'$.registeredAt') at
+         FROM edges e JOIN nodes s ON s.id = e.source JOIN nodes t ON t.id = e.target
+         WHERE json_extract(e.metadata,'$.synthesizedBy') = 'fivem-dispatch'`
+      )
+      .all();
+    const targets = (src: string) => edges.filter((r: any) => r.source === src).map((r: any) => r.target).sort();
+
+    // BuyItem: the event and the callback, nothing for the commented / unregistered lines.
+    expect(targets('BuyItem')).toEqual(['callback:qb-inventory:getCount', 'event:qb-inventory:server:AddItem']);
+    // Restock: the export by the right resource name only (exports.qb_inventory names a resource that does not exist).
+    expect(targets('Restock')).toEqual(['export:AddItem']);
+    expect(edges.find((r: any) => r.source === 'Restock').via).toBe('export:qb-inventory/AddItem');
+    // Refund built its key at runtime — boundary, not an edge.
+    expect(targets('Refund')).toEqual([]);
+    // RemoveItem is registered but only ever dispatched from a comment.
+    expect(edges.some((r: any) => r.target === 'event:qb-inventory:server:RemoveItem')).toBe(false);
+    // The AddItem export's body dispatches the AddItem event: an intra-resource edge whose source is the handler node itself.
+    expect(edges.some((r: any) => r.source === 'export:AddItem' && r.target === 'event:qb-inventory:server:AddItem')).toBe(true);
+    // NUI: the browser's fetch reaches the Lua RegisterNUICallback; the NUI callback body's own callback dispatch chains on.
+    expect(targets('loadStock')).toEqual(['nui:getStock']);
+    expect(edges.find((r: any) => r.source === 'loadStock').via).toBe('nui:qb-shops/getStock');
+    expect(targets('loadStockOwn')).toEqual(['nui:getStock']);   // `${GetParentResourceName()}` → own resource
+    expect(targets('loadStockLib')).toEqual(['nui:getStock']);   // fetchNui('name') → own resource
+    expect(targets('nui:getStock')).toEqual(['callback:qb-inventory:getCount']);
+    // JS: a dispatch inside an onNet arrow handler attributes to that handler node.
+    expect(targets('event:qb-shops:client:refresh')).toEqual(['event:qb-inventory:server:AddItem']);
+    // registeredAt points at the handler line.
+    const e = edges.find((r: any) => r.source === 'BuyItem' && r.via === 'event:qb-inventory:server:AddItem');
+    expect(e.at).toMatch(/qb-inventory[\\/]server[\\/]main\.lua:3$/);
+
+    cg.close?.();
+  });
+
+  it('contributes nothing to a Lua project with no manifest (clean control)', async () => {
+    write(dir, 'init.lua', `local M = {}
+function M.setup()
+    TriggerServerEvent('foo:bar')       -- not FiveM; no manifest anywhere
+    RegisterNetEvent('foo:bar', function() end)
+end
+return M
+`);
+    const cg = await CodeGraph.init(dir, { silent: true });
+    await cg.indexAll();
+    const db = (cg as any).db.db;
+    expect(db.prepare(`SELECT count(*) c FROM nodes WHERE id LIKE 'fivem:%'`).get().c).toBe(0);
+    expect(db.prepare(`SELECT count(*) c FROM edges WHERE json_extract(metadata,'$.synthesizedBy') = 'fivem-dispatch'`).get().c).toBe(0);
+    cg.close?.();
+  });
+});
+
+describe('stripLuaComments', () => {
+  it('blanks line and block comments, keeps strings and line count', () => {
+    const src = `a = 1 -- comment\n--[[ block\nspanning ]] b = "-- not a comment"\nc = [[long -- string]]\n`;
+    const out = stripLuaComments(src);
+    expect(out.split('\n').length).toBe(src.split('\n').length);
+    expect(out).not.toContain('-- comment');
+    expect(out).not.toContain('block');
+    expect(out).not.toContain('spanning');
+    expect(out).toContain('b = "-- not a comment"');
+    expect(out).toContain('c = [[long -- string]]');
+  });
+});

--- a/src/resolution/callback-synthesizer.ts
+++ b/src/resolution/callback-synthesizer.ts
@@ -37,6 +37,7 @@ import { svelteKitLinkEdges, svelteKitPageComponentEdges } from './sveltekit-syn
 import { createYielder, type MaybeYield } from './cooperative-yield';
 import { crossTierEdges } from './tier-synthesizer';
 import { enclosingFn, makeLineAt } from './synth-utils';
+import { fivemDispatchEdges } from './fivem-synthesizer';
 
 const REGISTRAR_NAME = /^(on[A-Z]\w*|subscribe|addListener|addEventListener|register|watch|listen|addCallback)$/;
 const DISPATCHER_NAME = /(emit|trigger|notify|dispatch|fire|publish|flush)/i;
@@ -3554,6 +3555,8 @@ export const SYNTH_PASSES: SynthPassDef[] = [
   // keeps the more specific edge — the one that says which tier it crosses.
   { name: 'tierEdges', gate: (has) => has(...JS_FAMILY), run: (_q, c, y) => crossTierEdges(c, y) },
   { name: 'emitterEdges', gate: ALWAYS, run: (_q, c, y) => eventEmitterEdges(c, y) },
+  // FiveM string-keyed dispatch (TriggerServerEvent/exports/lib.callback/…) → the resolver's handler nodes. Exits at once with no fxmanifest.
+  { name: 'fivemEdges', gate: (has) => has('lua', 'luau', ...JS_FAMILY), run: (_q, c, y) => fivemDispatchEdges(c, y) },
   { name: 'renderEdges', gate: ALWAYS, run: (q, c, y) => reactRenderEdges(q, c, y) },
   { name: 'jsxEdges', gate: (has) => has(...JS_FAMILY), run: (_q, c, y) => reactJsxChildEdges(c, y) },
   { name: 'vueEdges', gate: (has) => has('vue'), run: (_q, c, y) => vueTemplateEdges(c, y) },

--- a/src/resolution/fivem-synthesizer.ts
+++ b/src/resolution/fivem-synthesizer.ts
@@ -1,0 +1,122 @@
+/**
+ * FiveM — the dispatch half of string-keyed dispatch. See `frameworks/fivem.ts` for
+ * the registrar half and the shape of the problem.
+ *
+ * For every literal-keyed dispatch site inside a resource —
+ *
+ *   TriggerEvent / TriggerServerEvent / TriggerClientEvent / TriggerLatent*Event('e', …)
+ *   emit / emitNet('e', …)                                        (JS side)
+ *   exports['res']:Fn(…)  exports.res:Fn(…)  exports.res.Fn(…)  exports['res'].Fn(…)
+ *   lib.callback('c', …) / lib.callback.await('c', …) / QBCore.Functions.TriggerCallback('c', …)
+ *   ExecuteCommand('cmd …')
+ *   fetch(`https://res/name`)                                     (NUI → RegisterNUICallback)
+ *
+ * — link the enclosing function (or the file, for top-level code) to every handler node the
+ * resolver created for that key. Keys are global by construction, so this is the one place a
+ * cross-resource edge is drawn. A key with no registered handler yields nothing; a handler
+ * registered in several resources (`playerSpawned`-style broadcast events) yields one edge
+ * each, capped, because that fan-out is the truth of the runtime, not noise.
+ *
+ * Edges: `kind:'calls'`, `provenance:'heuristic'`, `synthesizedBy:'fivem-dispatch'`, `via` =
+ * the key, `registeredAt` = the handler's file:line. Precision floor: literal keys only; a
+ * computed key (`TriggerEvent(name, …)`) is left for boundary surfacing.
+ */
+
+import type { Edge, Node } from '../types';
+import type { ResolutionContext } from './types';
+import type { MaybeYield } from './cooperative-yield';
+import { enclosingFn } from './synth-utils';
+import { FIVEM_NODE_PREFIX, fivemLanguageFor, fivemResourceOf, fivemResourceRootsFrom, isFivemNuiFile, stripForFivem } from './frameworks/fivem';
+
+const Q = `(['"\`])`;
+const LIT = `([^'"\`\\n]+)`;
+const ID = `([A-Za-z_][A-Za-z0-9_]*)`;
+
+/** Not preceded by `.`/`:`/word — a member call is somebody's method, not a FiveM global. */
+const G = `(?<![\\w.:])`;
+
+/** Sentinel: the dispatching file's own resource (NUI pages talk to the resource that serves them). */
+const SELF = '\0self';
+
+interface DispatchSpec {
+  re: RegExp;
+  /** handler-node name to look up, plus the resource the site names (exports / NUI) when it names one */
+  key: (m: RegExpExecArray) => { key: string; res?: string };
+  /** the one dispatch shape browser (NUI) code can perform */
+  nui?: true;
+}
+const DISPATCHERS: DispatchSpec[] = [
+  { re: new RegExp(`${G}(?:TriggerEvent|TriggerServerEvent|TriggerClientEvent|TriggerLatentServerEvent|TriggerLatentClientEvent|emit|emitNet)\\s*\\(\\s*${Q}${LIT}\\1`, 'g'), key: (m) => ({ key: `event:${m[2]}` }) },
+  { re: new RegExp(`${G}exports\\s*\\[\\s*${Q}${LIT}\\1\\s*\\]\\s*[:.]\\s*${ID}\\s*\\(`, 'g'), key: (m) => ({ key: `export:${m[3]}`, res: m[2]! }) },
+  { re: new RegExp(`${G}exports\\.${ID}\\s*[:.]\\s*${ID}\\s*\\(`, 'g'), key: (m) => ({ key: `export:${m[2]}`, res: m[1]! }) },
+  { re: new RegExp(`${G}(?:lib\\.callback(?:\\.await)?|QBCore\\.Functions\\.TriggerCallback)\\s*\\(\\s*${Q}${LIT}\\1`, 'g'), key: (m) => ({ key: `callback:${m[2]}` }) },
+  { re: new RegExp(`${G}ExecuteCommand\\s*\\(\\s*${Q}([^'"\`\\s]+)`, 'g'), key: (m) => ({ key: `command:${m[2]}` }) },
+  // NUI → RegisterNUICallback. A page almost never spells its resource: it is
+  // `https://${GetParentResourceName()}/name` (any `${…}` host) or ox_lib's `fetchNui('name')`, both
+  // meaning "my own resource" — resolved from the file's location. A literal host is honoured as written.
+  { re: new RegExp(`${G}fetch\\s*\\(\\s*${Q}https?://([^/'"\`$]+)/([^'"\`?\\s]+)`, 'g'), key: (m) => ({ key: `nui:${m[3]}`, res: m[2]! }), nui: true },
+  { re: new RegExp(`${G}fetch\\s*\\(\\s*\`https?://\\$\\{[^}]*\\}/([^\`?\\s]+)`, 'g'), key: (m) => ({ key: `nui:${m[1]}`, res: SELF }), nui: true },
+  { re: new RegExp(`${G}fetchNui\\s*(?:<[^>]*>)?\\s*\\(\\s*${Q}${LIT}\\1`, 'g'), key: (m) => ({ key: `nui:${m[2]}`, res: SELF }), nui: true },
+];
+
+
+
+// An event legitimately has as many receivers as resources listen to it (`QBCore:Client:OnPlayerLoaded`
+// has ~30 in a stock pack) — that fan-out is the runtime's truth, not noise, so events are uncapped.
+// An export / callback / command / NUI callback resolves to one registration in one resource; more than
+// a few means duplicate registrations, still real, but bounded.
+const FANOUT_CAP_KEYED = 8;
+
+export async function fivemDispatchEdges(ctx: ResolutionContext, onYield: MaybeYield): Promise<Edge[]> {
+  const files = ctx.getAllFiles();
+  const roots = fivemResourceRootsFrom(files);
+  if (roots.length === 0) return [];
+  const edges: Edge[] = [];
+  const seen = new Set<string>();
+  let scanned = 0;
+  for (const file of files) {
+    const language = fivemLanguageFor(file);
+    if (!language || !fivemResourceOf(file, roots)) continue;
+    if ((++scanned & 15) === 0) await onYield();
+    const content = ctx.readFile(file);
+    if (!content) continue;
+    if (!/Trigger|emit|exports|callback|ExecuteCommand|fetch/.test(content)) continue;
+    const src = stripForFivem(content, language);
+    const nodesInFile = ctx.getNodesInFile(file);
+    const fileNode = nodesInFile.find((n) => n.kind === 'file' || n.kind === 'module') ?? null;
+    const nui = isFivemNuiFile(file);
+    const ownResource = fivemResourceOf(file, roots)?.name;
+    for (const spec of DISPATCHERS) {
+      if (nui && !spec.nui) continue;
+      spec.re.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = spec.re.exec(src))) {
+        const keyed = spec.key(m);
+        const key = keyed.key;
+        const res = keyed.res === SELF ? ownResource : keyed.res;
+        const line = src.slice(0, m.index).split('\n').length;
+        const disp: Node | null = enclosingFn(nodesInFile, line) ?? fileNode;
+        if (!disp) continue;
+        // `exports['res']:Fn` / NUI `https://res/name` name a resource: only that resource's handler counts.
+        const targets = ctx
+          .getNodesByName(key)
+          .filter((n) => n.id.startsWith(FIVEM_NODE_PREFIX) && n.id !== disp.id && (res === undefined || fivemResourceOf(n.filePath, roots)?.name === res));
+        const via = res === undefined ? key : `${key.slice(0, key.indexOf(':'))}:${res}/${key.slice(key.indexOf(':') + 1)}`;
+        for (const t of key.startsWith('event:') ? targets : targets.slice(0, FANOUT_CAP_KEYED)) {
+          const k = `${disp.id}>${t.id}`;
+          if (seen.has(k)) continue;
+          seen.add(k);
+          edges.push({
+            source: disp.id,
+            target: t.id,
+            kind: 'calls',
+            line,
+            provenance: 'heuristic',
+            metadata: { synthesizedBy: 'fivem-dispatch', via, registeredAt: `${t.filePath}:${t.startLine}` },
+          });
+        }
+      }
+    }
+  }
+  return edges;
+}

--- a/src/resolution/frameworks/fivem.ts
+++ b/src/resolution/frameworks/fivem.ts
@@ -1,0 +1,262 @@
+/**
+ * FiveM (Cfx.re) resources — the registrar half of string-keyed dispatch.
+ *
+ * A FiveM server is a set of *resources*, each a directory with an `fxmanifest.lua`
+ * (older packs: `__resource.lua`). Almost every cross-resource call is dispatched
+ * through a string literal the runtime resolves at call time:
+ *
+ *   -- qb-inventory/server/main.lua
+ *   RegisterNetEvent('qb-inventory:server:AddItem', function(item, amount) … end)
+ *   exports('AddItem', function(src, item, amount) … end)
+ *   lib.callback.register('qb-inventory:getStock', function(source, shop) … end)
+ *
+ *   -- qb-shops/client/main.lua (a different resource)
+ *   TriggerServerEvent('qb-inventory:server:AddItem', item, 1)
+ *   exports['qb-inventory']:AddItem(src, item, 1)
+ *   local stock = lib.callback.await('qb-inventory:getStock', false, shop)
+ *
+ * Tree-sitter sees a call on an indexed table; nothing links the two files. Worse, the
+ * handler is almost always an inline anonymous `function … end` — the extractor makes no
+ * node for it, so a synthesizer alone would have nothing to point an edge at.
+ *
+ * This resolver's `extract()` creates that node: one `function` node per registration
+ * site, named by a keyed literal — `event:<name>`, `export:<name>`, `callback:<name>`,
+ * `command:<name>`, `nui:<name>` — so the dispatch
+ * synthesizer (`../fivem-synthesizer.ts`) can find handlers with `getNodesByName(key)`
+ * and nothing else in the graph can collide with them. `detect()` gates on a manifest
+ * existing; the synthesizer resolves `exports['res']:Fn` to the `export:Fn` node under the
+ * root named `res` (extraction runs in parse workers and cannot see the file list).
+ *
+ * Precision floor: only literal keys, only registrars with a handler argument, only
+ * bare globals (a `.on(` member call is not FiveM). A repo with no manifest contributes nothing.
+ */
+
+import type { Language, Node } from '../../types';
+import type { FrameworkExtractionResult, FrameworkResolver, ResolutionContext, ResolvedRef, UnresolvedRef } from '../types';
+import { stripCommentsForRegex } from '../strip-comments';
+
+const MANIFEST_RE = /(?:^|\/)(?:fxmanifest|__resource)\.lua$/;
+
+/**
+ * Resource roots — directories holding a manifest — longest-first so a nested pack resolves to
+ * the innermost. Pure: computed from a file list by whoever holds one. `extract()` runs inside
+ * parse workers that only receive framework *names*, so nothing here may depend on state
+ * `detect()` set on the main thread; the synthesizer recomputes roots from `ctx.getAllFiles()`.
+ */
+export function fivemResourceRootsFrom(files: Iterable<string>): string[] {
+  const roots = new Set<string>();
+  for (const f of files) {
+    if (MANIFEST_RE.test(f)) roots.add(f.includes('/') ? f.slice(0, f.lastIndexOf('/')) : '');
+  }
+  return [...roots].sort((a, b) => b.length - a.length);
+}
+
+/** The resource a file belongs to — its root's basename — or null when outside every root. */
+export function fivemResourceOf(filePath: string, roots: readonly string[]): { root: string; name: string } | null {
+  for (const root of roots) {
+    if (root === '' || filePath.startsWith(root + '/')) {
+      return { root, name: root === '' ? '' : root.slice(root.lastIndexOf('/') + 1) };
+    }
+  }
+  return null;
+}
+
+/**
+ * NUI (browser) code — `html/`, `web/`, `ui/`, `nui/` trees and minified bundles. No FiveM global
+ * exists there, so nothing in it registers a handler (`on('hook:destroyed')` in vue.min.js is Vue),
+ * and its only dispatch into the resource is `fetch('https://<resource>/<name>')`.
+ */
+export function isFivemNuiFile(filePath: string): boolean {
+  return /(?:^|\/)(?:html|web|ui|nui)\//i.test(filePath) || /\.min\.[cm]?js$/i.test(filePath);
+}
+
+export function fivemLanguageFor(filePath: string): Language | null {
+  if (/\.luau$/i.test(filePath)) return 'luau';
+  if (/\.lua$/i.test(filePath)) return 'lua';
+  if (/\.(?:ts|mts|cts)$/i.test(filePath)) return 'typescript';
+  if (/\.(?:js|mjs|cjs)$/i.test(filePath)) return 'javascript';
+  return null;
+}
+
+/**
+ * Blank out Lua comments (`--` and `--[[ … ]]` / `--[==[ … ]==]`) with spaces, keeping every
+ * newline so line numbers survive. Strings and long strings are skipped, not stripped.
+ * `strip-comments.ts` has no Lua dialect; this is the minimum it would need.
+ */
+export function stripLuaComments(src: string): string {
+  let out = '';
+  let i = 0;
+  const n = src.length;
+  const blank = (s: string): string => s.replace(/[^\n]/g, ' ');
+  while (i < n) {
+    const c = src[i]!;
+    if (c === '"' || c === "'") {
+      const q = c;
+      out += c;
+      i++;
+      while (i < n && src[i] !== q && src[i] !== '\n') {
+        if (src[i] === '\\' && i + 1 < n) { out += src[i]! + src[i + 1]!; i += 2; continue; }
+        out += src[i]!;
+        i++;
+      }
+      if (i < n && src[i] === q) { out += q; i++; }
+      continue;
+    }
+    const longOpen = c === '[' ? /^\[(=*)\[/.exec(src.slice(i, i + 32)) : null;
+    if (longOpen) {
+      const close = `]${longOpen[1]}]`;
+      const end = src.indexOf(close, i + longOpen[0].length);
+      const stop = end === -1 ? n : end + close.length;
+      out += src.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (c === '-' && src[i + 1] === '-') {
+      const block = /^--\[(=*)\[/.exec(src.slice(i, i + 32));
+      let stop: number;
+      if (block) {
+        const close = `]${block[1]}]`;
+        const end = src.indexOf(close, i + block[0].length);
+        stop = end === -1 ? n : end + close.length;
+      } else {
+        const nl = src.indexOf('\n', i);
+        stop = nl === -1 ? n : nl;
+      }
+      out += blank(src.slice(i, stop));
+      i = stop;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+export function stripForFivem(content: string, language: Language): string {
+  if (language === 'lua' || language === 'luau') return stripLuaComments(content);
+  return stripCommentsForRegex(content, language === 'javascript' ? 'javascript' : 'typescript');
+}
+
+// ── handler extent ────────────────────────────────────────────────────────────
+// The registrar's handler argument is almost always an inline function. Its extent is what
+// lets a dispatch *inside* the handler be attributed to the handler node (the chain
+// `export AddItem → event AddItem` is the one card mining wants). Source is comment-stripped
+// already; strings are skipped here. A named handler (`RegisterNetEvent('x', OnX)`) has no
+// body at the site — its extent is the line.
+
+const LUA_WORD = /\b(function|if|do|repeat|until|end)\b|(['"])/g;
+
+/** Line of the `end` closing the `function` that begins at/after `from`, or null when the arg is not an inline function. */
+function luaHandlerEnd(src: string, from: number): number | null {
+  const head = /^\s*,\s*(function\b)/.exec(src.slice(from, from + 64));
+  if (!head) return null;
+  let i = from + head.index + head[0].length - head[1]!.length; // at `function`
+  let depth = 0;
+  LUA_WORD.lastIndex = i;
+  let m: RegExpExecArray | null;
+  while ((m = LUA_WORD.exec(src))) {
+    if (m[2]) { // skip a short string
+      const q = m[2];
+      let j = m.index + 1;
+      while (j < src.length && src[j] !== q && src[j] !== '\n') j += src[j] === '\\' ? 2 : 1;
+      LUA_WORD.lastIndex = j + 1;
+      continue;
+    }
+    const w = m[1]!;
+    if (w === 'function' || w === 'if' || w === 'do' || w === 'repeat') depth++;
+    else if (w === 'end' || w === 'until') depth--;
+    if (depth === 0) return src.slice(0, m.index).split('\n').length;
+  }
+  return null;
+}
+
+/** Line of the `}` closing the arrow/function handler that begins at/after `from`, or null. */
+function jsHandlerEnd(src: string, from: number): number | null {
+  const head = /^\s*,\s*(?:async\s*)?(?:function\b[^{]*|\([^)]*\)\s*=>\s*|[A-Za-z_$][\w$]*\s*=>\s*)\{/.exec(src.slice(from, from + 200));
+  if (!head) return null;
+  let i = from + head[0].length; // just past the opening `{`
+  let depth = 1;
+  for (; i < src.length; i++) {
+    const c = src[i]!;
+    if (c === '"' || c === "'" || c === '`') { const q = c; i++; while (i < src.length && src[i] !== q) i += src[i] === '\\' ? 2 : 1; continue; }
+    if (c === '{') depth++;
+    else if (c === '}' && --depth === 0) return src.slice(0, i).split('\n').length;
+  }
+  return null;
+}
+
+// ── registrars ────────────────────────────────────────────────────────────────
+// Each yields (keyKind, literal) at a site that supplies a handler. `RegisterNetEvent('x')`
+// with no handler is a declaration, not a handler — the handler is the `AddEventHandler`
+// that follows, and that one matches.
+interface RegistrarSpec {
+  re: RegExp;
+  key: (m: RegExpExecArray) => string;
+}
+const Q = `(['"\`])`;
+const LIT = `([^'"\`\\n]+)`;
+/** Not preceded by `.`/`:`/word — `socket.on(`, `emitter.emit(`, `obj:TriggerEvent(` are somebody's methods, not FiveM globals. */
+const G = `(?<![\\w.:])`;
+// `export:`/`nui:` keys carry only the exported name here — the resource is a property of the
+// file's location, which only the synthesizer (with the file list) can resolve.
+const REGISTRARS: RegistrarSpec[] = [
+  { re: new RegExp(`${G}(?:RegisterNetEvent|AddEventHandler|RegisterServerEvent|onNet|on)\\s*\\(\\s*${Q}${LIT}\\1\\s*,`, 'g'), key: (m) => `event:${m[2]}` },
+  { re: new RegExp(`${G}exports\\s*\\(\\s*${Q}${LIT}\\1\\s*,`, 'g'), key: (m) => `export:${m[2]}` },
+  { re: new RegExp(`${G}(?:lib\\.callback\\.register|QBCore\\.Functions\\.CreateCallback)\\s*\\(\\s*${Q}${LIT}\\1\\s*,`, 'g'), key: (m) => `callback:${m[2]}` },
+  { re: new RegExp(`${G}RegisterCommand\\s*\\(\\s*${Q}${LIT}\\1\\s*,`, 'g'), key: (m) => `command:${m[2]}` },
+  { re: new RegExp(`${G}RegisterNUICallback\\s*\\(\\s*${Q}${LIT}\\1\\s*,`, 'g'), key: (m) => `nui:${m[2]}` },
+];
+
+export const FIVEM_NODE_PREFIX = 'fivem:';
+
+export const fivemResolver: FrameworkResolver = {
+  name: 'fivem',
+  languages: ['lua', 'luau', 'javascript', 'typescript'],
+
+  detect(context: ResolutionContext): boolean {
+    return fivemResourceRootsFrom(context.getAllFiles()).length > 0;
+  },
+
+  resolve(_ref: UnresolvedRef, _context: ResolutionContext): ResolvedRef | null {
+    return null; // bridging is the synthesizer's job — it needs the whole graph, not one ref
+  },
+
+  extract(filePath: string, content: string): FrameworkExtractionResult {
+    const none: FrameworkExtractionResult = { nodes: [], references: [] };
+    const language = fivemLanguageFor(filePath);
+    if (!language || isFivemNuiFile(filePath)) return none;
+    const src = stripForFivem(content, language);
+    const nodes: Node[] = [];
+    const seen = new Set<string>();
+    const lines = src.split('\n');
+    for (const spec of REGISTRARS) {
+      spec.re.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = spec.re.exec(src))) {
+        const key = spec.key(m);
+        const line = src.slice(0, m.index).split('\n').length;
+        const afterKey = m.index + m[0].length - 1; // at the `,` following the literal
+        const endLine = (language === 'lua' || language === 'luau' ? luaHandlerEnd(src, afterKey) : jsHandlerEnd(src, afterKey)) ?? line;
+        const qualifiedName = `${filePath}::${key}@${line}`;
+        if (seen.has(qualifiedName)) continue;
+        seen.add(qualifiedName);
+        nodes.push({
+          id: `${FIVEM_NODE_PREFIX}${qualifiedName}`,
+          kind: 'function',
+          name: key,
+          qualifiedName,
+          filePath,
+          language,
+          startLine: line,
+          endLine,
+          startColumn: 0,
+          endColumn: 0,
+          signature: (lines[line - 1] ?? '').trim().slice(0, 160),
+          isExported: true,
+          updatedAt: Date.now(),
+        });
+      }
+    }
+    return { nodes, references: [] };
+  },
+};

--- a/src/resolution/frameworks/index.ts
+++ b/src/resolution/frameworks/index.ts
@@ -15,6 +15,7 @@ import { nextjsResolver } from './nextjs';
 import { reactRouterResolver } from './react-router';
 import { tanstackRouterResolver } from './tanstack-router';
 import { vueRouterResolver } from './vue-router';
+import { fivemResolver } from './fivem';
 import { svelteKitRouterResolver } from './sveltekit-router';
 import { svelteResolver } from './svelte';
 import { vueResolver } from './vue';
@@ -60,6 +61,8 @@ const FRAMEWORK_RESOLVERS: FrameworkResolver[] = [
   // Vue Router — `createRouter({ routes })` → route nodes; `router.push({ name })` / `router.push('/x')` → navigates edges
   vueRouterResolver,
   astroResolver,
+  // FiveM — `fxmanifest.lua` resources; RegisterNetEvent/exports/lib.callback/RegisterCommand/RegisterNUICallback('literal', fn) → handler nodes; string-keyed dispatch bridged by `fivem-synthesizer.ts`
+  fivemResolver,
   // Python
   djangoResolver,
   flaskResolver,
@@ -157,6 +160,7 @@ export { reactResolver } from './react';
 export { reactRouterResolver } from './react-router';
 export { tanstackRouterResolver } from './tanstack-router';
 export { vueRouterResolver } from './vue-router';
+export { fivemResolver } from './fivem';
 export { svelteKitRouterResolver } from './sveltekit-router';
 export { svelteResolver } from './svelte';
 export { vueResolver } from './vue';


### PR DESCRIPTION
Refs #967 (framework coverage tracking). Adjacent to the Lua row's "anonymous-handler frontier" in `docs/design/framework-coverage.md` and to #1616 / #1650 — this takes the FiveM case of that frontier, where the anonymous handler is *the* shape.

## Problem

A FiveM (Cfx.re) server is a set of *resources* — directories with an `fxmanifest.lua` — that call each other almost exclusively through **string literals the runtime resolves at call time**:

```lua
-- qb-inventory/server/main.lua
RegisterNetEvent('qb-inventory:server:AddItem', function(item, amount) … end)
exports('AddItem', function(src, item, amount) … end)
lib.callback.register('qb-inventory:getCount', function(source, item) … end)

-- qb-shops/client/main.lua  (a different resource)
TriggerServerEvent('qb-inventory:server:AddItem', item, 1)
exports['qb-inventory']:AddItem(src, item, 1)
local n = lib.callback.await('qb-inventory:getCount', false, item)
```

Tree-sitter sees a method call on an indexed table; nothing links the files. Worse, the handler is nearly always an **inline anonymous `function … end`**, so the extractor has no node for it — a synthesizer alone would have nothing to point an edge at. On a stock pack that is every cross-resource flow: `codegraph_explore` dead-ends at the dispatch line and the agent greps the literal and reads the other file.

## Fix

Two halves, the router pattern (route nodes from a resolver's `extract()`, edges from a synthesizer):

- **`frameworks/fivem.ts`** — resolver. `detect()` fires on any `fxmanifest.lua`/`__resource.lua`. `extract()` creates one `function` node per registration site that supplies a handler — `RegisterNetEvent` / `AddEventHandler` / `RegisterServerEvent` / `onNet` / `on`, `exports()`, `lib.callback.register` / `QBCore.Functions.CreateCallback`, `RegisterCommand`, `RegisterNUICallback` — named by a keyed literal (`event:x`, `export:x`, `callback:x`, `command:x`, `nui:x`) so nothing else can collide, with the inline handler's **real extent** from a Lua `function/if/do…end` balancer or JS brace matching, so a dispatch inside a handler body attributes to the handler. Includes a Lua comment stripper (`strip-comments.ts` has no Lua dialect). Runs in parse workers, so it depends on nothing `detect()` computed — keys carry no resource; that is the synthesizer's job.
- **`fivem-synthesizer.ts`** — `SYNTH_PASSES` entry. Recomputes resource roots from `ctx.getAllFiles()` and links every literal dispatch site — `Trigger*Event` / `emit*`, `exports['res']:Fn` / `exports.res.Fn` (filtered to the handler under the root named `res`), `lib.callback(.await)` / `TriggerCallback`, `ExecuteCommand`, and NUI `fetch('https://res/name')` / `` fetch(`https://${GetParentResourceName()}/name`) `` / `fetchNui('name')` (own resource) — from its innermost enclosing function to the handler nodes for that key. Events are uncapped (`QBCore:Client:OnPlayerLoaded` has 29 receivers in a stock pack; that fan-out is the runtime's truth); keyed kinds cap at 8.

**Precision floor.** Literal keys only. A computed key, a commented-out dispatch, an unregistered key, a wrong resource name, and a member call (`socket.on(`, `emitter.emit(`) all yield nothing. NUI trees (`html/`, `web/`, `ui/`, `nui/`) and minified bundles never produce handler nodes and are scanned for `fetch` only. A project with no manifest contributes no nodes and no edges. Edges are `provenance:'heuristic'`, `synthesizedBy:'fivem-dispatch'`, `via` = the key (`export:qb-inventory/AddItem`), `registeredAt` = handler `file:line`.

## Validation

**Fixture** (`__tests__/fivem-dispatch-synthesizer.test.ts`): two-resource pack — cross-resource event, export, callback, JS `onNet`/`emitNet`, all three NUI forms, handler→handler chaining (`export:AddItem → event:…:AddItem`, `nui:getStock → callback:…:getCount`), and the precision controls above; plus a no-manifest Lua control and the stripper.

**Real system resource** — cfx `chat` (Lua client/server + NUI), indexed with the built CLI: 27 handler nodes with correct extents (`event:chatMessage cl_chat.lua:30-43`, `command:toggleChat 251-271`), 12 edges including server `routeMessage → event:chatMessage` (client handler), `nui:loaded → event:chat:init`, `export:addMessage → event:chat:addMessage`.

**Real pack** — the [Qbox txAdmin recipe](https://github.com/Qbox-project/txAdminRecipe) as source checkouts: 88 resources, 1,895 files (968 Lua, 511 JS/TS).

| | before | this PR |
|---|---|---|
| index time | — | 2.1 s (whole pack) |
| nodes / edges | 15,705 / 39,322 | 17,635 / 41,990 |
| FiveM handler nodes | 0 | **1,930** (event 1,048 · export 511 · callback 205 · nui 137 · command 29) |
| `fivem-dispatch` edges | 0 | **2,668** (export 1,309 · event 1,106 · callback 235 · nui 18) |
| of which cross-resource | 0 | **1,655** (62%) — the edges grep cannot produce |
| `QBCore:Client:OnPlayerLoaded` receivers per dispatch site | 0 | 29 / 29 registered |
| handler nodes from NUI bundles | — | 0 |
| precision spot-check (random edges, handler line contains the literal) | — | 30 / 30, twice |

Cross-resource flows now connect in one explore, e.g. `ox_fuel/client/fuel.lua::getPetrolCan → ox_inventory/modules/inventory/client.lua:301` (`exports.ox_inventory:Search`) and `qbx_npwd/client.lua::doPhoneCheck → ox_inventory …:172`.

**Recall notes** (not bridged, by design or by scope): computed keys (`TriggerServerEvent(evt, …)`) — a boundary-surfacing candidate; dispatches to resources outside the pack (`qb-phone:*`, `InteractSound_SV:*`); NUI in compiled bundles (`html/*.js`) — the 18 NUI edges come from TS sources (`npwd_qbx_mail/src/hooks/useMailAPI.ts`).

**Suite:** `npx vitest run` on this branch vs `main` (both with a built `dist/`): identical failure set — 7 tests in `cli-ui-command` / `ui-entrypoints-api`, all `ViewerMissingError` (viewer assets not built in that environment), pre-existing. 4,037 passed here incl. the 3 new; 0 regressions. `tsc --noEmit` clean. Handler bodies' own callees stay attributed to the file (the Lua kernel does not make a scope for an anonymous argument) — a follow-up in `codegraph-kernel/src/lua.rs` would complete the picture; a `synthEdgeNote` case for `fivem-dispatch` is another small one (the generic branch renders it today).

No migration: an existing index picks the nodes and edges up on its next `codegraph sync` / re-`init`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDKLQxLmiMUFzLBBEQvwdG
