### PR TITLE
test(mcp): reap the daemon-mode writer so the temp project can be removed

### DIFF
--- a/__tests__/mcp-writer-lock.test.ts
+++ b/__tests__/mcp-writer-lock.test.ts
@@ -34,6 +34,15 @@ function spawnMcp(
   return { child, getStderr: () => stderr };
 }
 
+function readWriterPid(root: string): number | undefined {
+  try {
+    const { pid } = JSON.parse(fs.readFileSync(getWriterPidPath(root), 'utf8')) as { pid?: number };
+    return typeof pid === 'number' ? pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 describe('issue #1740 — direct-mode writer lock', () => {
   let tempDir: string;
   let realRoot: string;
@@ -50,12 +59,22 @@ describe('issue #1740 — direct-mode writer lock', () => {
   });
 
   afterEach(async () => {
+    // In daemon mode the writer is a third process, spawned by the proxies and
+    // never recorded in `children` — the second test asserts exactly that. It
+    // holds the index open, so killing only the proxies leaves tempDir
+    // unremovable. writer.pid names it; the removal must not be silenced,
+    // because a swallowed failure here is what let this leak run unnoticed.
+    const childPids = new Set(children.map((c) => c.pid));
+    const writerPid = readWriterPid(realRoot);
     for (const c of children) {
       try { c.kill('SIGTERM'); } catch { /* ignore */ }
     }
     children.length = 0;
+    if (writerPid !== undefined && !childPids.has(writerPid)) {
+      try { process.kill(writerPid, 'SIGTERM'); } catch { /* already exited */ }
+    }
     await sleep(300);
-    try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 10 });
   });
 
   it('second CODEGRAPH_NO_DAEMON serve --mcp exits with writer-lock error', async () => {


### PR DESCRIPTION
Fixes #1782.

`__tests__/mcp-writer-lock.test.ts` leaves a live `serve --mcp` daemon running after every run, and the temp project it holds open can never be removed. Both tests pass while this happens, which is why it has gone unnoticed.

## Measured

Windows 11 Pro 26200, Node 24 (the bundled runtime), vitest 2.1.9, `TEMP` redirected to a private directory for the vitest process so nothing else on the machine could contaminate the counts.

| | temp dirs left | `serve --mcp` processes | tests |
| --- | --- | --- | --- |
| `main` (`7be699c`) | **1** | **+1** | 2 passed |
| this branch | **0** | **+0** | 2 passed |

One directory and one orphaned process per run, on a green suite.

## Cause

`afterEach` reaps only what the test pushed into `children`:

```ts
for (const c of children) {
  try { c.kill('SIGTERM'); } catch { /* ignore */ }
}
```

The second test runs *without* `CODEGRAPH_NO_DAEMON`, so the two processes it spawns are proxies and the writer is a third process — the daemon. The test asserts this itself:

```ts
expect(lock.mode).toBe('daemon');
expect(lock.pid).not.toBe(a.child.pid);
expect(lock.pid).not.toBe(b.child.pid);
```

Nothing kills that third process. It stays attached to `--path <tempDir>` with `codegraph.db`, `-wal` and `-shm` open, so the following `fs.rmSync` fails on Windows — and `catch { /* ignore */ }` hides the failure.

The first test is unaffected: `CODEGRAPH_NO_DAEMON=1` makes the spawned child itself the writer, it is in `children`, and its directory is removed.

## Fix

`writer.pid` already names the daemon, and the test already parses that file. `afterEach` now reads it before killing the proxies and sends `SIGTERM` to the writer as well, when it is not one of the children.

The removal is also no longer swallowed. That is deliberate — the swallowed error is exactly what turned a reproducible process leak into an invisible one. `maxRetries: 10` covers Windows releasing handles after the daemon exits.

## Note

Killing by a pid read from a file carries the usual recycling risk if the file is stale. The window here is one test, and the guard is that the pid is skipped when it belongs to a child the test already killed. If you would rather have the daemon reaped by a job object or a handshake, I am happy to rework it.

## Related

- #1777 / #1786 — `resolution.test.ts`, same symptom class, different cause (cleanup on the wrong branch of an `if`, plus never-closed connections).
- #1722 (closed) — "Tests leak file handles into their temp projects: 24 fail with EPERM on Windows". Same underlying Windows behaviour; that one surfaced as failures, this one does not surface at all.
