### PR TITLE
fix(cli): index <path> never rebuilds an ancestor instead (#1524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 #### MCP / indexing
 
+- `codegraph index <path>` now refuses uninitialized paths and names the nearest initialized parent instead of silently rebuilding it; thanks @danusha2345. (#1524, #1689)
+
 - Sync now recovers the same connections as a clean index after interrupted reference resolution, including inherited calls and callbacks that previously stayed missing. (#1577)
 
 - `codegraph_explore` now re-serves source to fresh subagents and after context compaction, with cross-call dedup available only through an explicit `CODEGRAPH_EXPLORE_DEDUP=1` opt-in; thanks @danusha2345. (#1620, #1624)

--- a/__tests__/cli-index-explicit-path.test.ts
+++ b/__tests__/cli-index-explicit-path.test.ts
@@ -1,0 +1,64 @@
+/**
+ * `codegraph index <path>` rebuilds <path>, never an ancestor (#1524).
+ *
+ * The command used to resolve an uninitialized <path> upward to the nearest
+ * initialized parent and rebuild THAT under a normal "Done" — so
+ * `codegraph index child` from a monorepo re-indexed the whole container and
+ * never said so. An explicit path that is not initialized is now an error that
+ * names the ancestor it would have picked.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CodeGraph } from '../src';
+
+const BIN = path.resolve(__dirname, '../dist/bin/codegraph.js');
+
+function run(cwd: string, args: string[]) {
+  const r = spawnSync(process.execPath, [BIN, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, CODEGRAPH_NO_DAEMON: '1', CODEGRAPH_WASM_RELAUNCHED: '1', NO_COLOR: '1' },
+  });
+  return { status: r.status, out: (r.stdout ?? '') + (r.stderr ?? '') };
+}
+
+describe('codegraph index <path> (#1524)', () => {
+  let root: string;
+  let parent: string;
+  let child: string;
+
+  beforeAll(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-index-path-'));
+    parent = path.join(root, 'parent');
+    child = path.join(parent, 'child');
+    fs.mkdirSync(child, { recursive: true });
+    fs.writeFileSync(path.join(parent, 'p.py'), 'def parent_only():\n    return 1\n');
+    fs.writeFileSync(path.join(child, 'c.py'), 'def child_only():\n    return 2\n');
+    const cg = CodeGraph.initSync(parent);
+    await cg.indexAll();
+    cg.close();
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('refuses an explicit path that has no index of its own, naming the ancestor it would have rebuilt', () => {
+    const before = fs.statSync(path.join(parent, '.codegraph', 'codegraph.db')).mtimeMs;
+    const r = run(root, ['index', child, '--quiet']);
+    expect(r.status).toBe(1);
+    expect(r.out).toContain(`not initialized in ${child}`);
+    expect(r.out).toContain(parent);
+    // The parent's index was not touched.
+    expect(fs.statSync(path.join(parent, '.codegraph', 'codegraph.db')).mtimeMs).toBe(before);
+    expect(fs.existsSync(path.join(child, '.codegraph'))).toBe(false);
+  });
+
+  it('rebuilds the explicit path when it is initialized, and a bare `index` still resolves upward from a subdirectory', () => {
+    expect(run(root, ['index', parent, '--quiet']).status).toBe(0);
+    expect(run(child, ['index', '--quiet']).status).toBe(0);
+  });
+});

--- a/src/bin/codegraph.ts
+++ b/src/bin/codegraph.ts
@@ -791,7 +791,13 @@ program
   .option('-q, --quiet', 'Suppress progress output')
   .option('-v, --verbose', 'Show detailed worker lifecycle and memory info')
   .action(async (pathArg: string | undefined, options: { force?: boolean; quiet?: boolean; verbose?: boolean }) => {
-    const projectPath = resolveProjectPath(pathArg);
+    // An EXPLICIT path names the project to rebuild — it is never a hint to go
+    // looking for one. resolveProjectPath walks up to the nearest initialized
+    // ancestor, which is right for `codegraph query` run from a subdirectory,
+    // but for a full re-index it silently rebuilt the parent's graph under a
+    // normal "Done" when <path> had no index of its own (#1524). Only a bare
+    // `codegraph index` (cwd) may resolve upward.
+    const projectPath = pathArg ? path.resolve(pathArg) : resolveProjectPath();
 
     try {
       // Don't (re)index your home directory / a filesystem root (#845). --force
@@ -804,7 +810,12 @@ program
 
       if (!isInitialized(projectPath)) {
         error(`CodeGraph not initialized in ${projectPath}`);
-        info('Run "codegraph init" first');
+        const ancestor = pathArg ? resolveProjectPath(pathArg) : projectPath;
+        if (ancestor !== projectPath) {
+          info(`The nearest initialized project is ${ancestor} — pass that path to rebuild it, or run "codegraph init" in ${projectPath} to index it on its own.`);
+        } else {
+          info('Run "codegraph init" first');
+        }
         process.exit(1);
       }
 


### PR DESCRIPTION
## Summary
- Lands upstream [#1689](https://github.com/colbymchenry/codegraph/pull/1689) (`danusha2345`) onto current `main`: an **explicit** `codegraph index <path>` no longer walks up to rebuild a nearest initialized ancestor under a silent `Done`.
- Uninitialized explicit paths now exit 1, name the ancestor `resolveProjectPath` would have picked, and tell the user how to `init` the named path. Bare `codegraph index` (cwd) still resolves upward.
- Cherry-picked `6674d970` with CHANGELOG resolved for current Unreleased; author danusha2345 preserved.

Fixes #1524

## Test plan
- [x] Linux fail→pass: init parent only; `codegraph index .` from child exits 1, names parent, no child `.codegraph`, parent DB untouched
- [x] `npx vitest run __tests__/cli-index-explicit-path.test.ts` — 2 passed
- [x] Agency: do not merge this until ready; close #1689 as superseded when this lands