### PR TITLE
fix(resolution): resolve Python aliased module imports (#1626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fixed a long-running `codegraph ui` session serving a symbol that a sync had already deleted. The viewer keeps one connection to your index open, and its in-memory lookup didn't notice when another process — your agent's sync, or `codegraph sync` — rewrote the file underneath it, so a symbol screen could keep showing a body with no callers while search correctly reported it had moved. Because a symbol's identity includes the line it starts on, this happened after almost any edit above it.
 
+- Python calls made through a renamed import are no longer missing from the graph. After `from package import module as alias`, a call like `alias.func()` produced no call edge, so `codegraph_callers` could report a function as uncalled while a live caller reached it under the alias — the same wrong answer to "is this dead code?" that the unaliased form used to give. Thanks @JoeyNPP. (#1626)
+
 ## [1.6.0] - 2026-08-26
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,7 +251,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fixed a long-running `codegraph ui` session serving a symbol that a sync had already deleted. The viewer keeps one connection to your index open, and its in-memory lookup didn't notice when another process — your agent's sync, or `codegraph sync` — rewrote the file underneath it, so a symbol screen could keep showing a body with no callers while search correctly reported it had moved. Because a symbol's identity includes the line it starts on, this happened after almost any edit above it.
 
-- Python calls made through a renamed import are no longer missing from the graph. After `from package import module as alias`, a call like `alias.func()` produced no call edge, so `codegraph_callers` could report a function as uncalled while a live caller reached it under the alias — the same wrong answer to "is this dead code?" that the unaliased form used to give. Thanks @JoeyNPP. (#1626)
+- Python calls and file dependencies through `from package import module as alias` now appear in the graph, so renamed imports no longer hide live callers or imported modules. Thanks @JoeyNPP. (#1626)
 
 ## [1.6.0] - 2026-08-26
 

--- a/__tests__/resolution.test.ts
+++ b/__tests__/resolution.test.ts
@@ -1558,7 +1558,7 @@ def add_outcome(row):
       expect(buildMapCalls.map((e) => e.target)).not.toContain(ledgerAppend!.id);
     });
 
-    it('resolves Python module-attribute calls through an ALIASED import (#1626)', async () => {
+    it('resolves Python module-attribute calls and file imports through an alias (#1626)', async () => {
       // #715 taught resolvePythonModuleMember to fall back to a dotted-module
       // file lookup, which fixed `from pkg import module` (#578). The aliased
       // form still missed: the module path was rebuilt from the LOCAL name, so
@@ -1606,6 +1606,15 @@ def plain_import_caller():
       const plainCalls = cg.getOutgoingEdges(plainCaller!.id).filter((e) => e.kind === 'calls');
       expect(plainCalls).toHaveLength(1);
       expect(cg.getNode(plainCalls[0]!.target)?.name).toBe('top_func');
+
+      // The file dependency must resolve too: fixing only the member lookup
+      // restores calls but leaves the aliased module's imports edge missing.
+      const mainFile = cg.getNodesByKind('file').find((n) => n.filePath === 'main.py');
+      const moduleFile = cg.getNodesByKind('file').find((n) => n.filePath.replace(/\\/g, '/') === 'pkg/module.py');
+      expect(mainFile).toBeDefined();
+      expect(moduleFile).toBeDefined();
+      const fileImports = cg.getOutgoingEdges(mainFile!.id).filter((e) => e.kind === 'imports');
+      expect(fileImports.map((e) => e.target)).toContain(moduleFile!.id);
     });
 
     it('attaches Go methods to their receiver type across files (#583, cross-file half)', async () => {

--- a/__tests__/resolution.test.ts
+++ b/__tests__/resolution.test.ts
@@ -1558,6 +1558,56 @@ def add_outcome(row):
       expect(buildMapCalls.map((e) => e.target)).not.toContain(ledgerAppend!.id);
     });
 
+    it('resolves Python module-attribute calls through an ALIASED import (#1626)', async () => {
+      // #715 taught resolvePythonModuleMember to fall back to a dotted-module
+      // file lookup, which fixed `from pkg import module` (#578). The aliased
+      // form still missed: the module path was rebuilt from the LOCAL name, so
+      // `from pkg import module as alias` looked for `pkg.alias` — a file that
+      // does not exist — and the call landed in unresolved_refs. The plain
+      // `import top as alias` form is a namespace import and binds at `source`,
+      // so it was already correct; it is pinned here so the fix can't regress it.
+      fs.mkdirSync(path.join(tempDir, 'pkg'));
+      fs.writeFileSync(path.join(tempDir, 'pkg', '__init__.py'), '');
+      fs.writeFileSync(
+        path.join(tempDir, 'pkg', 'module.py'),
+        'def func():\n    return 1\n'
+      );
+      fs.writeFileSync(
+        path.join(tempDir, 'top_level.py'),
+        'def top_func():\n    return 2\n'
+      );
+      fs.writeFileSync(
+        path.join(tempDir, 'main.py'),
+        `from pkg import module as mod_alias
+import top_level as tl
+
+
+def from_import_caller():
+    return mod_alias.func()
+
+
+def plain_import_caller():
+    return tl.top_func()
+`
+      );
+
+      cg = await CodeGraph.init(tempDir, { index: true });
+
+      const fromImportCaller = cg.getNodesByKind('function').filter((n) => n.name === 'from_import_caller')[0];
+      expect(fromImportCaller).toBeDefined();
+      const aliasCalls = cg.getOutgoingEdges(fromImportCaller!.id).filter((e) => e.kind === 'calls');
+      expect(aliasCalls).toHaveLength(1);
+      const aliasTarget = cg.getNode(aliasCalls[0]!.target);
+      expect(aliasTarget?.name).toBe('func');
+      expect(aliasTarget?.filePath.replace(/\\/g, '/')).toBe('pkg/module.py');
+
+      const plainCaller = cg.getNodesByKind('function').filter((n) => n.name === 'plain_import_caller')[0];
+      expect(plainCaller).toBeDefined();
+      const plainCalls = cg.getOutgoingEdges(plainCaller!.id).filter((e) => e.kind === 'calls');
+      expect(plainCalls).toHaveLength(1);
+      expect(cg.getNode(plainCalls[0]!.target)?.name).toBe('top_func');
+    });
+
     it('attaches Go methods to their receiver type across files (#583, cross-file half)', async () => {
       // In Go a type's methods are commonly declared in a different file from the
       // `type` declaration (`type Box` in box.go, `func (b *Box) Get()` in

--- a/src/resolution/import-resolver.ts
+++ b/src/resolution/import-resolver.ts
@@ -1892,9 +1892,12 @@ function resolveModuleImportToFile(
       modulePath = imp.source;
     } else if (ref.language === 'python') {
       // `from . import certs` — the imported NAME is a submodule of the source.
+      // As in resolvePythonModuleMember, use the exported name so an alias
+      // still links to the real module file (#1626).
+      const moduleName = imp.exportedName === '*' ? imp.localName : imp.exportedName;
       modulePath = imp.source.endsWith('.')
-        ? imp.source + imp.localName
-        : imp.source + '.' + imp.localName;
+        ? imp.source + moduleName
+        : imp.source + '.' + moduleName;
     } else {
       // A named TS/JS import binds a symbol, not a module — leave it alone.
       continue;

--- a/src/resolution/import-resolver.ts
+++ b/src/resolution/import-resolver.ts
@@ -1692,11 +1692,19 @@ function resolvePythonModuleMember(
     // `import mod` / `import numpy as np` bind the module at `source` itself;
     // `from . import certs` / `from pkg import mod` bind a SUBMODULE whose
     // dotted path is the source joined with the imported name.
+    //
+    // Join with the EXPORTED name, not the local one: under
+    // `from pkg import mod as alias` the receiver is `alias` but the module on
+    // disk is `pkg.mod`, and building `pkg.alias` looked for a file that does
+    // not exist — so the aliased form dropped its `calls` edge while the plain
+    // form (where the two names coincide) worked (#1626). For an unaliased
+    // import the two are identical, so this changes nothing there.
+    const moduleName = imp.exportedName === '*' ? imp.localName : imp.exportedName;
     const modulePath = imp.isNamespace
       ? imp.source
       : imp.source.endsWith('.')
-        ? imp.source + imp.localName
-        : imp.source + '.' + imp.localName;
+        ? imp.source + moduleName
+        : imp.source + '.' + moduleName;
 
     // resolveImportPath only maps RELATIVE dotted paths (`.mod`, `..pkg.mod`); an
     // ABSOLUTE package path (`pkg.module` from `from pkg import module`, or a bare


### PR DESCRIPTION
## Summary
Lands upstream [#1635](https://github.com/colbymchenry/codegraph/pull/1635) (cherry-pick `-x` of `f7a8940e`) and extends it so aliased Python from-imports restore both `calls` and file→file `imports` edges.

- `resolvePythonModuleMember` now joins with the **exported** name (`from pkg import mod as alias` → `pkg.mod`, not `pkg.alias`) — from #1635
- Same join rule applied in `resolveModuleImportToFile` so the imports edge is restored too
- Regression test pins both aliased forms from #1626 (`from … import … as …` and `import … as …`); plain `import x as y` already worked on main and stays green

Fixes #1626. Supersedes #1635.

## Linux verify (fail → pass)
Fixture: aliased from-import caller, unaliased control, plain `import as` caller.

| Form | Before | After |
|---|---|---|
| `from services import kit as kit_service` → `kit_service.sync_subscribers()` | no `calls`, no `imports` | `calls` + `imports` to `services/kit.py` |
| `from services import kit` → `kit.sync_subscribers()` | works | works |
| `import build_api_contract as builder` → `builder.source_fingerprint()` | works on main | still works |

`npx vitest run __tests__/resolution.test.ts -t 1626` — pass.

## Commits
- `57d56859` cherry-pick of #1635 (`f7a8940e`)
- `cfe8fb7b` Colby follow-up: imports-edge twin site + test/changelog