### PR TITLE
fix(resolution): Python module-qualified calls colliding with builtin methods

### DIFF
--- a/src/extraction/tree-sitter.ts
+++ b/src/extraction/tree-sitter.ts
@@ -4878,6 +4878,19 @@ export class TreeSitterExtractor {
               // (#1707). Calls inside arguments are visited independently.
               // Mirrored in the kernel's extract_call (tsjs/extractors.rs).
               return;
+            } else if (this.language === 'python' && receiver) {
+              // Any other receiver shape — attribute chain (`self.data`), subscript
+              // (`d[k]`), call chain (`rows.setdefault(k, []).append(x)`) — previously
+              // fell through to a bare methodName. A bare name matching a common
+              // list/dict/str method (`append`, `get`, `update`, ...) can exact-match
+              // an unrelated top-level project function sharing that name, fabricating
+              // a call edge (#66, same class as #1230/#1276, and the Python sibling
+              // of the TS/JS chain guard above (#1566)). Keep the receiver's source
+              // text as a qualifier so the ref can only resolve through
+              // import/module-member resolution, never the bare-name fallback; an
+              // unresolvable qualifier is a silent miss, never a wrong edge.
+              const receiverText = getNodeText(receiver, this.source).replace(/\s+/g, ' ').trim();
+              calleeName = receiverText ? `${receiverText}.${methodName}` : methodName;
             } else {
               calleeName = methodName;
             }

--- a/src/resolution/index.ts
+++ b/src/resolution/index.ts
@@ -2212,8 +2212,8 @@ export class ReferenceResolver {
         // OR the receiver is itself an imported project module — a module can
         // export a top-level function sharing a common collection-method name
         // (`ledger.append`, `from . import ledger`), and that call is a real
-        // project dependency, not `list.append` (#1681). Without this, the
-        // qualified ref never reaches resolveViaImport / resolvePythonModuleMember.
+        // project dependency, not `list.append` (#1681, same class as #66).
+        // Without this, the qualified ref never reaches resolveViaImport / resolvePythonModuleMember.
         if (PYTHON_BUILT_IN_METHODS.has(method)) {
           // A module-scope collection binding is stronger evidence than a
           // coincidentally matching class name (#1652). Only use this file's


### PR DESCRIPTION
## Summary
- \`isBuiltInOrExternal\`'s Python built-in-method filter treated any \`x.method()\` as a builtin (\`list.append\`, \`dict.update\`, etc.) whenever \`method\` matched a common collection method name, unless the capitalized receiver matched a known **class**. A real project **module** exporting a same-named top-level function (e.g. \`ledger.append\`) was dropped before \`resolveViaImport\`/\`resolvePythonModuleMember\` ever ran — a false negative (missing edge).
- Separately, the method-call extractor in \`tree-sitter.ts\` only preserved the qualified \`receiver.method\` shape for a plain-identifier receiver. A chained-call receiver (\`rows.setdefault(k, []).append(v)\`) degraded to a bare \`append\` ref, which then exact-matched an unrelated same-named project function — a false positive (fabricated edge).
- Rebased onto current \`main\`; the false-negative half is now largely superseded by \`isPythonProjectModule\` (#1681) already on \`main\`, so this PR's \`src/resolution/index.ts\` change is now just a comment cross-reference. The chained-receiver false-positive fix in \`src/extraction/tree-sitter.ts\` is still needed for Python — the existing TS/JS chain guard (#1566) does not cover it. \`__tests__/resolution.test.ts\` already carries the equivalent test upstream (#1681/#1683/#1748); no test changes needed here.

## Test plan
- [x] Full suite on the rebased branch: 4421 passed / 12 failed / 192 skipped — the 12 failures are pre-existing on a clean, unmodified \`main\` checkout (verified side-by-side, identical failing test names, all in unrelated Next.js/Express/React-Native UI-steps tests)
- [x] \`npm run build && npm test\` green for the two files this PR actually changes