### PR TITLE
fix(build): build the ui workspace by directory, not --workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   ],
   "scripts": {
     "build": "tsc && npm run copy-assets && npm run build:ui && node -e \"require('fs').chmodSync('dist/bin/codegraph.js', 0o755)\"",
-    "build:ui": "npm run build --workspace ui && node scripts/check-ui-build.mjs",
-    "build:lib": "npm run build:lib --workspace ui",
+    "build:ui": "cd ui && npm run build && cd .. && node scripts/check-ui-build.mjs",
+    "build:lib": "cd ui && npm run build:lib",
     "preuninstall": "node dist/bin/uninstall.js",
     "copy-assets": "node -e \"const fs=require('fs');fs.mkdirSync('dist/db',{recursive:true});fs.copyFileSync('src/db/schema.sql','dist/db/schema.sql');fs.mkdirSync('dist/extraction/wasm',{recursive:true});fs.readdirSync('src/extraction/wasm').filter(f=>f.endsWith('.wasm')).forEach(f=>fs.copyFileSync('src/extraction/wasm/'+f,'dist/extraction/wasm/'+f))\"",
     "dev": "tsc --watch",


### PR DESCRIPTION
`npm run build --workspace ui` re-enters the **root** `build` script under bun, so `bun run build` recurses until it dies. npm is unaffected, which is why this has gone unnoticed.

Two behaviours combine:

1. bun rewrites `npm run …` to `bun run …` inside a package script.
2. bun ignores `--workspace`.

So `build:ui` runs `bun run build` in the root package — which calls `build:ui` again.

### Reproduction

Clean checkout of `main` at `cd4e65b`, on Windows x64, bun 1.4.2:

```
$ bun run build:ui        # killed at 120s
error: script "build" exited with code 143
error: script "build:ui" exited with code 143
...
```

40 nested `build` / `build:ui` invocations before the timeout killed it. Without a timeout it runs until it exits 255.

### The change

Name the workspace by directory, which does the same thing under either runtime:

```diff
-    "build:ui": "npm run build --workspace ui && node scripts/check-ui-build.mjs",
-    "build:lib": "npm run build:lib --workspace ui",
+    "build:ui": "cd ui && npm run build && cd .. && node scripts/check-ui-build.mjs",
+    "build:lib": "cd ui && npm run build:lib",
```

`build:lib` had the same shape and the same fix; its script already expects `ui` as its cwd.

### After

Same tree, same command:

```
$ bun run build:ui
../dist/viewer/assets/index-D-yfaNsy.js   494.80 kB │ gzip: 165.88 kB
✓ built in 1.95s
[check-ui-build] dist/viewer ok (index.html + 2 referenced asset(s)); dist/extraction/wasm ok (29 grammars); dist/ engine intact
exit=0
```

`npm run build:ui` and `npm run build` are unchanged in behaviour — `cd ui && npm run build` resolves the same workspace script npm was already running.
