### PR TITLE
test(mcp): cover per-definition callers truncation

### DIFF
--- a/__tests__/mcp-callers-truncation.test.ts
+++ b/__tests__/mcp-callers-truncation.test.ts
@@ -35,14 +35,17 @@ beforeAll(async () => {
       Array.from({ length: CALLERS }, (_, i) => `export function caller${i}(): number { return warm(${i}); }`).join('\n') +
       '\n'
   );
-  // `hot` shares its name with its file, so the answer groups per definition.
-  fs.writeFileSync(path.join(tmpDir, 'src', 'hot.ts'), 'export function hot(n: number): number { return n; }\n');
-  fs.writeFileSync(
-    path.join(tmpDir, 'src', 'hot-callers.ts'),
-    "import { hot } from './hot';\n" +
-      Array.from({ length: CALLERS }, (_, i) => `export function hotCaller${i}(): number { return hot(${i}); }`).join('\n') +
-      '\n'
-  );
+  // Two functions with the same bare name exercise per-definition grouping.
+  // A single `hot.ts` is one definition, so callers stay a flat capped list.
+  for (const suffix of ['a', 'b']) {
+    fs.writeFileSync(path.join(tmpDir, 'src', `hot-${suffix}.ts`), 'export function hot(n: number): number { return n; }\n');
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', `hot-${suffix}-callers.ts`),
+      `import { hot } from './hot-${suffix}';\n` +
+        Array.from({ length: CALLERS }, (_, i) => `export function hot${suffix.toUpperCase()}Caller${i}(): number { return hot(${i}); }`).join('\n') +
+        '\n'
+    );
+  }
   fs.writeFileSync(
     path.join(tmpDir, 'src', 'fan.ts'),
     Array.from({ length: CALLERS }, (_, i) => `export function helper${i}(): number { return ${i}; }`).join('\n') +


### PR DESCRIPTION
## Summary

`codegraph_callers` only groups by definition when the same name has more than one definition. The truncation test on `main` used a single `hot` function, so the grouped `distinct definitions` / `… +N more` assertion failed even though the flat `Showing 20 of 26` marker is correct for that fixture.

This change gives `hot` two definitions so that assertion matches the product path. Handler behavior is unchanged.

## Test plan

- [x] `fnm exec --using codegraph npx vitest run __tests__/mcp-callers-truncation.test.ts --minWorkers 1 --maxWorkers 1` (5/5 pass)