### PR TITLE
fix(status): see committed-but-unindexed changes without losing the fast path (#1829)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 #### MCP / indexing
 
+- `codegraph status` no longer reports zero pending changes for work you have already committed. Change detection asked git for the working-tree diff, and committing a file is exactly what removes it from that answer — so an edit read as pending until you committed it, then read as nothing while the index still lacked it. It now also asks git what changed between the commit the index was built from and where you are now, so the number matches what a sync would actually do. (#1829)
+
 - The prompt hook no longer injects unrelated projects when run from your home directory or a broader directory containing a stray workspace manifest. (#1454)
 
 - Indexing now succeeds when Node.js's SQLite lacks FTS5, with search falling back to name and fuzzy matching; thanks @aniruddhaadak80. (#1532)

--- a/__tests__/sync.test.ts
+++ b/__tests__/sync.test.ts
@@ -984,6 +984,24 @@ describe('committed-but-unindexed changes (#1829)', () => {
     expect(result.filesModified).toBe(1);
   });
 
+  it('sees a committed RENAME as a removal plus an add', async () => {
+    // `--no-renames` on the committed diff is deliberate: the index keys files
+    // by path, so a rename IS a removal and an add, and pairing them up would
+    // only have to be taken apart again.
+    fs.renameSync(path.join(testDir, 'src', 'one.ts'), path.join(testDir, 'src', 'renamed.ts'));
+    git('add', '-A');
+    git('commit', '-m', 'rename one');
+
+    const changes = cg.getChangedFiles();
+    expect(changes.removed).toContain('src/one.ts');
+    expect(changes.added).toContain('src/renamed.ts');
+
+    const result = await cg.sync();
+    expect(result.filesRemoved).toBe(1);
+    expect(result.filesAdded).toBe(1);
+    expect(cg.searchNodes('alpha').every((r) => r.node.filePath !== 'src/one.ts')).toBe(true);
+  });
+
   it('still filters committed changes by the rules the full index uses', async () => {
     // vendor/ is a built-in exclude git knows nothing about. Sourcing candidates
     // from `git diff` must not smuggle in files `git status` would have had

--- a/__tests__/sync.test.ts
+++ b/__tests__/sync.test.ts
@@ -881,3 +881,147 @@ describe('Scoped sync parity (#watcher-scoped)', () => {
     expect(cg.searchNodes('gamma').length).toBe(1);
   });
 });
+
+// A change that is COMMITTED but not yet indexed used to read as zero pending
+// changes: getChangedFiles' git fast path built its candidate list from
+// `git status --porcelain`, and committing is exactly what removes a file from
+// that output. The hash comparison below it was correct and simply never
+// reached. Committed work is now sourced from `git diff <indexed commit> HEAD`.
+// (#1829)
+describe('committed-but-unindexed changes (#1829)', () => {
+  let testDir: string;
+  let cg: CodeGraph;
+
+  const git = (...args: string[]) =>
+    execFileSync('git', args, { cwd: testDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+
+  beforeEach(async () => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-1829-'));
+    git('init');
+    git('config', 'user.email', 'test@test.com');
+    git('config', 'user.name', 'Test');
+
+    fs.mkdirSync(path.join(testDir, 'src'));
+    fs.writeFileSync(path.join(testDir, 'src', 'one.ts'), `export function alpha() { return 1; }`);
+    git('add', '-A');
+    git('commit', '-m', 'initial');
+
+    cg = CodeGraph.initSync(testDir, { config: { include: ['**/*.ts'], exclude: [] } });
+    await cg.indexAll();
+  });
+
+  afterEach(() => {
+    if (cg) cg.destroy();
+    if (fs.existsSync(testDir)) fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('sees a committed NEW file (git status shows nothing; the DB has no row)', async () => {
+    fs.writeFileSync(path.join(testDir, 'src', 'two.ts'), `export function beta() { return 2; }`);
+    git('add', '-A');
+    git('commit', '-m', 'add two');
+
+    const changes = cg.getChangedFiles();
+    expect(changes.added).toContain('src/two.ts');
+
+    // status and sync must agree — the whole point is that the number a user
+    // reads matches the work that is actually outstanding.
+    const result = await cg.sync();
+    expect(result.filesAdded).toBe(1);
+    expect(cg.searchNodes('beta').length).toBeGreaterThan(0);
+  });
+
+  it('sees a committed MODIFICATION to an already-tracked file', async () => {
+    fs.writeFileSync(path.join(testDir, 'src', 'one.ts'), `export function alphaRenamed() { return 99; }`);
+    git('add', '-A');
+    git('commit', '-m', 'edit one');
+
+    expect(cg.getChangedFiles().modified).toContain('src/one.ts');
+    const result = await cg.sync();
+    expect(result.filesModified).toBe(1);
+    expect(cg.searchNodes('alphaRenamed').length).toBeGreaterThan(0);
+  });
+
+  it('sees a committed DELETE', async () => {
+    fs.writeFileSync(path.join(testDir, 'src', 'two.ts'), `export function beta() { return 2; }`);
+    git('add', '-A');
+    git('commit', '-m', 'add two');
+    await cg.sync();
+
+    fs.rmSync(path.join(testDir, 'src', 'two.ts'));
+    git('add', '-A');
+    git('commit', '-m', 'remove two');
+
+    expect(cg.getChangedFiles().removed).toContain('src/two.ts');
+    const result = await cg.sync();
+    expect(result.filesRemoved).toBe(1);
+  });
+
+  it('reports zero once the sync has absorbed the commit (the stamp advances)', async () => {
+    fs.writeFileSync(path.join(testDir, 'src', 'two.ts'), `export function beta() { return 2; }`);
+    git('add', '-A');
+    git('commit', '-m', 'add two');
+    await cg.sync();
+
+    const after = cg.getChangedFiles();
+    expect(after.added).toHaveLength(0);
+    expect(after.modified).toHaveLength(0);
+    expect(after.removed).toHaveLength(0);
+  });
+
+  it('counts a file once when it was committed AND edited again since', async () => {
+    // The same path now reaches the candidate list from both sources — the
+    // committed diff and `git status`. It is still one changed file.
+    fs.writeFileSync(path.join(testDir, 'src', 'one.ts'), `export function alpha() { return 2; }`);
+    git('add', '-A');
+    git('commit', '-m', 'edit one');
+    fs.writeFileSync(path.join(testDir, 'src', 'one.ts'), `export function alpha() { return 3; }`);
+
+    const changes = cg.getChangedFiles();
+    expect(changes.modified.filter((f) => f === 'src/one.ts')).toHaveLength(1);
+    expect(changes.added).toHaveLength(0);
+
+    const result = await cg.sync();
+    expect(result.filesModified).toBe(1);
+  });
+
+  it('still filters committed changes by the rules the full index uses', async () => {
+    // vendor/ is a built-in exclude git knows nothing about. Sourcing candidates
+    // from `git diff` must not smuggle in files `git status` would have had
+    // filtered out (#766) — same classifier, both sources.
+    fs.mkdirSync(path.join(testDir, 'vendor'));
+    fs.writeFileSync(path.join(testDir, 'vendor', 'lib.ts'), `export function vendored() { return 1; }`);
+    git('add', '-A');
+    git('commit', '-m', 'add vendor');
+
+    const changes = cg.getChangedFiles();
+    expect(changes.added).not.toContain('vendor/lib.ts');
+    expect(changes.modified).not.toContain('vendor/lib.ts');
+  });
+
+  it('falls back to the full scan when history moved under the index', async () => {
+    // A rebase/gc/shallow clone can leave the stamped commit unreachable. The
+    // fast path cannot diff against a commit that is gone, so the (correct,
+    // slower) full scan has to answer instead of silently reporting zero.
+    fs.writeFileSync(path.join(testDir, 'src', 'two.ts'), `export function beta() { return 2; }`);
+    git('add', '-A');
+    git('commit', '-m', 'add two');
+    (cg as unknown as { queries: { setMetadata(k: string, v: string): void } })
+      .queries.setMetadata('indexed_at_commit', '0'.repeat(40));
+
+    expect(cg.getChangedFiles().added).toContain('src/two.ts');
+  });
+
+  it('an index with no stamp still answers correctly (pre-#1829 index upgrading)', async () => {
+    (cg as unknown as { queries: { setMetadata(k: string, v: string): void } })
+      .queries.setMetadata('indexed_at_commit', '');
+    fs.writeFileSync(path.join(testDir, 'src', 'two.ts'), `export function beta() { return 2; }`);
+    git('add', '-A');
+    git('commit', '-m', 'add two');
+
+    expect(cg.getChangedFiles().added).toContain('src/two.ts');
+
+    // ...and it self-heals: the sync writes a stamp, so the next read is clean.
+    await cg.sync();
+    expect(cg.getChangedFiles().added).toHaveLength(0);
+  });
+});

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -1287,20 +1287,97 @@ interface GitChanges {
  * case this cannot see (the child status that would report the deletions is gone
  * with it); a full `codegraph index` reconciles that.
  */
-export function getGitChangedFiles(rootDir: string): GitChanges | null {
+export function getGitChangedFiles(rootDir: string, sinceCommit?: string | null): GitChanges | null {
   try {
+    // `git status` only ever describes the WORKING TREE, so a change that has
+    // been committed leaves no entry and never enters the candidate set — the
+    // hash comparison in getChangedFiles is correct but is never reached for
+    // it, and `pendingChanges` reads 0 while the index is genuinely behind
+    // (#1829). `sinceCommit` — the commit the index was last brought up to
+    // date at — adds the other half: what has been committed since. Callers
+    // that hold no such stamp still get exactly what they always did, the
+    // working-tree changes.
     const changes: GitChanges = { modified: [], added: [], deleted: [] };
     // Custom extension → language overrides from the project's codegraph.json,
     // so change detection sees the same custom-extension files the full index does.
     const overrides = loadExtensionOverrides(rootDir);
-    collectGitStatus(rootDir, '', changes, overrides, loadIncludeIgnoredMatcher(rootDir), loadExcludeMatcher(rootDir));
+    collectGitStatus(rootDir, '', changes, overrides, loadIncludeIgnoredMatcher(rootDir), loadExcludeMatcher(rootDir), sinceCommit ?? undefined);
     return changes;
   } catch {
     return null;
   }
 }
 
-function collectGitStatus(repoDir: string, prefix: string, out: GitChanges, overrides?: Record<string, Language>, includeIgnored: Ignore | null = null, exclude: Ignore | null = null): void {
+/**
+ * Metadata key: the commit the index was last brought up to date at. Written by
+ * a full index AND by every successful sync — unlike the extraction stamp, which
+ * a sync must not advance because it only touches a subset of files. This one is
+ * about the TREE, and a sync does absorb the whole diff it computed. (#1829)
+ */
+export const INDEXED_AT_COMMIT_KEY = 'indexed_at_commit';
+
+/** HEAD's commit sha, or null in a non-git repo or one with no commits yet. */
+export function getGitHeadSha(rootDir: string): string | null {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: rootDir, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true,
+    }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `A<TAB>path` / `M<TAB>path` / `D<TAB>path` lines for every path committed
+ * between `sinceCommit` and HEAD. Empty when the stamp IS HEAD, which is the
+ * common case — one cheap git call on the hot path.
+ */
+function gitCommittedChangesSince(repoDir: string, sinceCommit: string): string[] {
+  try {
+    const out = execFileSync('git', ['diff', '--name-status', '--no-renames', sinceCommit, 'HEAD'], {
+      cwd: repoDir, encoding: 'utf-8', timeout: 10000, maxBuffer: 50 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true,
+    });
+    return out.split('\n').filter((l) => l.length > 2);
+  } catch {
+    // Unreachable in practice — isCommittedDiffUsable already proved the commit
+    // resolves — but a diff that fails must not take the whole fast path down.
+    return [];
+  }
+}
+
+/**
+ * Can an INDEX trust the git fast path, given the commit it was built at?
+ *
+ * False means "fall back to the full scan" — the expensive path that compares
+ * every file on disk against the DB, and the only correct read when git cannot
+ * say what happened between the stamp and now:
+ *
+ *  - stamp present but unknown to this repo (rebase, gc, shallow clone, a stamp
+ *    from a different checkout) — history moved under the index.
+ *  - stamp absent while the repo HAS commits — an index built before stamping
+ *    existed. One full scan; the next sync stamps it and the fast path returns.
+ *
+ * A repo with NO commits keeps the fast path with or without a stamp: every
+ * file is untracked, so `git status` already sees all of them. Callers with no
+ * index behind them (the exported `getGitChangedFiles`) never ask this — a
+ * working-tree diff is the whole of what they wanted. (#1829)
+ */
+export function canTrustGitFastPath(rootDir: string, sinceCommit?: string | null): boolean {
+  const head = getGitHeadSha(rootDir);
+  if (head == null) return true; // no commits (or not a git repo — caller handles that)
+  if (!sinceCommit) return false;
+  if (sinceCommit === head) return true;
+  try {
+    execFileSync('git', ['cat-file', '-e', `${sinceCommit}^{commit}`], {
+      cwd: rootDir, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function collectGitStatus(repoDir: string, prefix: string, out: GitChanges, overrides?: Record<string, Language>, includeIgnored: Ignore | null = null, exclude: Ignore | null = null, sinceCommit?: string): void {
   const output = execFileSync(
     'git',
     // `-uall` lists individual untracked files instead of collapsing an
@@ -1325,6 +1402,39 @@ function collectGitStatus(repoDir: string, prefix: string, out: GitChanges, over
   // parent's. (#766)
   const ig = buildDefaultIgnore(repoDir);
 
+  // One classifier for both candidate sources below, so a committed change is
+  // filtered by exactly the rules a working-tree change is (#766, #999, #1829).
+  const classify = (statusCode: string, rel: string): void => {
+    const filePath = normalizePath(prefix + rel);
+    if (!isSourceFile(filePath, overrides)) return;
+
+    if (statusCode.includes('D')) {
+      // Deletions stay unfiltered: getChangedFiles acts on one only when the
+      // path is already tracked in the DB, where removal is always correct — and
+      // that lets a newly-excluded dir's stale rows clean themselves up. (#766)
+      out.deleted.push(filePath);
+      return;
+    }
+
+    // Added (`??`) / modified files inside an excluded dir must not enter the
+    // index — match against the repo-relative path, same as the full scan. (#766)
+    if (ig.ignores(rel)) return;
+    // User `codegraph.json` `exclude` (#999) is project-root-relative, so it's
+    // matched against the full path — sync must not re-add a tracked file the
+    // full index now keeps out. Deletions above stay unfiltered so a file that
+    // WAS indexed before an exclude was added still cleans itself out.
+    if (exclude && exclude.ignores(filePath)) return;
+
+    if (statusCode === '??') {
+      out.added.push(filePath);
+    } else {
+      // M, MM, AM, A (staged), etc. — treat as modified. getChangedFiles
+      // re-decides added-vs-modified from the DB, so a committed `A` that the
+      // index never saw still lands in `added`.
+      out.modified.push(filePath);
+    }
+  };
+
   const untrackedDirs: string[] = [];
   for (const line of output.split('\n')) {
     if (line.length < 4) continue; // Minimum: "XY file"
@@ -1339,31 +1449,20 @@ function collectGitStatus(repoDir: string, prefix: string, out: GitChanges, over
       continue;
     }
 
-    const filePath = normalizePath(prefix + rel);
-    if (!isSourceFile(filePath, overrides)) continue;
+    classify(statusCode, rel);
+  }
 
-    if (statusCode.includes('D')) {
-      // Deletions stay unfiltered: getChangedFiles acts on one only when the
-      // path is already tracked in the DB, where removal is always correct — and
-      // that lets a newly-excluded dir's stale rows clean themselves up. (#766)
-      out.deleted.push(filePath);
-      continue;
-    }
-
-    // Added (`??`) / modified files inside an excluded dir must not enter the
-    // index — match against the repo-relative path, same as the full scan. (#766)
-    if (ig.ignores(rel)) continue;
-    // User `codegraph.json` `exclude` (#999) is project-root-relative, so it's
-    // matched against the full path — sync must not re-add a tracked file the
-    // full index now keeps out. Deletions above stay unfiltered so a file that
-    // WAS indexed before an exclude was added still cleans itself out.
-    if (exclude && exclude.ignores(filePath)) continue;
-
-    if (statusCode === '??') {
-      out.added.push(filePath);
-    } else {
-      // M, MM, AM, A (staged), etc. — treat as modified
-      out.modified.push(filePath);
+  // Committed but unindexed: everything between the commit this index was last
+  // brought up to date at and HEAD. `git status` cannot see these — committing
+  // is precisely what removes a file from its output — so without this pass a
+  // `git commit` makes a real pending change read as zero (#1829). The stamp
+  // belongs to the ROOT repo, so the embedded-repo recursion below passes none.
+  if (sinceCommit) {
+    for (const line of gitCommittedChangesSince(repoDir, sinceCommit)) {
+      const tab = line.indexOf('\t');
+      if (tab < 1) continue;
+      // `A`/`M`/`D`/`T`… — padded to porcelain's two columns for `classify`.
+      classify(`${line.substring(0, tab).charAt(0)} `, normalizePath(line.substring(tab + 1)));
     }
   }
 
@@ -3176,7 +3275,15 @@ export class ExtractionOrchestrator {
    * Uses git status as a fast path when available, falling back to full scan.
    */
   getChangedFiles(): { added: string[]; modified: string[]; removed: string[] } {
-    const gitChanges = getGitChangedFiles(this.rootDir);
+    // The commit this index was last brought up to date at. Absent on an index
+    // built before stamping existed — getGitChangedFiles then declines the fast
+    // path and the full scan below answers correctly, once, until a sync or a
+    // full index writes the stamp. (#1829)
+    let sinceCommit: string | null = null;
+    try { sinceCommit = this.queries.getMetadata(INDEXED_AT_COMMIT_KEY) ?? null; } catch { /* advisory */ }
+    const gitChanges = canTrustGitFastPath(this.rootDir, sinceCommit)
+      ? getGitChangedFiles(this.rootDir, sinceCommit)
+      : null;
 
     if (gitChanges) {
       // === Git fast path ===
@@ -3184,8 +3291,20 @@ export class ExtractionOrchestrator {
       const modified: string[] = [];
       const removed: string[] = [];
 
+      // One file can now reach these lists from two candidate sources — the
+      // working tree AND the committed diff — when it was committed and then
+      // edited again. It is still one changed file: counting it twice would
+      // inflate `pendingChanges` and hand sync the same path twice. (#1829)
+      // Kept per list, not shared: a path can legitimately be BOTH — a commit
+      // deleted it and the working tree recreated it untracked — and that is a
+      // removal followed by an add, exactly as before.
+      const seenGone = new Set<string>();
+      const seenHere = new Set<string>();
+
       // Deleted files — only report if tracked in DB
       for (const filePath of gitChanges.deleted) {
+        if (seenGone.has(filePath)) continue;
+        seenGone.add(filePath);
         const tracked = this.queries.getFileByPath(filePath);
         if (tracked) {
           removed.push(filePath);
@@ -3197,6 +3316,8 @@ export class ExtractionOrchestrator {
       // hash-compared like modified files instead of always counting as added —
       // otherwise status reports them as pending forever. (See issue #206.)
       for (const filePath of [...gitChanges.modified, ...gitChanges.added]) {
+        if (seenHere.has(filePath)) continue;
+        seenHere.add(filePath);
         const fullPath = path.join(this.rootDir, filePath);
         let content: string;
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ import {
   IndexResult,
   SyncResult,
   extractFromSource,
+  getGitHeadSha,
+  INDEXED_AT_COMMIT_KEY,
   initGrammars,
 } from './extraction';
 import {
@@ -692,6 +694,11 @@ export class CodeGraph {
           try {
             this.queries.setMetadata('indexed_with_version', CodeGraphPackageVersion);
             this.queries.setMetadata('indexed_with_extraction_version', String(EXTRACTION_VERSION));
+            // ...and the commit whose tree it was built from, so change
+            // detection can ask git what has been COMMITTED since — the half
+            // `git status` structurally cannot answer. (#1829)
+            const head = getGitHeadSha(this.projectRoot);
+            if (head) this.queries.setMetadata(INDEXED_AT_COMMIT_KEY, head);
           } catch { /* metadata is advisory — never fail an index over it */ }
         }
 
@@ -822,6 +829,12 @@ export class CodeGraph {
         // timer-driven PASSIVE checkpoints ran, and a query-pool reader could
         // pin frames while the WAL grew without a bound.
         const backpressure = walValve ? () => walValve!.backpressure() : undefined;
+        // Captured BEFORE change detection runs, not after: if a commit lands
+        // while this sync is working, stamping the NEW head would claim we
+        // absorbed a diff we never looked at. Stamping the older commit only
+        // costs the next run a re-check of what it already has. (#1829)
+        const headBeforeSync = getGitHeadSha(this.projectRoot);
+
         const result = await this.orchestrator.sync(options.onProgress, options.paths, backpressure);
 
         // Fold the store phase's WAL BEFORE the post-store reads below
@@ -1026,6 +1039,17 @@ export class CodeGraph {
         const fullReconcile = !options.paths || options.paths.length === 0;
         if (fullReconcile && this.getIndexState() === 'indexing') {
           try { this.queries.setMetadata('index_state', 'complete'); } catch { /* advisory */ }
+        }
+
+        // Stamp the commit this sync brought the tree up to date at, so the
+        // NEXT change detection can see what was committed since. Only on a
+        // whole-tree sync: a `--paths` subset absorbed part of the diff, and
+        // stamping HEAD would tell the next run the rest was already indexed.
+        // Unlike the extraction stamp above, a sync DOES advance this one —
+        // it is about which tree the files came from, not which extractor
+        // produced their symbols. (#1829)
+        if (fullReconcile && headBeforeSync) {
+          try { this.queries.setMetadata(INDEXED_AT_COMMIT_KEY, headBeforeSync); } catch { /* advisory */ }
         }
 
         return result;


### PR DESCRIPTION
**An alternative to #1843 for the same bug — same symptom, same repro, but it keeps the git fast path.** @bompus got there first and his diagnosis matches mine exactly; this is offered as a choice of shape, not as a competing claim on the bug. Take whichever you prefer, or take his and treat this as a follow-up.

The difference is what replaces the incomplete candidate set. #1843 drops the fast path and compares the **full source inventory** on every call. This stamps the commit the index was built at and asks git for the **committed diff since that commit**, so the candidate set becomes complete without the tree walk.

## Why it matters

#1843's own table, on a 14,486-file VS Code checkout:

| State | Before | #1843 |
| --- | ---: | ---: |
| Clean | 50.2 ms | 614.2 ms |
| One uncommitted edit | 59.1 ms | 676.7 ms |
| Committed, not indexed | 51.1 ms (wrong) | 604.4 ms (right) |

`getChangedFiles` is on the hot path — `codegraph status`, every sync, and the watcher's catch-up all land here — so that cost is paid per call, forever, to catch a case that is rare per call.

## Measured here, same checkout, all three arms on one machine

VS Code at `7b7e49c8` — the commit #1843 measured — indexed once (14,137 files, 475,316 nodes) and read by all three builds. Timing `getChangedFiles()` in-process, excluding CLI startup, as #1843's table does: 2 warm-ups then 10 samples, two passes per state with the arm order reversed on the second, `nice -n 10`. WSL2/ext4, Node 22.23.2.

| State | `main` @ 3ed73bc | #1843 | this PR |
| --- | ---: | ---: | ---: |
| Clean | **119 ms** | 1470 ms | **132 ms** |
| One uncommitted edit | **131 ms** | 1488 ms | **136 ms** |
| Committed, not indexed | 122 ms *(reports 0 — the bug)* | 1547 ms | **146 ms** |

Median of 10, both passes within ~1% of each other. Ranges across all samples: `main` 117–184 ms, #1843 1451–2517 ms, this PR 129–150 ms. Both fixes report `modified: 1` in the committed state; `main` reports nothing.

The absolute numbers are higher than #1843's on every arm — different machine, and this box was busier — but all three arms are measured under the same conditions, so the ratio is the point: **the full-inventory walk is ~11× the current cost, the committed diff is ~1.1×.**


## What it does

The index stamps the commit it was built at (`indexed_at_commit`), and the git fast path adds `git diff --name-status --no-renames <stamp> HEAD` to the candidates `git status` already gives it. One extra git call; the rest of the function is untouched.

This is also the only cheap way to catch a committed **modification**. A file the index already tracks is invisible to `git status` once committed, and a DB-side inventory can't see it either without re-hashing the file — which is the walk we are trying to avoid. The committed diff names it directly.

Mechanics worth reviewing:

- The stamp is written by a full index **and** by every whole-tree sync — a `--paths` sync absorbs only part of the diff, so it must not stamp. It is captured **before** change detection runs, so a commit landing mid-sync is never claimed as absorbed.
- Committed lines go through the **same classifier** as working-tree lines, so an excluded dir stays excluded (#766, #999) and a committed `A` the index never saw still lands in `added`.
- `--no-renames` is deliberate: the index keys files by path, so a rename is a removal plus an add.
- A path reaching the list from both sources — committed, then edited again — is counted once.
- A stamp git cannot resolve (rebase, gc, shallow clone) falls back to the existing full scan, as does an index built before stamping existed. The next sync stamps it and the fast path returns, so an existing index self-heals after one slow call and is **never slower than #1843**.
- The exported `getGitChangedFiles` keeps its contract — a working-tree diff for callers holding no index. The trust decision lives in `canTrustGitFastPath`, which only the DB-aware caller asks. (`git-changed-untracked-dir.test.ts` catches this if it regresses; it caught it for me.)

## Where #1843 is strictly better

One case, and it is real: a file hidden from git with `git update-index --assume-unchanged` and then edited. #1843's inventory walk sees it; this does not, because neither `git status` nor `git diff` reports it. Verified on all three builds:

```
base     pending {added: 0, modified: 0}
#1843    pending {added: 0, modified: 1}   <- correct
this PR  pending {added: 0, modified: 0}
```

If that case matters more than the per-call cost, #1843 is the right fix and this one isn't.

## Tests

Nine cases in `__tests__/sync.test.ts`: committed add, committed modify, committed delete, committed rename, zero-after-sync, the double-source count, the exclusion filter, an unresolvable stamp, and a pre-stamp index upgrading. Six of them fail against pre-fix source.

## Validation

Based on upstream `3ed73bc`. Linux/WSL2, Node 22.23.2 for the source build (the source tree's Node gate rejects 26; the published bundle carries its own runtime).

- `npx tsc --noEmit` clean.
- `npm test`: 13 failures, all of which reproduce on pristine `upstream/main` @ `3ed73bc` in a throwaway worktree against the same index — `mcp-callers-truncation`, `nextjs`, `object-literal-methods`, `react-native-bridge`, `ui-server-api`, `ui-steps-api`, `ui-steps-api-servers`, `ui-steps-cross-tier`. No new failures.
- Both repros from #1829 re-run end to end on a built binary.
- Windows and the viewer build were not re-run for this change.
