### PR TITLE
test(resolution): close graphs and connections, and always remove the temp project

### DIFF
--- a/__tests__/resolution.test.ts
+++ b/__tests__/resolution.test.ts
@@ -28,12 +28,15 @@ describe('Resolution Module', () => {
   });
 
   afterEach(() => {
-    // Clean up
+    // destroy() is an alias for close(): it releases the database but leaves
+    // the project directory on disk, so removing tempDir cannot be the
+    // alternative to it. Both must run, on every test. maxRetries covers
+    // Windows releasing the SQLite handles slightly after close() returns.
     if (cg) {
       cg.destroy();
-    } else if (fs.existsSync(tempDir)) {
-      fs.rmSync(tempDir, { recursive: true });
+      cg = undefined as unknown as CodeGraph;
     }
+    fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5 });
   });
 
   describe('Name Matcher', () => {
@@ -3741,6 +3744,7 @@ int run() {
             and src.kind = 'file'
             and src.file_path = 'src/main.cpp'
         `).all() as Array<{ dstKind: string; dstPath: string }>;
+        db.close();
         const resolvedToHeader = rows.find(
           (r) => r.dstKind === 'file' && r.dstPath === 'include/utils.h'
         );
@@ -3751,6 +3755,13 @@ int run() {
         );
         expect(stdlibFile).toBeUndefined();
       } finally {
+        // The graph opened on tempProject has to be closed here: the outer
+        // afterEach runs after this finally, so on Windows the still-open
+        // database makes the removal fail with EPERM.
+        if (cg) {
+          cg.close();
+          cg = undefined as unknown as CodeGraph;
+        }
         fs.rmSync(tempProject, { recursive: true, force: true });
       }
     });
@@ -3788,6 +3799,7 @@ class Both : public Base<char>, public Plain {}; // templated + plain in one cla
             where e.kind = 'extends'`
         )
         .all() as Array<{ fromName: string; toName: string }>;
+      db.close();
       const has = (from: string, to: string) =>
         edges.some((r) => r.fromName === from && r.toName === to);
 
@@ -3850,11 +3862,19 @@ class Both : public Base<char>, public Plain {}; // templated + plain in one cla
             and src.kind = 'file'
             and src.file_path = 'src/page.php'
         `).all() as Array<{ dstKind: string; dstPath: string }>;
+        db.close();
         const resolved = rows.find(
           (r) => r.dstKind === 'file' && r.dstPath === 'src/lib.php'
         );
         expect(resolved, 'page.php → src/lib.php imports edge missing').toBeDefined();
       } finally {
+        // The graph opened on tempProject has to be closed here: the outer
+        // afterEach runs after this finally, so on Windows the still-open
+        // database makes the removal fail with EPERM.
+        if (cg) {
+          cg.close();
+          cg = undefined as unknown as CodeGraph;
+        }
         fs.rmSync(tempProject, { recursive: true, force: true });
       }
     });
@@ -3884,11 +3904,19 @@ class Both : public Base<char>, public Plain {}; // templated + plain in one cla
             and src.kind = 'file'
             and src.file_path = 'index.php'
         `).all() as Array<{ dstKind: string; dstPath: string }>;
+        db.close();
         expect(
           rows.find((r) => r.dstKind === 'file' && r.dstPath === 'inc/db.php'),
           'index.php → inc/db.php imports edge missing'
         ).toBeDefined();
       } finally {
+        // The graph opened on tempProject has to be closed here: the outer
+        // afterEach runs after this finally, so on Windows the still-open
+        // database makes the removal fail with EPERM.
+        if (cg) {
+          cg.close();
+          cg = undefined as unknown as CodeGraph;
+        }
         fs.rmSync(tempProject, { recursive: true, force: true });
       }
     });
@@ -3923,11 +3951,19 @@ class Both : public Base<char>, public Plain {}; // templated + plain in one cla
             and src.kind = 'file'
             and src.file_path = 'app/page.php'
         `).all() as Array<{ dstKind: string; dstPath: string }>;
+        db.close();
         expect(
           rows.find((r) => r.dstKind === 'file' && r.dstPath === 'lib/inc/db.php'),
           'app/page.php must NOT mis-connect to unrelated lib/inc/db.php'
         ).toBeUndefined();
       } finally {
+        // The graph opened on tempProject has to be closed here: the outer
+        // afterEach runs after this finally, so on Windows the still-open
+        // database makes the removal fail with EPERM.
+        if (cg) {
+          cg.close();
+          cg = undefined as unknown as CodeGraph;
+        }
         fs.rmSync(tempProject, { recursive: true, force: true });
       }
     });


### PR DESCRIPTION
Fixes #1777.

On Windows, `__tests__/resolution.test.ts` leaks **171 temp directories per run** and fails **4 of its 200 tests**. Both come from the same thing: something still holds the SQLite database open when the code that removes its directory runs.

## Measured

Windows 11 Pro 26200, Node 24 (the bundled runtime), vitest 2.1.9, `TEMP` redirected to a private directory for the vitest process so concurrent work on the machine could not contaminate the count.

| | directories left in TEMP | tests |
| --- | --- | --- |
| `main` (`7be699c`) | **171** | 4 failed, 196 passed |
| this branch | **0** | **200 passed** |

The four failures on `main` are pre-existing, not introduced here:

```
FAIL  C/C++ Import Resolution > connects #include to the real header file via include-dir scan (end-to-end)
FAIL  PHP Include Resolution > resolves require_once to a file→file imports edge (#660)
FAIL  PHP Include Resolution > resolves a subdirectory include path to the correct file (#660)
FAIL  PHP Include Resolution > does not mis-connect an unresolvable include to a same-named file elsewhere (#660)
Error: EPERM, Permission denied: ...\codegraph-php-subdir-mdiGnx
```

## Three changes

**1. `afterEach` removes the project on every test.** It removed `tempDir` only in the `else` branch of `if (cg)`, and `cg` is `describe`-scoped and never reset — so from the first test that assigns it (the `CodeGraph.init` around line 1105) onward, every later test kept its directory.

The reason the `else` looked reasonable is worth stating: `destroy()` is a **deprecated alias for `close()`**. It releases the database and leaves the project on disk; `uninitialize()` is the method that removes it. So the `if` branch was never cleaning up anything, and making removal its alternative meant removal almost never ran.

**2. Five `DatabaseConnection.open` calls are closed.** None of them were. Making the removal unconditional immediately converts the silent leak into `EPERM`, so these have to be fixed in the same change — a second connection to the same database keeps a handle on the directory. Each is now closed once its rows are materialised, before the assertions that use them.

**3. Four nested tests close their graph before removing their own project.** These create their own `tempProject`, assign the outer `cg`, and remove the directory in a `finally` that runs *before* the outer `afterEach` closes `cg`. The graph is now closed inside that `finally`.

## Note on the removal no longer being silent

`afterEach` now lets a failed removal throw rather than swallowing it. That is deliberate: the swallowed failure is what let this run unnoticed, and it was hiding a real second defect (the unclosed connections), not just noise. `force: true, maxRetries: 5` covers Windows releasing handles slightly after `close()` returns.

Related: #1722 was closed as "tests leak file handles into their temp projects: 24 fail with EPERM on Windows". This is the same underlying behaviour in this file, where it manifested as a silent leak instead of a failure.
