### PR TITLE
fix(mcp): carry the index-drift guardrail into the per-project instructions

### DIFF
--- a/__tests__/mcp-unindexed.test.ts
+++ b/__tests__/mcp-unindexed.test.ts
@@ -21,6 +21,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { CodeGraph } from '../src';
 import { ToolHandler } from '../src/mcp/tools';
+import { SERVER_INSTRUCTIONS, SERVER_INSTRUCTIONS_NO_ROOT_INDEX } from '../src/mcp/server-instructions';
 
 const BIN = path.resolve(__dirname, '../dist/bin/codegraph.js');
 
@@ -185,6 +186,22 @@ describe('No-root-index session policy', () => {
     // unindexed empty list above.
     expect(tools.length).toBeGreaterThanOrEqual(1);
     expect(tools.map((t) => t.name)).toContain('codegraph_explore');
+  });
+});
+
+describe('Index-drift guardrail is shared by both instruction variants', () => {
+  const drift = /changed on disk after the last index sync/;
+
+  it('the indexed-root playbook carries it', () => {
+    expect(SERVER_INSTRUCTIONS).toMatch(drift);
+  });
+
+  it('the per-project variant carries it too', () => {
+    expect(SERVER_INSTRUCTIONS_NO_ROOT_INDEX).toMatch(drift);
+  });
+
+  it('without becoming the full playbook', () => {
+    expect(SERVER_INSTRUCTIONS_NO_ROOT_INDEX).not.toMatch(/## How to query/);
   });
 });
 

--- a/src/mcp/server-instructions.ts
+++ b/src/mcp/server-instructions.ts
@@ -17,6 +17,16 @@
  * tools (node/search/callers/…) stay defined and are re-enablable via
  * CODEGRAPH_MCP_TOOLS, but they are NOT listed to agents, so don't name them.
  */
+
+/**
+ * The bullet's own parenthetical names `projectPath`-reached projects as the
+ * ones most exposed to drift, and a server whose root has no index serves
+ * nothing else — so {@link SERVER_INSTRUCTIONS_NO_ROOT_INDEX} carries it too,
+ * without becoming the full playbook. One constant, so a later wording edit
+ * cannot reach one variant and miss the other.
+ */
+const INDEX_DRIFT_GUARDRAIL = `- **A file flagged "⚠ changed on disk after the last index sync" drifted from its index** (most common on projects queried via \`projectPath\`, which have no live watcher). Codegraph never serves a possibly-mis-sliced body from such a file — it either shows the file's full CURRENT source (trust it as a Read) or omits the source with this flag. When the source was omitted, Read that specific file; line numbers referencing it elsewhere in the response may be shifted until that project's next sync. All unflagged files remain trustworthy.`;
+
 export const SERVER_INSTRUCTIONS = `# Codegraph — code intelligence over an indexed knowledge graph
 
 Codegraph is a SQLite knowledge graph of every symbol, edge, and file in
@@ -64,7 +74,7 @@ calls; a grep/read exploration is dozens.
 - **Don't grep or Read first** to find or understand indexed code — ONE \`codegraph_explore\` returns the relevant symbols' source together in a single round-trip. Reach for raw \`Read\`/\`Grep\` only to confirm a specific detail codegraph didn't cover, or for what codegraph doesn't index (configs, docs).
 - **Don't reconstruct a flow by hand** — name the endpoints in one \`codegraph_explore\` and it surfaces the path between them, dynamic-dispatch hops included.
 - **After editing, check the staleness banner.** When a tool response starts with "⚠️ Some files referenced below were edited since the last index sync…", the listed files are pending re-index — Read those specific files for accurate content. Every file NOT in that banner is fresh, so still trust codegraph. A different, rarer banner — "⚠️ CodeGraph auto-sync is DISABLED…" — means live watching stopped entirely (the whole index is frozen, not just a few files); until it's resolved, Read files directly to confirm anything that may have changed.
-- **A file flagged "⚠ changed on disk after the last index sync" drifted from its index** (most common on projects queried via \`projectPath\`, which have no live watcher). Codegraph never serves a possibly-mis-sliced body from such a file — it either shows the file's full CURRENT source (trust it as a Read) or omits the source with this flag. When the source was omitted, Read that specific file; line numbers referencing it elsewhere in the response may be shifted until that project's next sync. All unflagged files remain trustworthy.
+${INDEX_DRIFT_GUARDRAIL}
 
 - **Source is re-served on every call by default**, including for fresh subagents and after context compaction. Cross-call dedup requires \`CODEGRAPH_EXPLORE_DEDUP=1\` and is only suitable for hosts that guarantee one durable context per connection. With that opt-in, **"Already sent earlier in this conversation"** points to exact, unchanged source returned by an earlier \`codegraph_explore\` in that context. Use that copy; don't re-fetch it and don't Read the file. The bytes it freed went into source you have not seen yet, elsewhere in the same response.
 
@@ -87,6 +97,8 @@ calls; a grep/read exploration is dozens.
  * a `projectPath` to any project that HAS a `.codegraph/`. The full single-
  * project playbook ({@link SERVER_INSTRUCTIONS}) is sent instead when the root
  * IS indexed, so the common case stays tight.
+ *
+ * {@link INDEX_DRIFT_GUARDRAIL} is the one deliberate exception.
  */
 export const SERVER_INSTRUCTIONS_NO_ROOT_INDEX = `# Codegraph — available (per-project; pass projectPath)
 
@@ -107,4 +119,8 @@ default project — but the tools are available and work **per project**:
   for that project. Indexing is the user's decision — don't run it yourself, but
   if it comes up they can run \`codegraph init\` in a project to enable codegraph
   there (a new index is picked up live, no restart).
+
+Reading a project you reached this way:
+
+${INDEX_DRIFT_GUARDRAIL}
 `;


### PR DESCRIPTION
## The gap

`SERVER_INSTRUCTIONS_NO_ROOT_INDEX` omits the index-drift anti-pattern:

> **A file flagged "⚠ changed on disk after the last index sync" drifted from its index** (most common on projects queried via `projectPath`, which have no live watcher).

That parenthetical names `projectPath`-reached projects as the audience most exposed to drift. A server whose root has no index serves **nothing but** `projectPath` queries — the variant says so itself ("pass its path as `projectPath` … for as many projects as you like in one session"). So the guidance is absent from the only audience that always meets the condition it describes.

An agent that receives the `⚠ changed on disk` flag without ever having been told what it means can read a flagged response as a normal one. That makes this a correctness gap rather than an efficiency one: the flag exists precisely because codegraph declined to serve a possibly-mis-sliced body, and the agent is supposed to `Read` that file instead.

## This deliberately does *not* re-send the playbook

`__tests__/mcp-unindexed.test.ts` pins that the per-project variant is **not** the full playbook, and the comment gives the reason ("keeps the common case tight"). I agree with that decision, so this PR does not touch it:

- `expect(instructions).not.toMatch(/## How to query/)` still passes, unchanged.
- The variant grows by **581 characters**, not by the ~5.5 KB a full playbook would add.
- `SERVER_INSTRUCTIONS` is **byte-identical** before and after — verified by extracting both constants pre- and post-change and comparing.

Only the one bullet whose own text points at this audience moves, into a shared `INDEX_DRIFT_GUARDRAIL` constant that both variants interpolate, so a later wording edit cannot reach one variant and miss the other.

## Tests

Three assertions added to the existing `mcp-unindexed` suite: both variants carry the guardrail, and the per-project one still is not the full playbook.

```
npx vitest run __tests__/mcp-unindexed.test.ts
  Test Files  1 passed (1)
       Tests  11 passed (11)
```

`npm run build` (`tsc` included) passes. `__tests__/installer-targets.test.ts` shows 2 failures on my machine under the `CLAUDE_CONFIG_DIR` describe — I verified those are **pre-existing**: identical on a clean checkout with my changes stashed. Node 22.23.2 (the suite needs `node:sqlite`, so ≥22.5 as documented; on Node 20 the DB-backed tests fail before reaching any of this).

## How I ran into it

A global `codegraph install`, then work across several repos — so the server starts outside any index and every project is reached by `projectPath`. `src/mcp/tools.ts:1643` already records a prior case where this variant's prose was not enough on its own and "the reporter had to add an `AGENTS.md` note"; I had written the same kind of note before tracking it to this constant.

Happy to narrow or reword if you would rather keep the variant leaner still.
