### PR TITLE
fix(status): detect committed but unindexed changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
+- `codegraph status` now reports unindexed additions, edits, and deletions even after they have been committed to Git. (#1829)
+
 - Spring mappings now include every declared path combination and resolve constants declared in the same file, while unresolved paths no longer appear as false root routes. (#1461)
 - `codegraph callers`, `codegraph callees` and `codegraph impact` now resolve qualified names, group results and JSON edges by definition, and accept `--file` to narrow ambiguous names; thanks @ferrine. (#1512, #1656)
 - `codegraph callers`, `codegraph callees` and `codegraph impact` (CLI and MCP) now report missing names with did-you-mean suggestions instead of another symbol's results, and exact matches with no callers stay empty; thanks @uvmplus. (#1473, #1481)

--- a/__tests__/sync.test.ts
+++ b/__tests__/sync.test.ts
@@ -219,6 +219,26 @@ describe('Sync Module', () => {
       }
     });
 
+    it.each(['added', 'modified', 'removed'] as const)(
+      'reports %s files after committing without indexing (#1829)',
+      async (kind) => {
+        const relativePath = kind === 'added' ? 'src/new.ts' : 'src/index.ts';
+        const filePath = path.join(testDir, relativePath);
+        if (kind === 'removed') fs.unlinkSync(filePath);
+        else fs.writeFileSync(filePath, 'export function changed() { return 99; }');
+
+        const expected = { added: [], modified: [], removed: [], [kind]: [relativePath] };
+        // In particular, unstaged deletions remain in git ls-files.
+        expect(cg.getChangedFiles()).toEqual(expected);
+        git('add', '--', 'src');
+        git('commit', '-m', 'changed without indexing');
+        expect(cg.getChangedFiles()).toEqual(expected);
+
+        await cg.sync();
+        expect(cg.getChangedFiles()).toEqual({ added: [], modified: [], removed: [] });
+      }
+    );
+
     it('should detect modified files via git', async () => {
       fs.writeFileSync(
         path.join(testDir, 'src', 'index.ts'),

--- a/__tests__/sync.test.ts
+++ b/__tests__/sync.test.ts
@@ -239,6 +239,31 @@ describe('Sync Module', () => {
       }
     );
 
+    it('detects a committed rename and preserves the graph across repeated no-op syncs', async () => {
+      git('mv', 'src/index.ts', 'src/renamed.ts');
+      git('commit', '-m', 'rename without indexing');
+
+      expect(cg.getChangedFiles()).toEqual({
+        added: ['src/renamed.ts'], modified: [], removed: ['src/index.ts'],
+      });
+      // Status must not discard the last usable graph before sync succeeds.
+      expect(cg.searchNodes('hello').some(r => r.node.filePath === 'src/index.ts')).toBe(true);
+
+      const renamed = await cg.sync();
+      expect(renamed.filesAdded).toBe(1);
+      expect(renamed.filesRemoved).toBe(1);
+      const nodes = cg.searchNodes('hello').map(r => r.node);
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0].filePath).toBe('src/renamed.ts');
+
+      for (let i = 0; i < 2; i++) {
+        expect(cg.getChangedFiles()).toEqual({ added: [], modified: [], removed: [] });
+        const unchanged = await cg.sync();
+        expect([unchanged.filesAdded, unchanged.filesModified, unchanged.filesRemoved]).toEqual([0, 0, 0]);
+        expect(cg.searchNodes('hello').map(r => r.node.id)).toEqual(nodes.map(node => node.id));
+      }
+    });
+
     it('should detect modified files via git', async () => {
       fs.writeFileSync(
         path.join(testDir, 'src', 'index.ts'),

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -3173,53 +3173,10 @@ export class ExtractionOrchestrator {
 
   /**
    * Get files that have changed since last index.
-   * Uses git status as a fast path when available, falling back to full scan.
+   * Compare the full source inventory with the index: git status omits
+   * committed changes that have not been indexed yet (#1829).
    */
   getChangedFiles(): { added: string[]; modified: string[]; removed: string[] } {
-    const gitChanges = getGitChangedFiles(this.rootDir);
-
-    if (gitChanges) {
-      // === Git fast path ===
-      const added: string[] = [];
-      const modified: string[] = [];
-      const removed: string[] = [];
-
-      // Deleted files — only report if tracked in DB
-      for (const filePath of gitChanges.deleted) {
-        const tracked = this.queries.getFileByPath(filePath);
-        if (tracked) {
-          removed.push(filePath);
-        }
-      }
-
-      // Modified + added files — read + hash, compare with DB. Untracked (`??`)
-      // files stay untracked in git even after indexing, so they must be
-      // hash-compared like modified files instead of always counting as added —
-      // otherwise status reports them as pending forever. (See issue #206.)
-      for (const filePath of [...gitChanges.modified, ...gitChanges.added]) {
-        const fullPath = path.join(this.rootDir, filePath);
-        let content: string;
-        try {
-          content = fs.readFileSync(fullPath, 'utf-8');
-        } catch (error) {
-          logDebug('Skipping unreadable file while detecting changes', { filePath, error: String(error) });
-          continue;
-        }
-
-        const contentHash = hashContent(content);
-        const tracked = this.queries.getFileByPath(filePath);
-
-        if (!tracked) {
-          added.push(filePath);
-        } else if (tracked.contentHash !== contentHash) {
-          modified.push(filePath);
-        }
-      }
-
-      return { added, modified, removed };
-    }
-
-    // === Fallback: full scan (non-git project or git failure) ===
     const currentFiles = new Set(scanDirectory(this.rootDir));
     const trackedFiles = this.queries.getAllFiles();
 
@@ -3233,9 +3190,10 @@ export class ExtractionOrchestrator {
     const modified: string[] = [];
     const removed: string[] = [];
 
-    // Find removed files
+    // git ls-files can still list an unstaged deletion; check disk too,
+    // matching the full sync reconciliation.
     for (const tracked of trackedFiles) {
-      if (!currentFiles.has(tracked.path)) {
+      if (!currentFiles.has(tracked.path) || !fs.existsSync(path.join(this.rootDir, tracked.path))) {
         removed.push(tracked.path);
       }
     }


### PR DESCRIPTION
Committing an addition, edit, or deletion before indexing currently makes `codegraph status` report zero pending changes. This change compares the full in-scope source inventory with indexed hashes, so pending changes remain visible until sync absorbs them.

Fixes #1829.

The existing inventory comparison now handles Git projects as well as non-Git projects. It retains scope filtering and checks disk existence for removals, since `git ls-files` can still list unstaged deletions. No schema change or new dependency is needed.

Regression tests cover additions, edits, and deletions before and after committing, recovery after sync, committed renames, and graph preservation across repeated no-op syncs. The three addition/edit/deletion cases failed at the post-commit assertion before the fix.

### Validation

Based on upstream `3ed73bc127323e63153bf6ec8354afa82ce36aaf`; head `a5709f47` contains only this fix and its tests.

- **Exact PR branch, WSL/Linux, Node 24.21.0:** 59 tests passed across `sync`, `include-ignored-config`, `git-changed-untracked-dir`, and `extraction-old-git`, with `CODEGRAPH_KERNEL=0`, one worker. TypeScript compilation and diff whitespace checks passed.
- **Deployed downstream integration `3f1c3309`, including this fix and other fork changes:** 4,756 native tests and 4,754 WASM tests passed, zero failures; all five downstream source probes passed. These are integration results, not a full-suite run of this exact PR branch.
- Windows and the viewer build were not tested for this PR.

### Performance tradeoff

Reading and hashing the full inventory costs more than the incomplete Git-status candidate list. A disposable VS Code checkout at `7b7e49c83affacfac726040280da69b4999f3e01` contained **14,486 in-scope files, 166.77 MiB**:

| State | Before median | Fixed median | Fixed min–max |
| --- | ---: | ---: | ---: |
| Clean | 50.2 ms | 614.2 ms | 600.0–642.2 ms |
| One uncommitted edit | 59.1 ms | 676.7 ms | 604.6–780.7 ms |
| Same edit committed without indexing | 51.1 ms (incorrectly clean) | 604.4 ms (correctly modified) | 596.0–634.5 ms |

Measured on WSL/ext4 with Node 24.21.0 and `nice -n 10`: two warm-ups, then ten samples per arm per case, alternating arm order. The actual before/fixed detection methods from downstream `d5607a08` and `6cb53e82` used the same supporting modules and SQLite file records seeded from the checkout's current hashes. Those methods differ only by this fix; no symbol graph was extracted. All returned change sets were asserted.

These are warm-cache **change-detection** timings, excluding CLI startup and other status queries—not end-to-end CLI or cold-storage measurements. The shared host had background services; the Android build had completed before the reported run. An earlier run during build activity was excluded. The measured added cost is about 0.55–0.62 seconds on this repository.
