### PR TITLE
fix(resolution): a name bound to a bare import resolves to no project node

### DIFF
--- a/__tests__/fuzzy-bare-import-binding.test.ts
+++ b/__tests__/fuzzy-bare-import-binding.test.ts
@@ -7,8 +7,10 @@
  * matchFuzzy is driven directly. Which strategy reaches a given ref depends on
  * how many same-named symbols the repo holds and on what the earlier stages of
  * matchReference make of them, so a source fixture pins the pipeline rather
- * than this guard; the shape that routes through fuzzy on a real tree is vite's
- * playground configs, and the guard removes 44 of its wrong edges there.
+ * than this guard. On real trees the shape routes through fuzzy as a
+ * case-insensitive match — `EvaluatedModules` from `vite/module-runner` onto
+ * vitest's `VitestMocker::evaluatedModules`, `Bundle` from `magic-string` onto
+ * a svelte build script's `bundle`.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -31,8 +33,13 @@ const SURVIVOR: Node = {
   updatedAt: 0,
 };
 
-function contextWith(imports: ImportMapping[], candidate = SURVIVOR): ResolutionContext {
+function contextWith(
+  imports: ImportMapping[],
+  candidate = SURVIVOR,
+  localLinkNames?: Set<string>
+): ResolutionContext {
   return {
+    getWorkspacePackages: () => (localLinkNames ? { byName: new Map(), localLinkNames } : null),
     getNodesInFile: () => [],
     getNodesByName: () => [candidate],
     getNodesByLowerName: () => [candidate],
@@ -87,6 +94,26 @@ describe('matchFuzzy declines a lone survivor bound to a bare import', () => {
       expect(res?.resolvedBy).toBe('fuzzy');
     },
   );
+
+  // vitest's `test/browser/package.json` declares `"@vitest/bundled-lib":
+  // "link:./bundled-lib"`, a directory its `test/*` workspace globs do not
+  // reach, so the workspace map cannot vouch for the name and only the
+  // dependency protocol shows it is local.
+  it('still matches a link: dependency, which is local despite its package spelling', () => {
+    const linked = new Set(['@vitest/bundled-lib']);
+    const res = matchFuzzy(
+      callTo('javascript'),
+      contextWith(imported('@vitest/bundled-lib'), SURVIVOR, linked)
+    );
+    expect(res?.targetNodeId).toBe('m:resolve');
+  });
+
+  it('declines a scoped package that is not linked into the project', () => {
+    const linked = new Set(['@vitest/bundled-lib']);
+    expect(
+      matchFuzzy(callTo('javascript'), contextWith(imported('@vitest/mocker'), SURVIVOR, linked))
+    ).toBeNull();
+  });
 
   it('still matches when the name is bound by no import at all', () => {
     const res = matchFuzzy(callTo('javascript'), contextWith([]));

--- a/__tests__/fuzzy-bare-import-binding.test.ts
+++ b/__tests__/fuzzy-bare-import-binding.test.ts
@@ -76,6 +76,18 @@ describe('matchFuzzy declines a lone survivor bound to a bare import', () => {
     expect(res?.resolvedBy).toBe('fuzzy');
   });
 
+  // vite's playground/tsconfig.json declares `"paths": { "~utils": [...] }` —
+  // a nested tsconfig the alias loader never reads — so shape is the only
+  // signal that these are local. npm names cannot start with any of them.
+  it.each(['~utils', '~/utils', '#types/hmrPayload', '$lib/stores'])(
+    'still matches a local specifier with no slash after its prefix: %s',
+    (source) => {
+      const res = matchFuzzy(callTo('javascript'), contextWith(imported(source)));
+      expect(res?.targetNodeId).toBe('m:resolve');
+      expect(res?.resolvedBy).toBe('fuzzy');
+    },
+  );
+
   it('still matches when the name is bound by no import at all', () => {
     const res = matchFuzzy(callTo('javascript'), contextWith([]));
     expect(res?.targetNodeId).toBe('m:resolve');

--- a/__tests__/fuzzy-bare-import-binding.test.ts
+++ b/__tests__/fuzzy-bare-import-binding.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Filtering candidates until one survives does not make that survivor the
+ * target. When the call site's own name comes from a bare import — `resolve`
+ * from `node:path` — the real target is external and absent from the graph, so
+ * the last project symbol standing must not inherit the call.
+ *
+ * matchFuzzy is driven directly. Which strategy reaches a given ref depends on
+ * how many same-named symbols the repo holds and on what the earlier stages of
+ * matchReference make of them, so a source fixture pins the pipeline rather
+ * than this guard; the shape that routes through fuzzy on a real tree is vite's
+ * playground configs, and the guard removes 44 of its wrong edges there.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { matchFuzzy } from '../src/resolution/name-matcher';
+import type { Node } from '../src/types';
+import type { ImportMapping, ResolutionContext, UnresolvedRef } from '../src/resolution/types';
+
+/** vite's `pluginContainer.ts:resolve` — the sole survivor of the filters. */
+const SURVIVOR: Node = {
+  id: 'm:resolve',
+  kind: 'method',
+  name: 'resolve',
+  qualifiedName: 'PluginContainer::resolve',
+  filePath: 'packages/vite/src/node/server/pluginContainer.ts',
+  language: 'typescript',
+  startLine: 10,
+  endLine: 20,
+  startColumn: 0,
+  endColumn: 0,
+  updatedAt: 0,
+};
+
+function contextWith(imports: ImportMapping[], candidate = SURVIVOR): ResolutionContext {
+  return {
+    getNodesInFile: () => [],
+    getNodesByName: () => [candidate],
+    getNodesByLowerName: () => [candidate],
+    getNodesByQualifiedName: () => [],
+    getNodesByKind: () => [],
+    fileExists: () => false,
+    readFile: () => null,
+    getFileLines: () => [],
+    getProjectRoot: () => '',
+    getAllFiles: () => [],
+    getImportMappings: () => imports,
+  } as unknown as ResolutionContext;
+}
+
+const imported = (source: string): ImportMapping[] => [
+  { localName: 'resolve', exportedName: 'resolve', source, isDefault: false, isNamespace: false },
+];
+
+const callTo = (language: UnresolvedRef['language']): UnresolvedRef => ({
+  fromNodeId: 'f:outDir',
+  referenceName: 'resolve',
+  referenceKind: 'calls',
+  line: 4,
+  column: 2,
+  filePath: 'playground/css/vite.config.js',
+  language,
+});
+
+describe('matchFuzzy declines a lone survivor bound to a bare import', () => {
+  it('declines a node: builtin', () => {
+    expect(matchFuzzy(callTo('javascript'), contextWith(imported('node:path')))).toBeNull();
+  });
+
+  it('declines a bare npm specifier', () => {
+    expect(matchFuzzy(callTo('javascript'), contextWith(imported('rollup')))).toBeNull();
+  });
+
+  it('still matches when the binding is a relative import the resolver could not follow', () => {
+    const res = matchFuzzy(callTo('javascript'), contextWith(imported('./generated/chunks')));
+    expect(res?.targetNodeId).toBe('m:resolve');
+    expect(res?.resolvedBy).toBe('fuzzy');
+  });
+
+  it('still matches when the name is bound by no import at all', () => {
+    const res = matchFuzzy(callTo('javascript'), contextWith([]));
+    expect(res?.targetNodeId).toBe('m:resolve');
+  });
+
+  it('leaves languages whose own modules are imported by absolute name alone', () => {
+    // `from os import path` and `from myapp.util import path` are the same
+    // shape, so the bare test cannot tell external from internal here.
+    const pythonRef = { ...callTo('python'), filePath: 'app/main.py' };
+    const pythonNode = { ...SURVIVOR, language: 'python' as const };
+    const res = matchFuzzy(pythonRef, contextWith(imported('os'), pythonNode));
+    expect(res?.targetNodeId).toBe('m:resolve');
+  });
+});

--- a/src/resolution/name-matcher.ts
+++ b/src/resolution/name-matcher.ts
@@ -783,7 +783,22 @@ function isBoundToBareImport(ref: UnresolvedRef, context: ResolutionContext): bo
   if (aliases?.patterns.some((p) => source.startsWith(p.prefix))) return false;
   const workspaces = context.getWorkspacePackages?.();
   if (workspaces && resolveWorkspaceImport(source, workspaces)) return false;
+  // A `link:` / `file:` dependency is a directory in the project that no
+  // workspace glob need cover, so the workspace map above cannot see it:
+  // vitest imports `@vitest/bundled-lib` from `test/browser/bundled-lib`,
+  // which its `test/*` globs stop short of. The name is local even though it
+  // is spelled exactly like a scoped registry package.
+  if (workspaces?.localLinkNames?.has(packageNameOf(source))) return false;
   return true;
+}
+
+/**
+ * The package a specifier names, without its subpath: `@scope/pkg/sub` →
+ * `@scope/pkg`, `pkg/sub` → `pkg`. Scoped names keep two segments.
+ */
+function packageNameOf(source: string): string {
+  const parts = source.split('/');
+  return source.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]!;
 }
 
 /**

--- a/src/resolution/name-matcher.ts
+++ b/src/resolution/name-matcher.ts
@@ -771,7 +771,14 @@ function isBoundToBareImport(ref: UnresolvedRef, context: ResolutionContext): bo
     .find((i) => i.localName === ref.referenceName)?.source;
   if (source === undefined) return false;
   if (source.startsWith('.') || source.startsWith('/')) return false;
-  if (source.startsWith('@/') || source.startsWith('~/') || source.startsWith('src/')) return false;
+  // `~`, `#` and `$` cannot begin an npm package name, so the prefix alone
+  // proves a local binding and no resolver lookup is needed: `~utils` (a
+  // tsconfig `paths` entry, which a nested tsconfig the alias loader never
+  // reads still declares), `#types/hmrPayload` (a package.json `imports`
+  // subpath), `$lib/...` (SvelteKit). Matching only `~/` classed the slashless
+  // spellings as bare and sent real project edges out with the wrong ones.
+  if (source.startsWith('~') || source.startsWith('#') || source.startsWith('$')) return false;
+  if (source.startsWith('@/') || source.startsWith('src/')) return false;
   const aliases = context.getProjectAliases?.();
   if (aliases?.patterns.some((p) => source.startsWith(p.prefix))) return false;
   const workspaces = context.getWorkspacePackages?.();

--- a/src/resolution/name-matcher.ts
+++ b/src/resolution/name-matcher.ts
@@ -9,6 +9,7 @@ import { Language, Node } from '../types';
 import { UnresolvedRef, ResolvedRef, ResolutionContext, SUPERTYPE_TARGET_KINDS, isInheritanceRef, isImportableKind } from './types';
 import { blankStringContents, stripCommentsForRegex } from './strip-comments';
 import { JS_BUILT_INS } from './js-builtins';
+import { resolveWorkspaceImport } from './workspace-packages';
 
 /**
  * Ceiling on how many same-named definitions a FUZZY name-match strategy will
@@ -732,6 +733,50 @@ function isLocallyBoundJsName(name: string, filePath: string, context: Resolutio
   }
   memo.set(key, bound);
   return bound;
+}
+
+/**
+ * Whether the call site's own name is bound by an import of a BARE specifier —
+ * a Node builtin or an npm package. Such a binding names a symbol that is not
+ * in the graph at all, so no project node is the right target for it, however
+ * few candidates are left standing. That is the trap the name-based strategies
+ * fall into: filtering narrows a crowd of same-named symbols but says nothing
+ * about whether the true target was ever in the crowd, so when one survives it
+ * inherits the call. `import { resolve } from 'node:path'` is the case that
+ * matters — a common name, many project definitions, and the real target
+ * external.
+ *
+ * Relative, alias, and workspace imports are deliberately not treated this way:
+ * those point at project files, so a name match is a reasonable recovery when
+ * the import resolver could not follow the path.
+ *
+ * Only the JS/TS family is checked. There, a project-internal import is
+ * distinguishable by shape — it is relative, aliased, or a workspace member —
+ * so "bare" really does mean external. In Java, Kotlin, Go and Python a
+ * project's own modules are imported by absolute name too, and the same test
+ * would reject the internal case along with the external one.
+ */
+function isBoundToBareImport(ref: UnresolvedRef, context: ResolutionContext): boolean {
+  if (
+    ref.language !== 'typescript' &&
+    ref.language !== 'javascript' &&
+    ref.language !== 'tsx' &&
+    ref.language !== 'jsx' &&
+    ref.language !== 'arkts'
+  ) {
+    return false;
+  }
+  const source = context
+    .getImportMappings(ref.filePath, ref.language)
+    .find((i) => i.localName === ref.referenceName)?.source;
+  if (source === undefined) return false;
+  if (source.startsWith('.') || source.startsWith('/')) return false;
+  if (source.startsWith('@/') || source.startsWith('~/') || source.startsWith('src/')) return false;
+  const aliases = context.getProjectAliases?.();
+  if (aliases?.patterns.some((p) => source.startsWith(p.prefix))) return false;
+  const workspaces = context.getWorkspacePackages?.();
+  if (workspaces && resolveWorkspaceImport(source, workspaces)) return false;
+  return true;
 }
 
 /**
@@ -2934,6 +2979,7 @@ export function matchFuzzy(
   ref: UnresolvedRef,
   context: ResolutionContext
 ): ResolvedRef | null {
+  if (isBoundToBareImport(ref, context)) return null;
   const lowerName = ref.referenceName.toLowerCase();
 
   // Use pre-built lowercase index for O(1) lookup instead of scanning all nodes

--- a/src/resolution/workspace-packages.ts
+++ b/src/resolution/workspace-packages.ts
@@ -41,6 +41,15 @@ export interface WorkspacePackages {
    * list). Absent for npm/pnpm members (their index conventions cover it).
    */
   entryByName?: Map<string, string>;
+  /**
+   * Package names declared with a `link:` or `file:` specifier in the root or
+   * any member manifest (`"@vitest/bundled-lib": "link:./bundled-lib"`). Such
+   * a package lives in the project but need not sit under a workspace glob,
+   * so {@link resolveWorkspaceImport} cannot see it — this set exists only so
+   * a caller can tell that the NAME is project-local, and deliberately carries
+   * no directory, since resolving these is a separate change.
+   */
+  localLinkNames?: Set<string>;
 }
 
 /**
@@ -55,13 +64,24 @@ export interface WorkspacePackages {
 export function loadWorkspacePackages(projectRoot: string): WorkspacePackages | null {
   const byName = new Map<string, string>();
 
+  const memberDirs: string[] = [];
   const patterns = readWorkspaceGlobs(projectRoot);
   for (const pattern of patterns) {
     for (const dir of expandWorkspaceGlob(projectRoot, pattern)) {
+      memberDirs.push(dir);
       const pkgName = readPackageName(path.join(projectRoot, dir));
       // First declaration wins — workspace patterns are tried in order.
       if (pkgName && !byName.has(pkgName)) byName.set(pkgName, dir);
     }
+  }
+
+  // A member may depend on a package that is inside the project but outside
+  // every workspace glob (vitest's `test/browser` declares `"@vitest/
+  // bundled-lib": "link:./bundled-lib"`, and the globs stop at `test/*`).
+  // Reading each manifest we already opened for its name costs nothing more.
+  const localLinkNames = new Set<string>();
+  for (const dir of ['', ...memberDirs]) {
+    for (const dep of readLinkDepNames(path.join(projectRoot, dir))) localLinkNames.add(dep);
   }
 
   // HarmonyOS/OpenHarmony (ArkTS) modular projects: every module's
@@ -77,10 +97,14 @@ export function loadWorkspacePackages(projectRoot: string): WorkspacePackages | 
     if (entry) entryByName.set(name, entry);
   }
 
-  if (byName.size === 0) return null;
+  if (byName.size === 0 && localLinkNames.size === 0) return null;
 
-  logDebug('workspace packages loaded', { count: byName.size });
-  return { byName, entryByName: entryByName.size > 0 ? entryByName : undefined };
+  logDebug('workspace packages loaded', { count: byName.size, linked: localLinkNames.size });
+  return {
+    byName,
+    entryByName: entryByName.size > 0 ? entryByName : undefined,
+    localLinkNames: localLinkNames.size > 0 ? localLinkNames : undefined,
+  };
 }
 
 /**
@@ -314,6 +338,32 @@ function expandWorkspaceGlob(projectRoot: string, pattern: string): string[] {
 }
 
 /** Read the `name` field from a member directory's package.json. */
+/**
+ * Dependency names this manifest declares with a `link:` or `file:` specifier
+ * — the two protocols npm, yarn, pnpm and bun all read as "this package is a
+ * directory in the project", so the name is local however much it looks like
+ * a registry package. A missing or malformed manifest contributes nothing.
+ */
+function readLinkDepNames(dirAbs: string): string[] {
+  let pkg: Record<string, unknown>;
+  try {
+    pkg = JSON.parse(fs.readFileSync(path.join(dirAbs, 'package.json'), 'utf-8'));
+  } catch {
+    return [];
+  }
+  const names: string[] = [];
+  for (const field of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']) {
+    const deps = pkg?.[field];
+    if (!deps || typeof deps !== 'object') continue;
+    for (const [name, spec] of Object.entries(deps as Record<string, unknown>)) {
+      if (typeof spec === 'string' && (spec.startsWith('link:') || spec.startsWith('file:'))) {
+        names.push(name);
+      }
+    }
+  }
+  return names;
+}
+
 function readPackageName(dirAbs: string): string | null {
   try {
     const pkg = JSON.parse(fs.readFileSync(path.join(dirAbs, 'package.json'), 'utf-8'));


### PR DESCRIPTION
`matchFuzzy` commits to a candidate whenever filtering leaves exactly one. Filtering narrows a crowd of same-named symbols; it does not establish that the true target was ever in the crowd. When the call site's own name comes from a bare import the true target is external and absent from the graph, so the last project symbol standing inherits the reference.

The match is case-insensitive, so the crowd is larger than the name suggests. Instances from three of the four repos measured below:

```
vitest   import type { EvaluatedModules } from 'vite/module-runner'
           → [method] VitestMocker::evaluatedModules                   (17 refs)
vitest   import type { Result } from 'tinyexec'
           → [method] TestCase::result
svelte   import MagicString, { Bundle } from 'magic-string'
           → [function] bundle @ scripts/generate-browser-support.ts   (5 refs)
```

And on vite, two at the merge-base:

```
packages/vite/src/node/optimizer/scan.ts:7   import { scan } from 'rolldown/experimental'
  → packages/vite/src/node/optimizer/scan.ts:scan          (the importing file's OWN scan)

packages/vite/src/node/config.ts:14          import { getEnv } from '@vitejs/devtools/config'
  → packages/vite/src/node/plugins/importAnalysis.ts:getEnv
```

The first is a self-edge: a file importing a name from npm, resolved onto its own definition of that name, plus the `calls` edge from `build` that follows it.

## The change

Decline fuzzy matching when the call site's binding is a bare specifier — a builtin or an npm package. Relative, alias and workspace imports point at project files, so a fuzzy match is still a reasonable recovery there when the import resolver could not follow the path.

Only the JS/TS family is checked. There a project-internal import is distinguishable by shape — relative, aliased, or a workspace member — so "bare" really does mean external. In Java, Kotlin, Go and Python a project's own modules are imported by absolute name too, and the same test would reject the internal case along with the external one.

## Measurement

Four repos, each indexed at this PR's merge-base (`b9ca4b7`) and at its tip. **Every non-fuzzy resolver is unchanged on every repo and GAINED is 0 everywhere** — the change is purely subtractive:

| repo | edges | fuzzy | LOST | GAINED |
| --- | --- | ---: | ---: | ---: |
| vitest `7c81815` | 73,264 → 73,230 | 511 → 477 | 34 | 0 |
| svelte `5895c63` | 65,427 → 65,422 | 131 → 126 | 5 | 0 |
| vite `8492422` | 27,778 → 27,774 | 13 → 9 | 4 | 0 |
| rollup `e90af89` | 66,571 → 66,568 | 2,274 → 2,271 | 3 | 0 |

The per-resolver breakdown on vite, as the shape all four have:

| resolvedBy | base | PR | delta |
| --- | ---: | ---: | ---: |
| **fuzzy** | **13** | **9** | **-4** |
| exact-match | 10716 | 10716 | 0 |
| import | 5359 | 5359 | 0 |
| qualified-name | 1790 | 1790 | 0 |
| instance-method | 1035 | 1035 | 0 |
| (none) | 8684 | 8684 | 0 |
| function-ref | 99 | 99 | 0 |
| file-path | 63 | 63 | 0 |
| framework | 19 | 19 | 0 |

Edge-set delta on vite: **LOST 4, GAINED 0** — the two instances above and the two `calls` edges that follow them.

## Relationship to #1709 and #1718

The measurement above is against the merge-base and does not depend on either PR. Stacked on #1718, this guard removes a further 25 edges — measured below.

**#1718 supersedes #1709 and is the better fix.** #1709 filtered unreachable nested functions out of the fuzzy candidate set, which on vite left exactly one survivor for a crowd of `resolve` definitions; the survivor then inherited every `resolve` call from the playground configs. #1718 instead checks reachability on the single candidate `matchFuzzy` would already commit to. That is structurally stronger, not merely better-measured: a guard on the `finalCandidates.length === 1` branch can only decline an edge, never create a uniqueness, so GAINED 0 holds by construction. I checked that declining there is terminal rather than falling through — fuzzy is the last of four strategies at `name-matcher.ts:2776`, and the other call site at `:1219` returns null at `:1220` — so no reference can be routed into a later edge-producing path.

**That removes an argument this PR used to make.** Against #1709's filtering approach, this guard removed 44 of the 59 edges that approach gained. Under #1718 those 59 are never manufactured, so those 44 are no longer a benefit this change provides, and I am not claiming them. The measurements are kept below because they are the evidence for *why* filtering the set was wrong, which is now the accepted conclusion — not because they argue for this PR.

| | LOST | GAINED | fuzzy |
| --- | ---: | ---: | ---: |
| base → #1709 | 12 | 59 | 13 → 60 |
| base → #1709 + this | 12 | 15 | 13 → 16 |
| #1709 → #1709 + this | 44 | 0 | 60 → 16 |
| base → this alone | 4 | 0 | 13 → 9 |

**Measured stacked.** Both PRs branch from `b9ca4b7`, so an arm merging the two differs from #1718 alone by this guard and nothing else:

| repo | #1718 alone | #1718 + this | LOST | GAINED |
| --- | --- | --- | ---: | ---: |
| vitest | 73,004 (fuzzy 251) | 72,984 (fuzzy 231) | **20** | 0 |
| svelte | 65,346 (fuzzy 50) | 65,341 (fuzzy 45) | **5** | 0 |
| vite | 27,766 (fuzzy 1) | 27,766 (fuzzy 1) | 0 | 0 |
| rollup | 64,604 (fuzzy 307) | 64,604 (fuzzy 307) | 0 | 0 |

**25 wrong edges that #1718 cannot reach, and two of them show why it cannot:**

```
17x  EvaluatedModules from 'vite/module-runner'  → [method] VitestMocker::evaluatedModules
 1x  Result           from 'tinyexec'            → [method] TestCase::result
 2x  Pattern          from 'estree'              → [function] pattern @ test/unit/test/pattern.test.ts
 5x  Bundle           from 'magic-string'        → [function] bundle @ scripts/generate-browser-support.ts
```

`isLexicallyReachable` returns `true` on its first line for any candidate that is not a `function`, so a **method** survivor is admitted by construction — it is not the shape that check is for. Nothing about reachability can decline `EvaluatedModules`; only the import binding shows it is wrong.

**A correction, since an earlier revision of this section argued the reverse of its own measurement.** I claimed vite's `scan` and `getEnv` were candidates #1718 would pass because they were top-level. They are `scanImports::scan` and `importAnalysisPlugin::getEnv` — nested functions, exactly what `isLexicallyReachable` rejects — so #1718 declines them unaided, and vite's row above is a legitimate 0. I had read vite's source rather than querying the node's `qualifiedName`, which is the only view of the symbol the guard has, and I had never run the two arms in one tree. Adding three repos is what turned the argument into a measurement, and it also caught a defect in this PR (below).

**The two guards check opposite sides and neither subsumes the other.** #1718 guards the *candidate* it would commit to; this guards the *reference*, whose name is bound to an external specifier, so no project node is correct however reachable the survivors are. Conversely a `res.text()` whose only candidate is a closure never trips this guard, and #1718 declines it. They touch `matchFuzzy` at different points — this one at the top before candidate gathering, #1718 on the length-1 branch — and merging them confirms it: `name-matcher.ts` auto-merges, only `CHANGELOG.md` conflicts.

## What this does not fix

Two mis-resolutions on vite survive this guard, and both are a different failure mode rather than bare imports. (They were 15 of the edges in the `#1709 + this` arm above; that arm is superseded, but the two shapes are still there and neither guard addresses them.)

```
const resolve = (p) => path.resolve(import.meta.dirname, p)   // playground/ssr-conditions/server.js:13
await this.resolve(id, importer)                              // playground/css/vite.config.js:30
```

The first is a same-file `const` arrow. Querying the graph, there is no node named `resolve` in that file at all — extraction never emits the binding, so no resolver-layer rule can see it to shadow the cross-file candidate. The second is a method call on a rollup plugin context. Both are extraction-side and out of scope here.

I also tried the same guard in `matchByExactName`, which has an identical single-survivor commit at `name-matcher.ts:418`. On vite that moved exact-match 10,716 → 6,617 — 4,048 edges lost — so I reverted it.

**@danusha2345 found why, and it was a defect in my predicate rather than in the idea.** `startsWith('~/')` did not catch `~utils`, which vite's `playground/tsconfig.json` declares as a `paths` entry — a nested tsconfig the alias loader never reads — so a project alias was classed as an external package and took 1,395 real edges out with the wrong ones, plus 20 through `#types/hmrPayload`, a `package.json` `imports` subpath.

The second commit here fixes that: `~`, `#` and `$` are treated as local, since none of them can begin an npm package name, so the prefix alone is sufficient evidence without a resolver lookup. On vite this changes nothing measurable in `matchFuzzy` — those names resolve by exact match before fuzzy is reached, which is exactly why the defect survived a green measurement — but it is load-bearing for any use of the predicate in `matchByExactName`. The exact-match half is @danusha2345's #1715.

**Widening the corpus found a second one of the same kind, and the third commit fixes it.** vitest's `test/browser/package.json` declares `"@vitest/bundled-lib": "link:./bundled-lib"`, a directory its `test/*` workspace globs do not reach — so `resolveWorkspaceImport` could not vouch for the name, the predicate classed it external, and two correct edges onto the linked package's own source were removed. `link:` and `file:` are the protocols npm, yarn, pnpm and bun all read as "this package is a directory in the project", so the name is local however much it is spelled like a scoped registry package. `loadWorkspacePackages` now collects those dependency names while reading the manifests it already opens, and the predicate treats a match as local. It is deliberately a set of names with no directory: resolving these imports is a real improvement and a separate change, and this PR stays subtractive. The stacked table above is post-fix — before it, vitest read 22 rather than 20, and those two extra were this PR being wrong.

## Tests

`__tests__/fuzzy-bare-import-binding.test.ts` drives `matchFuzzy` directly — 11 cases, all passing. Three must decline: a `node:` builtin, a bare npm specifier, and a scoped package that is *not* linked into the project. Eight must not change: a relative import the resolver could not follow, no import binding at all, a Python ref bound to `os`, the four local-prefix spellings `~utils`, `~/utils`, `#types/hmrPayload`, `$lib/stores`, and a `link:` dependency. Ablating the guard fails exactly the three declines.

The guard is also ablated against **#1718** rather than only against the merge-base, since that is the arm it has to earn its place in: with #1718 applied and this guard removed, the run is 3 failed / 8 passed — the same three declines. Their candidate is a method, which `isLexicallyReachable` admits at its first line, so no amount of reachability checking covers them.

The direct-call shape is deliberate. Which strategy reaches a given ref depends on how many same-named symbols the tree holds and on what the earlier stages of `matchReference` make of them, so a source fixture pins the pipeline rather than this guard — my first attempt at one resolved through `matchByExactName` and passed with the guard removed.

## Verification notes

**Runtime.** Everything above was built, indexed and measured on **Node v24.16.0** — the version `scripts/build-bundle.sh` vendors, inside `engines.node` (`>=20.0.0 <25.0.0`). Every arm is a fresh `npm run build` (exit 0) and a fresh index into a deleted `.codegraph`; `tsc --noEmit` exit 0. `CODEGRAPH_KERNEL_DEBUG=1` confirms the native kernel loaded for typescript/tsx/javascript/jsx on every indexing pass, so these are kernel-arm numbers rather than the wasm fallback.

An earlier revision of this description reported the vite table measured under Bun and claimed that was the supported path. It is not — this project asks for Node and vendors its own — and I have replaced those numbers rather than annotate them. The vite arms were re-run **tip-first**, the reverse of the original ordering, and reproduce exactly: LOST 4, GAINED 0, fuzzy 13 → 9, total edges 27,778 → 27,774, the same four edges. @danusha2345 independently reproduced that table on their own tree. The three added repos were run in the opposite arm order again (#1718 before the stack), which is a formality here — every number in this description is a count, not a duration, and counts do not move with cache state.

**Why four repos.** vite alone was misleading in both directions: it is the only one of the four where this guard removes nothing on top of #1718, and it is the repo whose `link:` dependencies are absent, so the defect fixed in the third commit could not surface there. One corpus was enough to find the bug and not enough to characterise the fix.

Full suite on Node v24.16.0, Windows, at this PR's tip: **4,180 passed, 25 failed, 0 assertion failures.** Every failure is an `EPERM` on `fs.rmSync` of a temp directory in teardown, or a test timeout — none is an assertion, and none is in the resolution path this PR touches.

