### PR TITLE
fix(resolution): a store-action binding is not a local shadow

### DIFF
--- a/src/resolution/name-matcher.ts
+++ b/src/resolution/name-matcher.ts
@@ -704,7 +704,31 @@ function isLocallyBoundJsName(name: string, filePath: string, context: Resolutio
   );
   let bound = false;
   for (const m of source.matchAll(declRe)) {
-    if (!/^\s*(?:await\s+)?(?:require|import)\s*\(/.test(m[1] ?? '')) { bound = true; break; }
+    const rhs = m[1] ?? '';
+    // A store binding names the store's own action for the same reason an
+    // import does: the action is a node in the store file, so the bare call
+    // that follows means it rather than shadowing it. Two shapes, both naming
+    // the action explicitly — the accessors matchStoreAccessorChain already
+    // recognises (`const { fetchUser } = useStore.getState()`, `get()` inside
+    // the factory), and a selector that reads the same name off the state
+    // (`const setZipUri = useStore((s) => s.setZipUri)`). A selector returning
+    // a different name is a genuine rebinding and still shadows.
+    //
+    // The selector shape is exact on purpose: one named parameter, and a plain
+    // member READ of the same name. `const now = options.now || (() =>
+    // Date.now())` satisfies neither — no parameter, and `.now()` is a call —
+    // so it stays the local binding this predicate exists to find.
+    const selectorRe = new RegExp(
+      '\\(\\s*[\\w$]+\\s*\\)\\s*=>\\s*[\\w$]+(?:\\?\\.|\\.)' + n + '\\b(?!\\s*\\()'
+    );
+    if (
+      !/^\s*(?:await\s+)?(?:require|import)\s*\(/.test(rhs) &&
+      !/^\s*(?:await\s+)?(?:[\w$]+(?:\.[\w$]+)*\.)?(?:getState|get)\s*\(\s*\)/.test(rhs) &&
+      !selectorRe.test(rhs)
+    ) {
+      bound = true;
+      break;
+    }
   }
   if (!bound) {
     bound =


### PR DESCRIPTION
Fixes #1762.

`#1759` made `isLocallyBoundJsName` treat a Zustand-style store binding as a local rebinding, so bare calls to store actions stopped resolving. `main` at `cd4e65b` currently fails its own `__tests__/object-literal-methods.test.ts` with `expected [] to include 'loginFlow'`, plus two tests in `__tests__/ui-steps-api.test.ts`.

### The change

`isLocallyBoundJsName` already carves out `require(...)` / `import(...)` on the right-hand side, because an imported name is a node elsewhere rather than a shadow. This extends that same carve-out to store bindings, which are the same situation — the action is a node in the store file, so the bare call that follows means it:

```js
const { fetchUser } = useStore.getState();   // accessor shapes matchStoreAccessorChain already knows
const { fetchUser } = get();                 // inside the factory
const setZipUri = useStore((s) => s.setZipUri);  // selector reading the same name
```

A selector returning a *different* name is a genuine rebinding and still shadows.

The selector pattern is deliberately narrow: one named parameter, and a plain member **read** of the same name (`(?!\s*\()`). `const now = options.now || (() => Date.now())` matches neither clause — no parameter, and `.now()` is a call — so it stays the local binding this predicate exists to find. `bare-call-no-method` covers that case and stays green.

### Verification

Full suite, same machine and same build, pristine `cd4e65b` vs this branch:

| | pristine | this branch |
| --- | --- | --- |
| Test files | 13 failed | **7 failed** |
| Unique failing tests | 29 | **24** |

`object-literal-methods` and both `ui-steps-api` tests go green, and **no test that passed before fails after**. The remaining 24 are pre-existing on this machine (Windows, native kernel not built) and identical across both runs.
