### PR TITLE
fix(kotlin): read a function's signature positionally (#1495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 #### Symbols, tests and the viewer
 
+- Kotlin functions and methods now carry their signature — `(params): ReturnType` — in `codegraph_explore`, `node` and the viewer, instead of no signature at all. Re-index Kotlin projects after upgrading. (#1495)
 - `codegraph affected` now finds Go, Python and JVM test files that previously went unreported, while preserving custom `--filter` behavior (thanks @danusha2345; #1507, #1688).
 
 - Calls inside declaration initializers in Kotlin, Java, TypeScript, JavaScript, Scala, Rust and Python now appear under the declaration that owns them, making callers and impact results more accurate after re-indexing with `codegraph index -f` (thanks @danusha2345; #1510, #1511).

--- a/codegraph-kernel/src/kotlin.rs
+++ b/codegraph-kernel/src/kotlin.rs
@@ -549,6 +549,39 @@ impl<'t> Walker<'t> {
             .any(|c| c.kind() == "modifiers" && self.text(c).contains("suspend"))
     }
 
+    /// `(params): ReturnType` — the positional read TreeSitterExtractor's
+    /// kotlin getSignature does (#1495): the `function_value_parameters` child,
+    /// then the type node that follows it before the body. Verbatim source text,
+    /// so it round-trips through parity byte-for-byte.
+    fn signature_of(&self, node: Node) -> Option<String> {
+        let mut params: Option<Node> = None;
+        let mut return_type: Option<Node> = None;
+        for i in 0..node.named_child_count() {
+            let Some(child) = node.named_child(i) else { continue };
+            if child.kind() == "function_value_parameters" {
+                params = Some(child);
+                continue;
+            }
+            if params.is_none() {
+                continue;
+            }
+            if matches!(child.kind(), "function_body" | "type_constraints") {
+                break;
+            }
+            if matches!(child.kind(), "user_type" | "nullable_type" | "function_type") {
+                return_type = Some(child);
+                break;
+            }
+        }
+        let params = params?;
+        let mut sig = self.text(params).to_string();
+        if let Some(rt) = return_type {
+            sig.push_str(": ");
+            sig.push_str(self.text(rt));
+        }
+        Some(sig)
+    }
+
     /// extractKotlinReturnType — positional: the first user_type/nullable_type
     /// AFTER function_value_parameters; function_body/type_constraints first →
     /// None; Unit/Nothing → None; `: T` generic params leak (preserve).
@@ -918,7 +951,7 @@ impl<'t> Walker<'t> {
         }
         let extra = Extra {
             docstring: preceding_docstring(node, self.src),
-            signature: None, // dead hook (zero fields)
+            signature: self.signature_of(node),
             visibility: Some(self.visibility_of(node)),
             is_async: Some(self.is_async(node)),
             is_static: Some(false), // kotlin isStatic is always false
@@ -943,7 +976,7 @@ impl<'t> Walker<'t> {
         let qualified_override = receiver.as_ref().map(|r| format!("{r}::{name}"));
         let extra = Extra {
             docstring: preceding_docstring(node, self.src),
-            signature: None,
+            signature: self.signature_of(node),
             visibility: Some(self.visibility_of(node)),
             is_async: Some(self.is_async(node)),
             is_static: Some(false),

--- a/src/extraction/languages/kotlin.ts
+++ b/src/extraction/languages/kotlin.ts
@@ -1,5 +1,5 @@
 import type { Node as SyntaxNode } from 'web-tree-sitter';
-import { getNodeText, getChildByField } from '../tree-sitter-helpers';
+import { getNodeText } from '../tree-sitter-helpers';
 import type { LanguageExtractor } from '../tree-sitter-types';
 
 /** Kotlin return types that can't be a chained-call receiver (no class to chain on). */
@@ -390,9 +390,26 @@ export const kotlinExtractor: LanguageExtractor = {
     return undefined;
   },
   getSignature: (node, source) => {
-    // Kotlin function signature: fun name(params): ReturnType
-    const params = getChildByField(node, 'function_value_parameters');
-    const returnType = getChildByField(node, 'type');
+    // Kotlin function signature: fun name(params): ReturnType. tree-sitter-kotlin
+    // exposes no field names, so both parts are found positionally, the way
+    // extractKotlinReturnType does (#1495): the `function_value_parameters`
+    // child, then the type node that follows it before the body.
+    let params: SyntaxNode | null = null;
+    let returnType: SyntaxNode | null = null;
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (!child) continue;
+      if (child.type === 'function_value_parameters') {
+        params = child;
+        continue;
+      }
+      if (!params) continue;
+      if (child.type === 'function_body' || child.type === 'type_constraints') break;
+      if (child.type === 'user_type' || child.type === 'nullable_type' || child.type === 'function_type') {
+        returnType = child;
+        break;
+      }
+    }
     if (!params) return undefined;
     let sig = getNodeText(params, source);
     if (returnType) {


### PR DESCRIPTION
Fixes #1495.

## Summary
Lands upstream [#1687](https://github.com/colbymchenry/codegraph/pull/1687) (`danusha2345:fix/1495-kotlin-signature`) onto current `main` as a Forge PR authored by Colby McHenry. Prefer landing over reinventing.

## Problem
`tree-sitter-kotlin` exposes no field names, so `getSignature`'s `getChildByField(node, 'function_value_parameters')` / `'type'` reads always missed and every Kotlin function/method was indexed with `signature: undefined`.

## Fix
Find the parameter list and return type positionally (same approach as `extractKotlinReturnType`) in both:
- `src/extraction/languages/kotlin.ts` (wasm)
- `codegraph-kernel/src/kotlin.rs` (`signature_of`, lockstep)

Only Forge delta vs #1687 tip: Rust doc-comment placement so `signature_of` / `return_type_of` keep their own docs.

## Linux verify (fail → pass)
Repro fixture (class method + top-level fun):

| Symbol | Before | After (wasm + kernel) |
| --- | --- | --- |
| `greet` | undefined | `(name: String): String` |
| `noReturn` | undefined | `(x: Int)` |
| `topLevel` | undefined | `(a: Int, b: Int): Int` |

Undefined signatures: **3 → 0**. Wasm/kernel parity PASS. Focused tests: 31 passed (Kotlin extraction + kernel-kotlin-parity + kernel-scaffold) with `CODEGRAPH_KERNEL_EXPECT=1`.

## Credits
Thanks @danusha2345 for #1687. This PR supersedes it once merged (agency pattern: do not merge that fork tip directly).