### PR TITLE
fix(extraction): keep git-aware scans working before Git 2.36 (#1549)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `codegraph install` now honors `CLAUDE_CONFIG_DIR` and `CODEX_HOME` for global Claude Code and Codex setup so CodeGraph loads in your chosen profile (thanks @seanchann; #1627).
 
+- Files opted in with `includeIgnored` now stay indexed on Git older than 2.36, and embedded repositories remain visible to the watcher (thanks @maxmilian and @newshowardz777; #1549).
+
 #### Screens, links and navigation
 
 - **Where the app goes after login is a fork, not two always-es.** A navigation whose destination comes back from a helper — `router.replace(await resolvePostLoginRoute())` over `return (await hasSeenWelcome(…)) ? '/home/' : '/welcome/'` — drew both screens with no condition, reading as if the welcome screen always shows. The two arms share a line, and only a column can tell them apart; each synthesized edge now carries its literal's own position, so the guard reader says which arm it is: `WHEN await hasSeenWelcome(…)` → home, and its negation → welcome. And the scan starts at the helper's body, so a literal-union return type — `Promise<'/welcome/' | '/home/'>`, whose routes are string literals too, written first — no longer stands in for the navigation itself. Re-index after upgrading to pick the positions up.

--- a/__tests__/extraction-old-git.test.ts
+++ b/__tests__/extraction-old-git.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression: git older than 2.36 rejects `ls-files -s --recurse-submodules` (#1549).
+ *
+ * Kept in its own file rather than appended to extraction.test.ts: that suite
+ * loads every tree-sitter grammar in `beforeAll`, and running a git-scan case
+ * after it pushed the worker past its memory ceiling.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { execFileSync } from 'child_process';
+import { scanDirectory } from '../src/extraction';
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-test-'));
+}
+
+// git < 2.36 rejects `ls-files -s --recurse-submodules` outright: the guard in
+// builtin/ls-files.c listed `show_stage` among the modes that die, and it was
+// only dropped in 2.36. The die is unconditional — it does not check whether the
+// repo has submodules — so on Ubuntu 22.04 (git 2.34.1), Debian 11 (2.30.2) and
+// older, every call threw, `getGitVisibleFiles` swallowed it, and the whole
+// git-visible path went with it: `includeIgnored`, gitlink recursion and the
+// `codegraph.json` `include` allowlist all silently stopped applying (#1549).
+//
+// A PATH shim reproduces that on any git version, which is what makes this
+// testable in CI at all.
+describe('Old git without `ls-files -s --recurse-submodules` support (#1549)', () => {
+  let tempDir: string;
+  let originalPath: string | undefined;
+
+  const runGit = (cwd: string, ...args: string[]) =>
+    execFileSync('git', args, { cwd, stdio: 'pipe' });
+
+  const makeRepo = (dir: string, base: string) => {
+    fs.mkdirSync(dir, { recursive: true });
+    runGit(dir, 'init', '-q');
+    runGit(dir, 'config', 'user.email', 'test@test.com');
+    runGit(dir, 'config', 'user.name', 'Test');
+    fs.writeFileSync(path.join(dir, `${base}.ts`), `export const ${base} = 1;`);
+    runGit(dir, 'add', '-A');
+    runGit(dir, 'commit', '-q', '-m', `${base} init`);
+  };
+
+  /** A `git` that dies exactly like < 2.36 when it sees -s with --recurse-submodules. */
+  const installOldGitShim = () => {
+    const shimDir = path.join(tempDir, '.shim');
+    fs.mkdirSync(shimDir, { recursive: true });
+    const realGit = execFileSync('which', ['git']).toString().trim();
+    const shim = path.join(shimDir, 'git');
+    fs.writeFileSync(
+      shim,
+      [
+        '#!/bin/sh',
+        'for a in "$@"; do',
+        '  [ "$a" = "--recurse-submodules" ] && rs=1',
+        '  [ "$a" = "-s" ] && st=1',
+        'done',
+        'if [ -n "$rs" ] && [ -n "$st" ]; then',
+        '  echo "fatal: ls-files --recurse-submodules unsupported mode" >&2',
+        '  exit 128',
+        'fi',
+        `exec ${JSON.stringify(realGit)} "$@"`,
+      ].join('\n'),
+    );
+    fs.chmodSync(shim, 0o755);
+    originalPath = process.env.PATH;
+    process.env.PATH = `${shimDir}:${originalPath ?? ''}`;
+  };
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    if (originalPath !== undefined) process.env.PATH = originalPath;
+    originalPath = undefined;
+  });
+
+  it('still honours includeIgnored when `ls-files --recurse-submodules` is unsupported', () => {
+    const root = path.join(tempDir, 'root');
+    makeRepo(root, 'a');
+    // An embedded repo that .gitignore excludes but codegraph.json opts back in.
+    makeRepo(path.join(root, 'dir_b'), 'b');
+    fs.writeFileSync(path.join(root, '.gitignore'), 'dir_b/\n');
+    fs.writeFileSync(
+      path.join(root, 'codegraph.json'),
+      JSON.stringify({ includeIgnored: ['dir_b/'] }),
+    );
+    runGit(root, 'add', '-A');
+    runGit(root, 'commit', '-q', '-m', 'ignore dir_b');
+
+    // Baseline: the real git resolves both files.
+    const withRealGit = scanDirectory(root);
+    expect(withRealGit).toContain('a.ts');
+    expect(withRealGit).toContain(path.join('dir_b', 'b.ts'));
+
+    installOldGitShim();
+
+    // The opted-in file must survive the unsupported-mode failure, not vanish.
+    const withOldGit = scanDirectory(root);
+    expect(withOldGit).toContain('a.ts');
+    expect(withOldGit).toContain(path.join('dir_b', 'b.ts'));
+  });
+});

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -925,9 +925,7 @@ export function discoverEmbeddedRepoRoots(rootDir: string): string[] {
     // same way collectGitFiles does, keeping watcher scope == indexer scope.
     // (#1031, #1033)
     try {
-      const staged = execFileSync(
-        'git',
-        ['ls-files', '-z', '-s', '--recurse-submodules'],
+      const staged = lsFilesStaged(
         { cwd: repoAbs, encoding: 'utf-8', timeout: 30000, maxBuffer: 50 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
       );
       const repoIgnore = buildDefaultIgnore(repoAbs);
@@ -1041,6 +1039,30 @@ function findIgnoredEmbeddedRepos(repoDir: string, includeIgnored: Ignore | null
 }
 
 /**
+ * `git ls-files -z -s`, expanding submodules where git allows it.
+ *
+ * `--recurse-submodules` could not be combined with `-s` before git 2.36:
+ * `builtin/ls-files.c` listed `show_stage` among the modes that die, and the
+ * check is unconditional — it does not look at whether the repo actually has
+ * submodules, so every call fails on older git. Ubuntu 22.04 LTS (2.34.1) and
+ * Debian 11 (2.30.2) are both below that line.
+ *
+ * Letting the throw escape cost far more than submodule expansion: it unwound
+ * the whole git-visible pass, so `includeIgnored`, gitlink recursion and the
+ * `codegraph.json` include allowlist silently stopped applying and files went
+ * missing from the index with no error (#1549). Retry without the flag instead
+ * — `-s` is the part that matters here, since gitlink detection reads the mode
+ * bits, and embedded repos are reached through the gitlink recursion anyway.
+ */
+function lsFilesStaged(gitOpts: Parameters<typeof execFileSync>[2]): string {
+  try {
+    return execFileSync('git', ['ls-files', '-z', '-s', '--recurse-submodules'], gitOpts) as unknown as string;
+  } catch {
+    return execFileSync('git', ['ls-files', '-z', '-s'], gitOpts) as unknown as string;
+  }
+}
+
+/**
  * Collect git-visible files (tracked + untracked, .gitignore-respected) from the
  * git repository rooted at `repoDir`, adding each to `files` with `prefix`
  * prepended so paths stay relative to the original scan root.
@@ -1085,7 +1107,7 @@ function collectGitFiles(repoDir: string, prefix: string, files: Set<string>, em
   // on disk → those files are silently dropped from the index. (#541) With -s the
   // path follows a TAB after the `<mode> <object> <stage>` prefix.
   const gitlinkRels: string[] = [];
-  const tracked = execFileSync('git', ['ls-files', '-z', '-s', '--recurse-submodules'], gitOpts);
+  const tracked = lsFilesStaged(gitOpts);
   for (const entry of tracked.split('\0')) {
     if (!entry) continue;
     const tab = entry.indexOf('\t');


### PR DESCRIPTION
Fixes #1549.

Git older than 2.36 rejects `git ls-files -z -s --recurse-submodules`, causing indexing to fall back to a filesystem walk that drops files opted in through `includeIgnored`; watcher discovery also misses tracked embedded repositories. Both call sites now use the upstream `lsFilesStaged()` helper, retrying as `git ls-files -z -s` so gitlink mode bits remain available.

Lands @maxmilian's existing #1604, cherry-picked from `27c149524d968485164fb43bdec994fdb9323c75` onto `cece0720e3bc9a133a6a26aa2571607da1545fc3`. The upstream test is byte-for-byte unchanged, and current main's extraction/watcher changes, including #1728, are preserved. The changelog conflict is resolved under Unreleased, and the existing collection-function comment remains attached to that function. The landing commit is authored as Colby McHenry, with Max Hsu and @newshowardz777 credited as co-authors.

The issue was reported on August 13 against CodeGraph 1.5.0; this reproduction was run on September 8 against current main, after the August 26 release of 1.6.0. The accurate Git boundary is **2.36**: `show_stage` is rejected in the [Git 2.35 source](https://github.com/git/git/blob/v2.35.0/builtin/ls-files.c#L728-L731) and removed from that rejection in [Git 2.36](https://github.com/git/git/blob/v2.36.0/builtin/ls-files.c#L728-L731).

Linux x86_64 verification used Node 22.19.0 and Git 2.47.3. A PATH shim exits 128 with `fatal: ls-files --recurse-submodules unsupported mode` whenever `-s` and `--recurse-submodules` occur together, delegating other commands to real Git. Both arms used the same persistent fixtures and identical shim:

| Probe under old-Git shim | Before: current main | After: this PR |
| --- | --- | --- |
| `scanDirectory()` with `includeIgnored: ["dir_b/"]` | `["a.ts"]` | `["a.ts", "dir_b/b.ts"]` |
| Watcher discovery of tracked `lib/` gitlink without `.gitmodules` | `[]` | `["lib/"]` |

Real-Git controls return both files and the watcher root in both arms. The unchanged upstream regression fails before the fix with `expected [ 'a.ts' ] to include 'dir_b/b.ts'` and passes afterward.

Validation: **93 selected tests passed**, plus TypeScript checking:

- `npx vitest run __tests__/extraction-old-git.test.ts` — 1 passed.
- `npx vitest run __tests__/multi-repo-workspace.test.ts __tests__/include-ignored-config.test.ts __tests__/include-config.test.ts __tests__/exclude-config.test.ts` — 69 passed.
- `npx vitest run __tests__/extraction.test.ts -t 'Directory Exclusion|Nested .gitignore node_modules exclusion|Git Submodules|Nested gitlink repos|Nested non-submodule git repos'` — 23 passed; 617 outside the selection.
- `npx tsc --noEmit` — passed.

Fail/pass logs and the persistent reproduction are retained in `.git/forge-1549/` in the Linux workspace.
