### PR TITLE
fix(explore): report extension-less paths the index doesn't hold (#1830)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The prompt hook no longer injects unrelated projects when run from your home directory or a broader directory containing a stray workspace manifest. (#1454)
 
+- `codegraph_explore` now says so when a query names an extension-less file the index doesn't hold. A path like `scripts/deploy` has no extension on its last segment, so it failed the shape test that decides a span is a path beyond doubt — the name was left in the query, shredded into `scripts` and `deploy`, and the answer came back as a pile of unrelated source with no hint that the file you named was never consulted. Such a span is now checked against the project directory: if it is a real file, the answer carries the same `No indexed file uniquely matches ...` note a misspelled `src/foo.ts` already got. Slashed prose — `and/or`, `input/output`, `gen_server:call/2` — has no file behind it and is still left in the query untouched. (#1830)
+
 - Indexing now succeeds when Node.js's SQLite lacks FTS5, with search falling back to name and fuzzy matching; thanks @aniruddhaadak80. (#1532)
 
 - `codegraph_explore` now makes clear that suggested call counts are advisory, so agents keep exploring when an answer is incomplete; thanks @rongbc. (#1504, #1570)

--- a/__tests__/query-paths.test.ts
+++ b/__tests__/query-paths.test.ts
@@ -236,3 +236,84 @@ describe('extractQueryPaths — extension-less kebab basenames', () => {
     expect(out.strippedQuery).toBe('background-image-table then');
   });
 });
+
+/**
+ * Dotless slashed spans (#1830). `scripts/deploy` names a real file that the
+ * index does not hold (no recognized extension), but the shape test demands a
+ * dot-extension on the last segment — so the span was neither pinned NOR
+ * reported, and its fragments (`scripts`, `deploy`) went on to feed FTS. The
+ * agent got a pile of unrelated source with no hint that the file it named was
+ * never consulted. Shape alone cannot decide this (`and/or` is the same shape),
+ * so the caller injects an `existsOnDisk` predicate and the file's existence
+ * decides. These tests also pin that the predicate is genuinely CONSULTED —
+ * a predicate that is never called would make the whole arm vacuous.
+ */
+describe('extractQueryPaths — dotless slashed spans, decided on disk', () => {
+  /** Records every span the predicate is asked about. */
+  const probe = (onDisk: readonly string[]) => {
+    const asked: string[] = [];
+    return {
+      asked,
+      existsOnDisk: (rel: string) => { asked.push(rel); return onDisk.includes(rel); },
+    };
+  };
+
+  it('reports a dotless path that exists on disk but is not indexed', () => {
+    const p = probe(['scripts/deploy']);
+    const out = extractQueryPaths(
+      'why does scripts/deploy fail on release', INDEX, { existsOnDisk: p.existsOnDisk },
+    );
+    expect(out.pinnedFiles).toEqual([]);
+    expect(out.unresolvedPathSpans).toEqual(['scripts/deploy']);
+    expect(out.strippedQuery).toBe('why does fail on release');
+    // Vacuity guard: the verdict came from the predicate, not from some other arm.
+    expect(p.asked).toContain('scripts/deploy');
+  });
+
+  it('leaves the same span alone when no predicate is injected', () => {
+    const q = 'why does scripts/deploy fail on release';
+    const out = extractQueryPaths(q, INDEX);
+    expect(out.unresolvedPathSpans).toEqual([]);
+    expect(out.strippedQuery).toBe(q);
+  });
+
+  it('leaves `and/or` prose alone even though a predicate is injected', () => {
+    const p = probe(['scripts/deploy']);
+    const q = 'does gen_server:call/2 block and/or timeout';
+    const out = extractQueryPaths(q, INDEX, { existsOnDisk: p.existsOnDisk });
+    expect(out.pinnedFiles).toEqual([]);
+    expect(out.unresolvedPathSpans).toEqual([]);
+    expect(out.strippedQuery).toBe(q);
+    // Consulted and refused — not skipped by shape.
+    expect(p.asked).toContain('and/or');
+  });
+
+  it('leaves a slashed word pair that is not a file on disk alone', () => {
+    const p = probe(['scripts/deploy']);
+    const q = 'trace the input/output buffering path';
+    const out = extractQueryPaths(q, INDEX, { existsOnDisk: p.existsOnDisk });
+    expect(out.unresolvedPathSpans).toEqual([]);
+    expect(out.strippedQuery).toBe(q);
+    expect(p.asked).toContain('input/output');
+  });
+
+  it('still reports a dotted span that matches nothing and is not on disk', () => {
+    const p = probe([]);
+    const out = extractQueryPaths(
+      'crash in src/routes/gone/missing-page.svelte on load', INDEX,
+      { existsOnDisk: p.existsOnDisk },
+    );
+    expect(out.unresolvedPathSpans).toEqual(['src/routes/gone/missing-page.svelte']);
+    expect(out.strippedQuery).toBe('crash in on load');
+  });
+
+  it('pins an indexed dotless path by resolution, never asking about it', () => {
+    const p = probe(['scripts/pre-commit']);
+    const out = extractQueryPaths(
+      'what does scripts/pre-commit run', INDEX, { existsOnDisk: p.existsOnDisk },
+    );
+    expect(out.pinnedFiles).toEqual(['scripts/pre-commit']);
+    expect(out.unresolvedPathSpans).toEqual([]);
+    expect(p.asked).not.toContain('scripts/pre-commit');
+  });
+});

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -158,6 +158,25 @@ export function normalizeQuerySpelling(query: string): string {
 }
 
 /**
+ * Does this query-named span point at a real FILE inside the project?
+ *
+ * The `existsOnDisk` predicate `extractQueryPaths` takes (that module is pure —
+ * no DB, no fs — so the fs access lives here, where the project root is known).
+ * Only a REGULAR FILE counts: a directory span (`src/search`) is not a file
+ * reference and must keep flowing to the normal matching pipeline. Containment
+ * is enforced by `validatePathWithinRoot`, so a `../` span in a query cannot
+ * probe outside the project, and every fs error answers `false`.
+ */
+function pathIsProjectFile(projectRoot: string, relPath: string): boolean {
+  try {
+    const abs = validatePathWithinRoot(projectRoot, relPath);
+    return abs !== null && statSync(abs).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Calculate the recommended number of codegraph_explore calls based on project size.
  * Larger codebases need more exploration calls to cover their surface area,
  * but smaller ones should use fewer to avoid unnecessary overhead.
@@ -3318,7 +3337,7 @@ export class ToolHandler {
         const extraction = extractQueryPaths(
           rawQuery,
           cg.getFiles().map((f) => f.path),
-          { maxPins: maxFiles },
+          { maxPins: maxFiles, existsOnDisk: (rel) => pathIsProjectFile(projectRoot, rel) },
         );
         if (extraction.pinnedFiles.length > 0 || extraction.unresolvedPathSpans.length > 0) {
           pinnedFiles = extraction.pinnedFiles;

--- a/src/search/query-paths.ts
+++ b/src/search/query-paths.ts
@@ -24,7 +24,11 @@
  * spans removed.
  * Callers treat pinned files as first-class: guaranteed admission, top rank,
  * funded first. Pure string work — no DB, no fs — so it is trivially testable
- * and safe inside the query-pool workers.
+ * and safe inside the query-pool workers. The one question string shape cannot
+ * answer (is this dotless slashed span, `scripts/deploy`, a real file that is
+ * merely unindexed, or is it prose like `and/or`?) is delegated to an OPTIONAL
+ * `existsOnDisk` predicate the caller injects — the fs access stays at the call
+ * site, which owns the project root, and this module stays pure.
  */
 
 export interface QueryPathExtraction {
@@ -189,7 +193,18 @@ function resolveSpan(
 export function extractQueryPaths(
   query: string,
   indexedPaths: readonly string[],
-  opts: { maxPins?: number; maxMatchesPerSpan?: number } = {},
+  opts: {
+    maxPins?: number;
+    maxMatchesPerSpan?: number;
+    /**
+     * Does this repo-relative span name a real FILE in the project? Optional,
+     * injected by the caller (see the module docstring): it is the only way to
+     * tell a dotless path the index simply doesn't hold (`scripts/deploy`)
+     * from slashed prose (`and/or`), and it must stay out of this module.
+     * Must not throw — the caller absorbs fs errors and returns false.
+     */
+    existsOnDisk?: (relPath: string) => boolean;
+  } = {},
 ): QueryPathExtraction {
   const maxPins = Math.max(1, opts.maxPins ?? 8);
   const maxMatchesPerSpan = Math.max(1, opts.maxMatchesPerSpan ?? 3);
@@ -235,10 +250,19 @@ export function extractQueryPaths(
         pinnedSeen.add(m);
         pinned.push(m);
       }
-    } else if (ambiguous || isClearlyPathShaped(normalized)) {
+    } else if (
+      ambiguous
+      || isClearlyPathShaped(normalized)
+      || (normalized.includes('/') && opts.existsOnDisk?.(normalized) === true)
+    ) {
       // A real path that didn't resolve to a usable set. Keeping it in the
       // query is strictly worse — its fragments are what minted the junk
       // matches this module exists to stop — so strip it and say so.
+      // The third arm covers the DOTLESS slashed span (`scripts/deploy`,
+      // `bin/build`): shape alone cannot tell it from `and/or` or
+      // `input/output`, so the file's existence on disk decides. Loosening the
+      // SHAPE test instead would strip that prose out of every query and mint a
+      // false "no indexed file matches `and/or`" caveat.
       consumed.add(i);
       if (unresolved.length < 4) unresolved.push(normalized);
     }


### PR DESCRIPTION
Fixes #1830.

## The bug

`codegraph_explore` treats a path-shaped span with **no extension on its last segment** — `scripts/deploy`, `bin/build`, `scripts/pre-commit` in a repo that doesn't index it — as free text. The agent gets back a pile of unrelated source with **no indication at all** that the file it named was never consulted.

## Root cause

`extractQueryPaths` (`src/search/query-paths.ts`) sends a span to `unresolvedPathSpans` — the "say the miss out loud" channel — under:

```js
} else if (ambiguous || isClearlyPathShaped(normalized)) {
```

and `isClearlyPathShaped` requires a dot-extension on the last segment:

```js
const slash = normalized.lastIndexOf('/');
if (slash <= 0) return false;
return DOTTED_BASENAME.test(normalized.slice(slash + 1));
```

`scripts/deploy` has a slash, so it becomes a candidate; `resolveSpan` returns nothing (the file is not indexed); and then **both** arms are false — so the token is not consumed, never enters `unresolvedPathSpans`, and its fragments (`scripts`, `deploy`) go on to feed FTS.

Both downstream caveat sinks already exist and work — the empty-subgraph note and the summary line ("No indexed file uniquely matches …"). They were simply never handed the span.

## Why fs-existence and not a looser shape

The obvious "fix" — treat any slash-bearing span as a path — is wrong, and this repo already has a test that says so. `__tests__/query-paths.test.ts`'s `leaves slash-bearing non-paths alone` asserts that

```
does gen_server:call/2 block and/or timeout
```

comes back completely untouched. Loosening the shape test turns that red, strips `and/or`, `input/output`, `client/server` out of queries repo-wide, and mints a false ``No indexed file uniquely matches `and/or` `` caveat in the response. Shape genuinely cannot separate the two cases — `scripts/deploy` and `and/or` are the same shape. The file's existence on disk is the only discriminator available.

## Why the predicate is injected

`query-paths.ts`'s docstring states the module is "Pure string work — no DB, no fs — so it is trivially testable and safe inside the query-pool workers." That is load-bearing, so no `fs` was added to the module. Instead `extractQueryPaths` takes an optional `existsOnDisk?: (relPath: string) => boolean`, and the single call site in `src/mcp/tools.ts` — which owns `projectRoot` — supplies it:

```ts
function pathIsProjectFile(projectRoot: string, relPath: string): boolean {
  try {
    const abs = validatePathWithinRoot(projectRoot, relPath);
    return abs !== null && statSync(abs).isFile();
  } catch { return false; }
}
```

- Containment goes through `validatePathWithinRoot`, so a `../`-bearing span in an agent query cannot probe outside the project.
- Only a **regular file** counts. A directory span (`src/search`) is not a file reference and keeps flowing to the normal matching pipeline.
- Every fs error answers `false`; the whole extraction is already wrapped in `catch { /* path pinning must never fail an explore call */ }`.
- The predicate is optional, so callers that cannot touch the disk (query-pool workers) simply get today's behavior.

Net change in `query-paths.ts` is two lines plus doc.

> The issue also suggests the check might be shareable with the `node` tool, since `node` "already gets this right". I looked and I don't think it is: `node` matches a whole string against the index file list, while `explore` is classifying tokens inside free text. The inputs have different shapes and the correct answers differ. I left `node` alone.

## Retrieval effect — AGENTS.md "do not regress"

This change makes a token get **consumed and removed from `matchQuery`**, so it moves retrieval and falls under AGENTS.md's *Retrieval performance (do not regress)*. I ran a deterministic A/B on the built `dist` (`scripts/agent-eval/probe-explore.mjs`) over an indexed repro where `scripts/deploy` exists on disk but is not indexed. Baseline arm = this branch's merge-base build; fixed arm = this branch.

I deliberately did **not** use `ab-new-vs-baseline.sh` here: it drives a real agent on an implementation task, and no such task reliably emits a query naming a dotless unindexed path — both arms would have missed the changed code entirely and the numbers would have been noise.

| query | baseline | this PR |
|---|---|---|
| query is only the dotless path | 998 chars of unrelated source, no caveat | ``No relevant code found for "…" (no indexed file uniquely matches `scripts/deploy`)`` |
| dotless path inside a real symbol query | 1010 chars | 1061 chars — **byte-identical except the added caveat sentence**; same 4 symbols across the same 2 files |
| query with no path span | — | **byte-identical between arms** |

The middle row is the important one: when the query carries real content, nothing about what gets retrieved changes — only the caveat is added. The first row is the change the issue asks for, and worth an explicit maintainer call: `unresolvedPathSpans` in this module has always coupled "report the span" with "strip it from the query", and this arm inherits that coupling, so a query that is *only* the dotless path now answers with the caveat instead of unrelated source. I did not decouple the two.

## Tests

`__tests__/query-paths.test.ts` gains 6 tests (27 → 33):

- the dotless span is reported when the injected predicate says the file exists, **and** the predicate is asserted to have actually been consulted (vacuity guard);
- the same span is left alone when no predicate is injected;
- `and/or` prose stays untouched *even with a predicate present* — and the predicate is asserted to have been asked and refused, not bypassed by shape;
- `input/output` (slashed, not a file) stays untouched;
- a dotted span that matches nothing is still reported (the existing arm is independent of disk);
- an **indexed** dotless path (`scripts/pre-commit`) still pins by resolution and is never asked about.

Red-arm check — deleting only the new `||` line, tests unchanged: **3 failed / 30 passed**, with all 27 pre-existing tests (including the `and/or` guard) staying green. Restored: **33/33**.

`npm run build` clean. `npm test`: 14 failed / 4425 passed / 192 skipped — the same 14 failures across the same 8 files (`installer-targets`, `mcp-callers-truncation`, `nextjs`, `object-literal-methods`, `react-native-bridge`, `ui-steps-api`, `ui-steps-api-servers`, `ui-steps-cross-tier`) that the unpatched merge-base produces; unrelated to this change.

`CHANGELOG.md` `[Unreleased] → Fixes` updated.

## Out of scope

The issue also mentions the `prompt-hook` having the same blind spot, and asks about gating the *"Complete source for N files … do NOT re-read them"* footer. Both are separate decisions with their own trade-offs; this PR does only the caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDR1wm73oH8J8cRWnKyv9m
